### PR TITLE
Add app and module to switches 

### DIFF
--- a/archive/nerves_bootstrap/lib/mix/tasks/nerves.new.ex
+++ b/archive/nerves_bootstrap/lib/mix/tasks/nerves.new.ex
@@ -49,7 +49,7 @@ defmodule Mix.Tasks.Nerves.New do
       mix nerves.new blinky --module Blinky
   """
 
-  @switches [target: :string]
+  @switches [target: :string, app: :string, module: :string]
 
   def run([version]) when version in ~w(-v --version) do
     Mix.shell.info "Nerves v#{@version}"


### PR DESCRIPTION
# What is this?

The help docs show that `--app` and `--module` are supported, but if you try to use them you get the following error: 

> ** (Mix) Invalid option: --module

# What did I change?

Looking at the [mix.new Task](https://github.com/elixir-lang/elixir/blob/master/lib/mix/lib/mix/tasks/new.ex#L46) as a reference I was able to just add `app: :string, module: :string` to the `@switches` list to resolve this issue.

I tested this locally and it worked great! Cheers!