### PR TITLE
Don't ignore the .gitignore file in rel

### DIFF
--- a/archive/nerves_bootstrap/templates/new/rel/.gitignore
+++ b/archive/nerves_bootstrap/templates/new/rel/.gitignore
@@ -1,2 +1,3 @@
 *
 !vm.args
+!.gitignore


### PR DESCRIPTION
I believe this is why the `.gitignore` file in `rel` is not being tracked.  I had the same problem locally.

As discussed on Slack:
Trying to build the archive locally... getting
`** (File.Error) could not read file /Users/wsmoak/projects/nerves/archive/nerves_bootstrap/templates/new/rel/.gitignore: no such file or directory`
indeed it does not seem to be there: https://github.com/nerves-project/nerves/tree/master/archive/nerves_bootstrap/templates/new/rel (edited)

jschneck [1:35 PM] 
thats strange

jschneck [1:37 PM] 
im trying to figure out why its in my local copy but not being tracked
I forced it
its on master