### PR TITLE
fix Path.expand() issue causing paths to be duplicated.

### DIFF
--- a/lib/mix/tasks/firmware.burn.ex
+++ b/lib/mix/tasks/firmware.burn.ex
@@ -54,7 +54,7 @@ defmodule Mix.Tasks.Firmware.Burn do
       Environment variable $NERVES_TOOLCHAIN is not set
     """
 
-    fw = Path.join(File.cwd!, "#{images_path}/#{otp_app}.fw")
+    fw = "#{images_path}/#{otp_app}.fw"
     unless File.exists?(fw) do
       Mix.raise "Firmware for target #{target} not found at #{fw} run `mix firmware` to build"
     end

--- a/lib/mix/tasks/firmware.ex
+++ b/lib/mix/tasks/firmware.ex
@@ -96,7 +96,7 @@ defmodule Mix.Tasks.Firmware do
           |> Path.join(fwup_conf)
           ["-c", fw_conf]
       end
-    fw = ["-f", Path.join(File.cwd!, "#{images_path}/#{otp_app}.fw")]
+    fw = ["-f", "#{images_path}/#{otp_app}.fw"]
     release_path =
       Mix.Project.build_path()
       |> Path.join("rel/#{otp_app}")

--- a/lib/mix/tasks/firmware.image.ex
+++ b/lib/mix/tasks/firmware.image.ex
@@ -31,7 +31,7 @@ defmodule Mix.Tasks.Firmware.Image do
       Environment variable $NERVES_TOOLCHAIN is not set
     """
 
-    fw = Path.join(File.cwd!, "#{images_path}/#{otp_app}.fw")
+    fw = "#{images_path}/#{otp_app}.fw"
     unless File.exists?(fw) do
       Mix.raise "Firmware for target #{target} not found at #{fw} run `mix firmware` to build"
     end


### PR DESCRIPTION
Since we do `Path.expand()` now, `Path.join(File.cwd!, ...)` was causing the paths to be duplicated. so when you did `mix firmware` you would expect the firmware to exist in `/home/user/app/_build/rpi3/app.fw` but it really ends up in `/home/user/app/home/user/app/_build/rpi3/app.fw`