### PR TITLE
install deps, release config, and print additional info

### DIFF
--- a/bootstrap/lib/mix/tasks/nerves/new.ex
+++ b/bootstrap/lib/mix/tasks/nerves/new.ex
@@ -48,7 +48,7 @@ defmodule Mix.Tasks.Nerves.New do
       mix nerves.new blinky --module Blinky
   """
 
-  @switches [app: :string, module: :string]
+  @switches [app: :string, module: :string, target: :string]
 
   def run([version]) when version in ~w(-v --version) do
     Mix.shell.info "Nerves v#{@version}"
@@ -85,6 +85,18 @@ defmodule Mix.Tasks.Nerves.New do
   def run(app, mod, path, opts) do
     nerves_path = nerves_path(path, Keyword.get(opts, :dev, false))
     in_umbrella? = in_umbrella?(path)
+
+    if target = opts[:target] do
+      Mix.shell.info [:yellow, """
+      Usage of --target has been deprecated.
+      Nerves projects default to "host" target.
+      to use your target either export to your env
+        $ export MIX_TARGET=#{target}
+      or prefix any mix commands to execute un that target
+        $ MIX_TARGET=#{target} mix deps.get
+      """, :reset]
+    end
+
     binding = [app_name: app,
                app_module: mod,
                bootstrap_vsn: @version,

--- a/bootstrap/lib/mix/tasks/nerves/new.ex
+++ b/bootstrap/lib/mix/tasks/nerves/new.ex
@@ -140,7 +140,7 @@ defmodule Mix.Tasks.Nerves.New do
     All set!
       $ cd #{path}
 
-    Next, pick a deployent target.
+    Next, pick a deployment target.
       For example: `rpi3` for Raspberry Pi 3
       More info on targets: https://hexdocs.pm/nerves/targets.html#content
 


### PR DESCRIPTION
Enhanced new project generator to install deps, release config and print additional information.

The new project generator can be tested by cloning the nerves repository and installing the latest bootstrap.
```sh
$ cd cd nerves/bootstrap
$ mix install
```

The, generate a new project
```
mix nerves.new my_app
* creating my_app/config/config.exs
* creating my_app/lib/my_app.ex
* creating my_app/lib/my_app/application.ex
* creating my_app/test/test_helper.exs
* creating my_app/test/my_app_test.exs
* creating my_app/rel/vm.args
* creating my_app/.gitignore
* creating my_app/mix.exs
* creating my_app/README.md

Fetch and install dependencies? [Yn] y
* running mix deps.get
* running mix nerves.release.init
All set!
  $ cd my_app

Next, pick a deployent target.
  For example: `rpi3` for Raspberry Pi 3
  More info on targets: https://hexdocs.pm/nerves/targets.html#content

To set the target you can either
  $ export MIX_TARGET=rpi3
Or prefix your commands
  $ MIX_TARGET=rpi3 mix firmware

Finally, Create firmware
  $ mix deps.get
  $ mix firmware

You can also run your app inside IEx (Interactive Elixir) as:
  $ iex -S mix
```