### PR TITLE
Add support for Elixir >= 1.4.0-dev

### DIFF
--- a/archive/nerves_bootstrap/mix.exs
+++ b/archive/nerves_bootstrap/mix.exs
@@ -4,7 +4,7 @@ defmodule Nerves.Bootstrap.Mixfile do
   def project do
     [app: :nerves_bootstrap,
      version: "0.1.4",
-     elixir: "~> 1.2.4 or ~> 1.3.0",
+     elixir: "~> 1.2.4 or ~> 1.3.0 or ~> 1.4.0-dev",
      aliases: aliases]
   end
 


### PR DESCRIPTION
Similar to a01596ec59, allow use of Elixir 1.4.0-dev (the version currently on master.)

This prevents a warning every time mix is used while nerves.archive is installed.

