### PR TITLE
Return error when tar command isn't successful

### DIFF
--- a/lib/mix/tasks/compile.nerves_package.ex
+++ b/lib/mix/tasks/compile.nerves_package.ex
@@ -22,7 +22,7 @@ defmodule Mix.Tasks.Compile.NervesPackage do
     if Nerves.Package.stale?(package, toolchain) do
       Nerves.Package.artifact(package, toolchain)
     end
-    
+
   end
 
 end

--- a/lib/nerves/package.ex
+++ b/lib/nerves/package.ex
@@ -104,9 +104,11 @@ defmodule Nerves.Package do
             end
           end)
       end
-    if ret == :ok do
-      Path.join(Artifact.dir(pkg, toolchain), @checksum)
-      |> File.write!(checksum(pkg))
+
+    case ret do
+      :ok -> Path.join(Artifact.dir(pkg, toolchain), @checksum)
+             |> File.write!(checksum(pkg))
+        _ -> :error
     end
   end
 

--- a/test/nerves/artifact_test.exs
+++ b/test/nerves/artifact_test.exs
@@ -79,4 +79,22 @@ defmodule Nerves.ArtifactTest do
       System.delete_env("NERVES_TOOLCHAIN")
     end
   end
+
+  @tag :skip
+  test "tar file error detection" do
+      pkg =
+      %Nerves.Package{app: :nerves_system_rpi3,
+                      compiler: :nerves_package,
+                      config: [compiler: :nerves_package,
+                               artifact_url: ["https://github.com/nerves-project/nerves_system_rpi3/releases/download/v0.10.0/nerves_system_rpi3-v0.10.0.fw"],
+                               platform_config: [defconfig: "nerves_defconfig"],
+                               checksum: []],
+                      dep: :hex,
+                      path: "",
+                      provider: [{Nerves.Package.Providers.HTTP, []}],
+                      type: :system,
+                      version: "0.10.0"}
+
+      assert  :error  == Nerves.Package.artifact(pkg, %Nerves.Package{})
+  end
 end


### PR DESCRIPTION
Whenever we are pulling down tar files, if the connection drops the tar file may be incomplete.  To make this a bit more robust, I added code to catch the return code from the tar command.   If it's not 0, then return an error.  Otherwise keep on trucking.

Also, I created a unit test to test this, it passes in a .fw file instead of a tar ball which obviously should throw an error.   The .fw file is fairly large, so I have it skipping it.   Any feedback is welcome, as I wasn't sure what the best strategy for a test would be.


 