### PR TITLE
Fix typo on FAQ page of docs

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -60,7 +60,7 @@ To have the device restart instead of hang on failure, make a copy of the `erlin
 
 Some target hardware has particular features that can be used from your application, but they're not covered in the general Nerves documentation.
 In general, platform-specific features will be documented in the target's system documentation.
-You may also find what you need by looking at the [community-maintained lisf of libraries](http://nerves-project.org/libraries/) that work well with Nerves.
+You may also find what you need by looking at the [community-maintained list of libraries](http://nerves-project.org/libraries/) that work well with Nerves.
 
 If you still don't see what you're looking for, please let us know in the #nerves channel on [the Elixir-Lang Slack](https://elixir-slackin.herokuapp.com/), or create an Issue or Pull Request to the [relevant `nerves_system-<target>` repository](https://github.com/nerves-project?query=nerves_system_).
 


### PR DESCRIPTION
Sorry, I know it's petty. Just been  getting into Nerves. Reading through all the Nerves docs and this was the only typo I noticed. Thanks!