### PR TITLE
Remove rel/.gitignore from the skeleton

### DIFF
--- a/bootstrap/lib/mix/tasks/nerves/new.ex
+++ b/bootstrap/lib/mix/tasks/nerves/new.ex
@@ -13,7 +13,6 @@ defmodule Mix.Tasks.Nerves.New do
     {:eex,  "new/test/test_helper.exs",             "test/test_helper.exs"},
     {:eex,  "new/test/application_name_test.exs",   "test/application_name_test.exs"},
     {:eex,  "new/rel/vm.args",                      "rel/vm.args"},
-    {:text, "new/rel/.gitignore",                   "rel/.gitignore"},
     {:text, "new/.gitignore",                       ".gitignore"},
     {:eex,  "new/mix.exs",                          "mix.exs"},
     {:eex,  "new/README.md",                        "README.md"},

--- a/bootstrap/templates/new/rel/.gitignore
+++ b/bootstrap/templates/new/rel/.gitignore
@@ -1,3 +1,0 @@
-*
-!vm.args
-!.gitignore


### PR DESCRIPTION
This .gitignore is no longer needed since the release build products
aren't stored there any more. It also removes a minor speed bump when
wanting to commit a rel/config.exs.