### PR TITLE
make output of images configurable

### DIFF
--- a/lib/mix/tasks/firmware.burn.ex
+++ b/lib/mix/tasks/firmware.burn.ex
@@ -42,7 +42,9 @@ defmodule Mix.Tasks.Firmware.Burn do
     config = Mix.Project.config
     otp_app = config[:app]
     target = config[:target]
-    images_path = config[:images_path] || config[:build_path] || "_build/images"
+    images_path =
+      (config[:images_path] || Path.join([Mix.Project.build_path, "nerves", "images"]))
+      |> Path.expand
 
     System.get_env("NERVES_SYSTEM") || raise """
       Environment variable $NERVES_SYSTEM is not set
@@ -52,7 +54,7 @@ defmodule Mix.Tasks.Firmware.Burn do
       Environment variable $NERVES_TOOLCHAIN is not set
     """
 
-    fw = Path.join(File.cwd!, "#{images_path}/#{target}/#{otp_app}.fw")
+    fw = Path.join(File.cwd!, "#{images_path}/#{otp_app}.fw")
     unless File.exists?(fw) do
       Mix.raise "Firmware for target #{target} not found at #{fw} run `mix firmware` to build"
     end

--- a/lib/mix/tasks/firmware.burn.ex
+++ b/lib/mix/tasks/firmware.burn.ex
@@ -42,6 +42,7 @@ defmodule Mix.Tasks.Firmware.Burn do
     config = Mix.Project.config
     otp_app = config[:app]
     target = config[:target]
+    images_path = config[:images_path] || config[:build_path] || "_build/images"
 
     System.get_env("NERVES_SYSTEM") || raise """
       Environment variable $NERVES_SYSTEM is not set
@@ -51,7 +52,7 @@ defmodule Mix.Tasks.Firmware.Burn do
       Environment variable $NERVES_TOOLCHAIN is not set
     """
 
-    fw = Path.join(File.cwd!, "_images/#{target}/#{otp_app}.fw")
+    fw = Path.join(File.cwd!, "#{images_path}/#{target}/#{otp_app}.fw")
     unless File.exists?(fw) do
       Mix.raise "Firmware for target #{target} not found at #{fw} run `mix firmware` to build"
     end

--- a/lib/mix/tasks/firmware.ex
+++ b/lib/mix/tasks/firmware.ex
@@ -69,6 +69,7 @@ defmodule Mix.Tasks.Firmware do
     config = Mix.Project.config
     otp_app = config[:app]
     target = config[:target]
+    images_path = config[:images_path] || config[:build_path] || "_build/images"
 
     firmware_config = Application.get_env(:nerves, :firmware)
     rel2fw_path = Path.join(system_path, "scripts/rel2fw.sh")
@@ -90,7 +91,7 @@ defmodule Mix.Tasks.Firmware do
           |> Path.join(fwup_conf)
           ["-c", fw_conf]
       end
-    fw = ["-f", "_images/#{target}/#{otp_app}.fw"]
+    fw = ["-f", "#{images_path}/#{target}/#{otp_app}.fw"]
     release_path =
       Mix.Project.build_path()
       |> Path.join("rel/#{otp_app}")

--- a/lib/mix/tasks/firmware.ex
+++ b/lib/mix/tasks/firmware.ex
@@ -68,8 +68,13 @@ defmodule Mix.Tasks.Firmware do
   defp build_firmware(system_path) do
     config = Mix.Project.config
     otp_app = config[:app]
-    target = config[:target]
-    images_path = config[:images_path] || config[:build_path] || "_build/images"
+    images_path =
+      (config[:images_path] || Path.join([Mix.Project.build_path, "nerves", "images"]))
+      |> Path.expand
+
+    unless File.exists?(images_path) do
+      File.mkdir_p(images_path)
+    end
 
     firmware_config = Application.get_env(:nerves, :firmware)
     rel2fw_path = Path.join(system_path, "scripts/rel2fw.sh")
@@ -91,7 +96,7 @@ defmodule Mix.Tasks.Firmware do
           |> Path.join(fwup_conf)
           ["-c", fw_conf]
       end
-    fw = ["-f", "#{images_path}/#{target}/#{otp_app}.fw"]
+    fw = ["-f", Path.join(File.cwd!, "#{images_path}/#{otp_app}.fw")]
     release_path =
       Mix.Project.build_path()
       |> Path.join("rel/#{otp_app}")

--- a/lib/mix/tasks/firmware.image.ex
+++ b/lib/mix/tasks/firmware.image.ex
@@ -19,6 +19,7 @@ defmodule Mix.Tasks.Firmware.Image do
     config = Mix.Project.config
     otp_app = config[:app]
     target = config[:target]
+    images_path = config[:images_path] || config[:build_path] || "_build/images"
 
     System.get_env("NERVES_SYSTEM") || raise """
       Environment variable $NERVES_SYSTEM is not set
@@ -28,7 +29,7 @@ defmodule Mix.Tasks.Firmware.Image do
       Environment variable $NERVES_TOOLCHAIN is not set
     """
 
-    fw = Path.join(File.cwd!, "_images/#{target}/#{otp_app}.fw")
+    fw = Path.join(File.cwd!, "#{images_path}/#{target}/#{otp_app}.fw")
     unless File.exists?(fw) do
       Mix.raise "Firmware for target #{target} not found at #{fw} run `mix firmware` to build"
     end

--- a/lib/mix/tasks/firmware.image.ex
+++ b/lib/mix/tasks/firmware.image.ex
@@ -19,7 +19,9 @@ defmodule Mix.Tasks.Firmware.Image do
     config = Mix.Project.config
     otp_app = config[:app]
     target = config[:target]
-    images_path = config[:images_path] || config[:build_path] || "_build/images"
+    images_path =
+      (config[:images_path] || Path.join([Mix.Project.build_path, "nerves", "images"]))
+      |> Path.expand
 
     System.get_env("NERVES_SYSTEM") || raise """
       Environment variable $NERVES_SYSTEM is not set
@@ -29,7 +31,7 @@ defmodule Mix.Tasks.Firmware.Image do
       Environment variable $NERVES_TOOLCHAIN is not set
     """
 
-    fw = Path.join(File.cwd!, "#{images_path}/#{target}/#{otp_app}.fw")
+    fw = Path.join(File.cwd!, "#{images_path}/#{otp_app}.fw")
     unless File.exists?(fw) do
       Mix.raise "Firmware for target #{target} not found at #{fw} run `mix firmware` to build"
     end


### PR DESCRIPTION
in your mix config you can have something like:
```elixir
  def project do
    [app: :my_app,
     version: "1.2.3",
     target: "rpi3",
     archives: [nerves_bootstrap: "~> 0.2.0"],
     build_embedded: Mix.env == :prod,
     start_permanent: Mix.env == :prod,
     build_path:  "../../_build/#{target(Mix.env)}",
     deps_path:   "../../deps/#{target(Mix.env)}",
     images_path: "../../images", # THIS
     config_path: "../../config/config.exs",
     lockfile: "../../mix.lock",
     aliases:     [],
     deps:        deps()
   ]
  end
```