### PR TITLE
Add note about where args go in vm.args

### DIFF
--- a/bootstrap/templates/new/rel/vm.args
+++ b/bootstrap/templates/new/rel/vm.args
@@ -1,4 +1,9 @@
+## Add custom options here
+
 ## Start the Elixir shell
 -noshell
 -user Elixir.IEx.CLI
 -extra --no-halt
+
+## Options added here are interpreted as plain arguments and
+## can be retrieved using :init.get_plain_arguments().


### PR DESCRIPTION
The easy thing to do is to add parameters at the end of the file without noticing the `-extra`. Add a comment to save me from accidentally doing this in the future.