### PR TITLE
Host Target

### DIFF
--- a/bootstrap/mix.exs
+++ b/bootstrap/mix.exs
@@ -4,15 +4,12 @@ defmodule Nerves.Bootstrap.Mixfile do
   def project do
     [app: :nerves_bootstrap,
      version: "0.2.3-dev",
-     elixir: "~> 1.2.4 or ~> 1.3.2 or ~> 1.4",
+     elixir: "~> 1.4",
      aliases: aliases()]
   end
 
-  # Configuration for the OTP application
-  #
-  # Type "mix help compile.app" for more information
   def application do
-    [applications: []]
+    [extra_applications: []]
   end
 
   def aliases do

--- a/bootstrap/templates/new/README.md
+++ b/bootstrap/templates/new/README.md
@@ -1,7 +1,16 @@
-# <%= application_module %>
+# <%= app_module %>
+
+## Targets
+Nerves applications are configured that they can produce images for target
+hardware by setting `NERVES_TARGET`. By default, if MIX_TARGET is not set, Nerves
+defaults to building a host target. This is useful for executing logic tests,
+running utilities, and debugging. For more information about targets:
+https://hexdocs.pm/nerves/targets.html#content
+
+## Getting Started    
 
 To start your Nerves app:
-
+  * `export NERVES_TARGET=my_target` or prefix every command with `NERVES_TARGET=my_target`, Example: `NERVES_TARGET=rpi3`
   * Install dependencies with `mix deps.get`
   * Create firmware with `mix firmware`
   * Burn to an SD card with `mix firmware.burn`

--- a/bootstrap/templates/new/lib/app_name.ex
+++ b/bootstrap/templates/new/lib/app_name.ex
@@ -1,0 +1,3 @@
+defmodule <%= app_module %> do
+  
+end

--- a/bootstrap/templates/new/lib/app_name/application.ex
+++ b/bootstrap/templates/new/lib/app_name/application.ex
@@ -1,4 +1,4 @@
-defmodule <%= application_module %> do
+defmodule <%= app_module %>.Application do
   use Application
 
   # See http://elixir-lang.org/docs/stable/elixir/Application.html
@@ -8,13 +8,12 @@ defmodule <%= application_module %> do
 
     # Define workers and child supervisors to be supervised
     children = [
-      # worker(<%= application_module %>.Worker, [arg1, arg2, arg3]),
+      # worker(<%= app_module %>.Worker, [arg1, arg2, arg3]),
     ]
 
     # See http://elixir-lang.org/docs/stable/elixir/Supervisor.html
     # for other strategies and supported options
-    opts = [strategy: :one_for_one, name: <%= application_module %>.Supervisor]
+    opts = [strategy: :one_for_one, name: <%= app_module %>.Supervisor]
     Supervisor.start_link(children, opts)
   end
-
 end

--- a/bootstrap/templates/new/mix.exs
+++ b/bootstrap/templates/new/mix.exs
@@ -34,7 +34,7 @@ defmodule <%= app_module %>.Mixfile do
     [extra_applications: [:logger]]
   end
   def application(_target) do
-    [mod: {<%= app_module %>, []},
+    [mod: {<%= app_module %>.Application, []},
      extra_applications: [:logger]]
   end
 

--- a/bootstrap/templates/new/mix.exs
+++ b/bootstrap/templates/new/mix.exs
@@ -1,45 +1,66 @@
-defmodule <%= application_module %>.Mixfile do
+defmodule <%= app_module %>.Mixfile do
   use Mix.Project
 
-  @target System.get_env("NERVES_TARGET") || "<%= default_target %>"
+  @target System.get_env("MIX_TARGET") || "host"
 
   def project do
-    [app: :<%= application_name %>,
+    [app: :<%= app_name %>,
      version: "0.1.0",
+     elixir: "<%= elixir_req %>",
      target: @target,
-     archives: [nerves_bootstrap: "~> <%= bootstrap_vsn %>"],
-     <%= if in_umbrella do %>
+     archives: [nerves_bootstrap: "~> <%= bootstrap_vsn %>"],<%= if in_umbrella do %>
      deps_path: "../../deps/#{@target}",
      build_path: "../../_build/#{@target}",
      config_path: "../../config/config.exs",
-     lockfile: "../../mix.lock",
-     <% else %>
+     lockfile: "../../mix.lock",<% else %>
      deps_path: "deps/#{@target}",
-     build_path: "_build/#{@target}",
-     <% end %>
+     build_path: "_build/#{@target}",<% end %>
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     aliases: aliases(),
-     deps: deps() ++ system(@target)]
+     aliases: aliases(@target),
+     deps: deps()]
   end
 
   # Configuration for the OTP application.
   #
   # Type `mix help compile.app` for more information.
-  def application do
-    [mod: {<%= application_module %>, []},
-     applications: [:logger]]
+  def application, do: application(@target)
+
+  # Specify target specific application configurations
+  # It is common that the applicaiton start function will start and supervise
+  # applications which could cause the host to fail. Because of this, we only
+  # invoke <%= app_module %>.start/2 when running on a target.
+  def application("host") do
+    [extra_applications: [:logger]]
+  end
+  def application(_target) do
+    [mod: {<%= app_module %>, []},
+     extra_applications: [:logger]]
   end
 
+  # Dependencies can be Hex packages:
+  #
+  #   {:my_dep, "~> 0.3.0"}
+  #
+  # Or git/path repositories:
+  #
+  #   {:my_dep, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"}
+  #
+  # Type "mix help deps" for more examples and options
   def deps do
-    [<%= nerves_dep %>]
+    [<%= nerves_dep %>] ++
+    deps(@target)
   end
 
-  def system(target) do
+  # Specify target specific dependencies
+  def deps("host"), do: []
+  def deps(target) do
     [{:"nerves_system_#{target}", ">= 0.0.0"}]
   end
 
-  def aliases do
+  # We do not invoke the Nerves Env when running on the Host
+  def aliases("host"), do: []
+  def aliases(_target) do
     ["deps.precompile": ["nerves.precompile", "deps.precompile"],
      "deps.loadpaths":  ["deps.loadpaths", "nerves.loadpaths"]]
   end

--- a/bootstrap/templates/new/test/app_name_test.exs
+++ b/bootstrap/templates/new/test/app_name_test.exs
@@ -1,0 +1,8 @@
+defmodule <%= app_module %>Test do
+  use ExUnit.Case
+  doctest <%= app_module %>
+
+  test "the truth" do
+    assert 1 + 1 == 2
+  end
+end

--- a/bootstrap/templates/new/test/application_name_test.exs
+++ b/bootstrap/templates/new/test/application_name_test.exs
@@ -1,8 +1,0 @@
-defmodule <%= application_module %>Test do
-  use ExUnit.Case
-  doctest <%= application_module %>
-
-  test "the truth" do
-    assert 1 + 1 == 2
-  end
-end


### PR DESCRIPTION
This PR updates the new project generator to create a host first environment. Specifically, it makes the following changes:

* Do not invoke the nerves.loadpaths or nerves.precompile for the host target
* Separate OTP application configurations for targets
* --target is no longer needed for `mix nerves.new`
* `NERVES_TARGET` either needs to be `export`ed or prefixed on commands intended to be run for the target.
* ExUnit tests can be invoked on the host
* IEx sessions can be invoked on the host
* Utilities and other code can be invoked on the host