### PR TITLE
Correction to fw / firmware app refs

### DIFF
--- a/docs/User Interfaces.md
+++ b/docs/User Interfaces.md
@@ -20,7 +20,7 @@ $ mix phoenix.new ui --database sqlite
 ...
 ```
 
-Now, add the Phoenix `ui` app and the `nerves_networking` library to the firmware app as dependencies:
+Now, add the Phoenix `ui` app and the `nerves_networking` library to the `fw` app as dependencies:
 
 ```
 defp deps do
@@ -29,10 +29,10 @@ defp deps do
 end
 ```
 
-In order to build the `ui` Phoenix application into the nerves firmware app, you need to add some configuration to your firmware config:
+In order to build the `ui` Phoenix application into the nerves `fw` app, you need to add some configuration to your firmware config:
 
 ```elixir
-# nervy/apps/firmware/config/config.exs
+# nervy/apps/fw/config/config.exs
 
 use Mix.Config
 
@@ -65,6 +65,6 @@ $ mix phoenix.server
 
 When it's time to create your firmware:
 ```
-# nervy/apps/firmware
+# nervy/apps/fw
 $ mix firmware
 ```


### PR DESCRIPTION
User Interface doc has instructions to create a sub-app with the name `fw` but then its referenced as `firmware` elsewhere in the doc, just cleaning this up to make it less confusing