### PR TITLE
Update docs for Nerves 0.5.0 / Bootstrap 0.3.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,29 @@ Craft and deploy bulletproof embedded software in Elixir
 
 ## Requirements
 
-64-bit host running
-* Mac OS 10.10+ or Linux (We've tested on Debian / Ubuntu / Redhat / CentOS)
-* Elixir ~> 1.2.4 or ~> 1.3.2
+* 64-bit host
+* Mac OS 10.10+
+* Linux (tested on Debian / Ubuntu / Redhat / CentOS)
+* Windows 10 with [Windows Subsystem for Linux](https://msdn.microsoft.com/en-us/commandline/wsl/install_guide) (untested)
+* Elixir ~> 1.4
 * [fwup](https://github.com/fhunleth/fwup) >= 0.8.0
+
+## Quick-Reference
+
+### Generating a New Nerves Application
+
+```bash
+$ mix nerves.new my_app
+```
+
+### Building Firmware
+
+```bash
+$ export MIX_TARGET=rpi3
+$ mix deps.get      # Fetch the dependencies
+$ mix firmware      # Cross-compile dependencies and create a .fw file
+$ mix firmware.burn # Burn firmware to an inserted SD card
+```
 
 ## Docs
 
@@ -16,52 +35,14 @@ Craft and deploy bulletproof embedded software in Elixir
 
 [Getting Started](https://hexdocs.pm/nerves/getting-started.html)
 
+[Frequently-Asked Questions](https://hexdocs.pm/nerves/faq.html)
+
+[Systems](https://hexdocs.pm/nerves/systems.html)
+
+[Targets](https://hexdocs.pm/nerves/targets.html)
+
+[User Interfaces](https://hexdocs.pm/nerves/user-interfaces.html)
+
 [Advanced Configuration](https://hexdocs.pm/nerves/advanced-configuration.html)
 
-## Install
-
-### Bootstrap Archive
-
-Nerves is a suite of components which work together to create reproducible firmware using the Elixir programming language. To build Nerves applications on your machine, you will first be required to install the Nerves Bootstrap archive. The Nerves Bootstrap archive contains mix hooks required to bootstrap your mix environment to properly cross compile your application and dependency code for the Nerves target.
-
-To install the archive:
-```
-$ mix archive.install https://github.com/nerves-project/archives/raw/master/nerves_bootstrap.ez
-```
-If the Nerves Bootstrap archive does not install properly, you can download the file from github directly and then install using the command `mix archive.install /path/to/local/nerves_bootstrap.ez`
-
-In addition to the archive, you will need to include the `:nerves` application in your application deps and applications list.
-
-  1. Add nerves to your list of dependencies in `mix.exs`:
-
-        def deps do
-          [{:nerves, "~> 0.3"}]
-        end
-
-  2. Ensure nerves is started before your application:
-
-        def application do
-          [applications: [:nerves]]
-        end
-
-Installing system specific dependencies:
-  [Installation Docs](https://hexdocs.pm/nerves/installation.html)
-
-## Project Configuration
-You can generate a new nerves project using the project generator. You are required to pass a target tag to the generator. You can find more information about target tags for your board at  http://nerves-project.org
-
-`mix nerves.new my_app --target rpi2`
-
-### Building Firmware
-
-Now that everything is installed and configured its time to make some firmware. Here is the workflow
-
-`mix deps.get` - Fetch the dependencies.
-
-`mix compile` - Bootstrap the Nerves Env and compile the App.
-
-`mix firmware` - Creates a fw file
-
-`mix firmware.burn` - Burn firmware to an inserted SD card.
-
-Copyright (C) 2015-2016 by the Nerves Project developers <nerves@nerves-project.org>
+Copyright (C) 2015-2017 by the Nerves Project developers <nerves@nerves-project.org>

--- a/docs/Advanced Configuration.md
+++ b/docs/Advanced Configuration.md
@@ -1,30 +1,38 @@
 # Advanced Configuration
 
-## Target Specific Configuration
+## Target-Specific Configuration
 
-Different target boards have different layouts for GPIO, LEDs, and more. Often, this requires that configurations be specified per-target. In this example, we will be looking at how to configure the LEDs for two different targets. First, let's start by modifying our `config.exs` to include configs for each target.
+Different target boards have different layouts for GPIO, LEDs, and more.
+Often, this requires that configurations be specified per-target.
+In this example, we will be looking at how to configure the LEDs for two different targets.
+First, let's start by modifying our `config.exs` to include configs for each target.
 
 ```elixir
-use Mix.Config
+# config/config.exs
 
-config :blinky, led_list: [ :red, :green ]
+use Mix.Config
 
 import_config "#{Mix.Project.config[:target]}.exs"
 ```
 
-This will load separate Mix Configs for each target passed. Let's say we have targets `rpi` and `bbb`. Each of those files would look like this.
+This will load a different Mix config for each target.
+Let's say we plan to support targets `rpi3` and `bbb`.
+These target devices have different numbers of user-controlled LEDs and we want each to blink all of its LEDs.
+The configuration files would look like this:
 
 ```elixir
-# rpi
-config :nerves_io_led, names: [
-  red: "led0",
-  green: "led1"
-]
+# config/rpi3.exs
+
+config :blinky, led_list: [ :green ]
+config :nerves_leds, names: [ green: "led0" ]
 ```
 
 ```elixir
-# bbb
-config :nerves_io_led, names: [
+# config/bbb.exs
+
+config :blinky, led_list: [ :led0, :led1, :led2, :led3 ]
+
+config :nerves_leds, names: [
   led0: "beaglebone:green:usr0",
   led1: "beaglebone:green:usr1",
   led2: "beaglebone:green:usr2",
@@ -34,22 +42,27 @@ config :nerves_io_led, names: [
 
 ## Root Filesystem Additions
 
-Sometimes, you want to ship additional files and configurations with your firmware. You can do this by providing your own directory of root file system additions. This is done by configuring the firmware assembler and telling it where to find the folder it should use as an overlay:
+Sometimes, you want to ship additional files and configurations with your firmware.
+This is done by telling the firmware assembler where to find a directory to use as an overlay on the root mount point:
 
-```
+```elixir
 # config/config.exs
 
 config :nerves, :firmware,
   rootfs_additions: "config/rootfs-additions"
 ```
 
-This declares that the contents of the folder at `config/rootfs-additions` will be merged into the root file system when `mix firmware` is called. You can also specify different rootfs additions per target as illustrated above.
+This declares that the contents of the folder at `config/rootfs-additions` will be merged into the root file system when `mix firmware` is called.
+You can also specify different rootfs additions per target, as shown in the previous section.
 
 ## Overwriting Files in the Root File System
 
-Any files in the `rootfs_additions` will overwrite those present in the underlying system. This can be useful if you want to change the contents of included files in the underlying Nerves system. Let's say, for example, that you want to change the behaviour of `erlinit`. You can include your own `erlinit.config`:
+Any files in the `rootfs_additions` directory will overwrite those present in the underlying filesystem.
+This can be useful if you want to change the contents of included files in the underlying Nerves system.
+Let's say, for example, that you want to change the behavior of `erlinit`.
+You can include your own `erlinit.config`:
 
-```
+```bash
 # config/rootfs-additions/etc/erlinit.config
 
 # Uncomment to hang the board rather than rebooting when Erlang exits
@@ -69,33 +82,37 @@ Any files in the `rootfs_additions` will overwrite those present in the underlyi
 # Hostname
 -d "/usr/bin/boardid -b bbb -n 4"
 -n nerves-%.4s
-
 ```
 
-It is important to note that if you replace a config file, the entire file is replaced, rather than merging the contents. Therefore, you should first obtain and modify the original file. A trick for doing this is to expand the `rootfs.squashfs`. You can do this using `unsquashfs`:
+It is important to note that if you replace a config file, the entire file is replaced, rather than merging the contents.
+Therefore, you should first obtain and modify the original file.
+A trick for doing this is to expand the `rootfs.squashfs`.
+You can do this using `unsquashfs`:
 
-```
-$ unsquashfs path/to/rootfs.squashfs
+```bash
+$ unsquashfs ~/.nerves/artifacts/<cached_system_name>/images/rootfs.squashfs
 ```
 
-This file is typically found in `_build/(Target)/(Mix.env)/nerves/system/images/rootfs.squashfs`. It will be expanded into the current directory under `squashfs-root`
+It will be expanded into the current directory under `squashfs-root`
 
 ## Overwriting Files in the Boot Partition
 
-Different targets have different boot partition contents. To overwrite files in the boot partition, you will need to do this in your own `fwup.conf` file:
+Different targets have different boot partition contents.
+To overwrite files in the boot partition, you will need to use your own `fwup.conf` file:
 
-```
+```elixir
 # config/config.exs
 
 config :nerves, :firmware,
   fwup_conf: "config/fwup.conf"
 ```
 
-In your included `fwup.conf` file, you can use absolute paths, or environment variables to point to the location of included files.
+In your included `fwup.conf` file, you can use absolute paths or environment variables to point to the location of included files.
 
-Let's say you have a Raspberry Pi and you want to change the contents of the `cmdline.txt` file. You can do this by editing the `fwup.conf` as follows:
+Let's say you have a Raspberry Pi and you want to change the contents of the `cmdline.txt` file.
+You can do this by editing the `fwup.conf` as follows:
 
-```
+```bash
 # fwup.conf
 
 file-resource cmdline.txt {
@@ -103,13 +120,20 @@ file-resource cmdline.txt {
 }
 ```
 
-You can use the `NERVES_APP` environment variable to point to the root of your Elixir app. This variable is automatically managed for you by `nerves_bootstrap`.
+You can use the `NERVES_APP` environment variable to point to the root of your Elixir app.
+This variable is automatically managed for you by `nerves_bootstrap`.
 
 ## Partitions
 
-Nerves firmware uses Master Boot Record partition layout, which only supports 4 primary partitions. By default, the root filesystem partition is mounted as read-only. This is to prevent corruption of the root filesystem due to "improper shutdowns". With embedded systems, it is expected that the power can be pulled from the device at any time. This could be problematic if you are performing a write operation on the filesystem. Because of this, we also add a read/write partition by default, called `app_data`. This is mounted at `/root` and is dictated in `etc/erlinit.config`
+Nerves firmware uses Master Boot Record partition layout, which only supports 4 primary partitions.
+By default, the root filesystem partition is mounted in read-only mode.
+This prevents corruption of the root filesystem due to "improper shutdowns".
+With embedded systems, it is assumed that power can be removed from the device at any time.
+This could be problematic if you are performing a write operation on the filesystem.
+Because the root filesystem is read-only, we also add a read/write partition by default, called `app_data` and mounted at `/root` (the `root` user's home directory).
+These settings are defined in `etc/erlinit.config`.
 
-```
+```plain
 +----------------------------+
 | MBR                        |
 +----------------------------+
@@ -123,11 +147,16 @@ Nerves firmware uses Master Boot Record partition layout, which only supports 4 
 +----------------------------+
 ```
 
-You can enable and mount an additional read/write partition by modifying the `fwup.conf` file. This strategy is typically used to define two locations where data can be written. Let's say you want to persist some infrequently-written configuration data and some frequently-written log data. It would best be handled by separate partitions so that the important, infrequently-written configuration data is not corrupted due to a loss of power while writing the more frequent log data.
+You can enable and mount an additional read/write partition by modifying the `fwup.conf` file.
+This strategy is typically used to define two locations where data can be written.
+Let's say you want to persist some infrequently-written configuration data and some frequently-written log data.
+These use-cases could be segmented into separate partitions so that the important, infrequently-written configuration data is not corrupted due to a loss of power while writing the more-frequent, but less-critical, log data.
 
-First, start by defining a new space on the disk for the partition:
+First, define a new space on the disk for the partition:
 
-```
+```bash
+# fwup.conf
+
 # The boot partition
 define(BOOT_PART_OFFSET, 63)
 define(BOOT_PART_COUNT, 16321)
@@ -152,7 +181,10 @@ In this example, we are changing the app data partition to `CONFIG_PART` and add
 
 Next, we change the mapping to include these two new partitions:
 
-```
+```bash
+# fwup.conf
+
+...
 mbr mbr-a {
     partition 0 {
         block-offset = ${BOOT_PART_OFFSET}
@@ -204,7 +236,7 @@ mbr mbr-b {
 
 This layout defines our system as follows:
 
-```
+```plain
 +----------------------------+
 | MBR                        |
 +----------------------------+
@@ -215,31 +247,36 @@ This layout defines our system as follows:
 | p1*: Rootfs B (squashfs)   |
 +----------------------------+
 | p2: Config      (FAT32)    |
++----------------------------+
 | p3: Log         (EXT4)     |
 +----------------------------+
 ```
 
 ### Mounting the Partition
 
-Mounting your new partition can be handled by either `erlinit` or by your Elixir application. To have `erlinit` mount the partition for you, you will need to supply your own `erlinit.config` file to set the required `-m` option:
+Mounting your new partition can either be handled by `erlinit` or by your Elixir application.
+To have `erlinit` mount the partition for you, you will need to supply your own `erlinit.config` file to set the required `-m` option:
 
-```
+```bash
 # Mount the configdata partition
 # See http://www.linuxfromscratch.org/lfs/view/6.3/chapter08/fstab.html about
 # ignoring warning the Linux kernel warning about using UTF8 with vfat.
 -m /dev/mmcblk0p3:/root:vfat::;/dev/mmcblk0p4:/mnt/log:ext4::
 ```
 
-The other option is to handle it in your Elixir code. This can be useful if you want to scan the disk for corruption and reformat or seed it. `Erlinit` can only attempt to mount the partition.
+The other option is to handle it in your Elixir code.
+This can be useful if you want to scan the disk for corruption and reformat or seed it.
+`erlinit` can only attempt to mount the partition.
 
-First, we can initialize it:
+First, we initialize the filesystem on the partition:
 
 ```elixir
 System.cmd("mke2fs", ["-t", "ext4", "-L", "LOGDATA", "/dev/mmcblk0p4"])
 ```
 
-Then, we can mount the partition:
+Then, we mount it:
 
 ```elixir
 System.cmd("mount", ["-t", "ext4", "/dev/mmcblk0p4", "/mnt/log"])
 ```
+

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -6,7 +6,7 @@ If not, please let us know in the #nerves channel on [the Elixir-Lang Slack](htt
 
 ## Using a USB Serial Console
 
-By default, the `iex` console is displayed on the screen attached to the HDMI port, which tends to be easier for new people because they can simply connect their target device to a monitor or TV.
+By default on the Raspberry Pi family of targets, the `iex` console is displayed on the screen attached to the HDMI port, which tends to be easier for new people because they can simply connect their target device to a monitor or TV.
 For troubleshooting start-up issues and for more advanced development workflows, it's often desirable to connect from your development host to the target using a serial port, for example using the popular [FTDI Cable](https://www.sparkfun.com/products/9717).
 This allows you to interact with the console of the target device using a terminal emulator (like `screen`) on your development host.
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -18,7 +18,11 @@ For example, for the Raspberry Pi 3 target, you can find the [hardware descripti
  2. Place it in your project folder under `rootfs-additions/etc/erlinit.config`.
  2. Modify the `-c` console setting to match the value shown in the `UART` row of the hardware description table (`rpi3` example shown):
 
-    ```
+    ```bash
+    # rootfs-additions/etc/erlinit.config
+
+    ...
+
     # Specify the UART port that the shell should use.
     #-c tty1
     -c ttyS0
@@ -26,8 +30,9 @@ For example, for the Raspberry Pi 3 target, you can find the [hardware descripti
 
  3. Configure your project to replace this file in your firmware.
 
-    ```
-    # config.exs
+    ```elixir
+    # config/config.exs
+
     use Mix.Config
 
     config :nerves, :firmware,
@@ -37,10 +42,11 @@ For example, for the Raspberry Pi 3 target, you can find the [hardware descripti
  4. Connect your USB serial cable to the desired UART pins (per the I/O pin-out for your particular hardware).
  5. On your development host, connect to the serial console.
 
-    * On Linux and Mac OS, use `screen /dev/tty<device>`.  You may need to specify the baud rate as well, for example: `screen /dev/tty<device> 115200`.
+    * On Linux and Mac OS, use `screen /dev/tty<device>`.
+      You may need to specify the baud rate as well, for example: `screen /dev/tty<device> 115200`.
     * On Windows, use the `Serial` option to connect to `COM<device>`.
 
-### How do I Configure the Target Hardware to Reboot Instead of Halt on Failure?
+### How do I Configure What Happens on Failure?
 
 Similar to the previous question, we have chosen to have the device default to halting on certain kinds of failures that cause the Erlang VM to crash.
 This allows you to more easily read the error and diagnose the problem during development.
@@ -51,9 +57,16 @@ That way, in the unlikely event that your application crashes, the entire device
 This setting is also configured using the `erlinit.config` file described above.
 To have the device restart instead of hang on failure, make a copy of the `erlinit.config` file and make sure the `--hang-on-exit` option is commented out.
 
-```
+```bash
 # Uncomment to hang the board rather than rebooting when Erlang exits
 #--hang-on-exit
+```
+
+You can also have the device drop into a shell when the Erlang VM crashes, allowing you to troubleshoot at the Linux OS level.
+
+```bash
+# Optionally run a program if the Erlang VM exits
+#--run-on-exit /bin/sh
 ```
 
 ### How do I Use the Platform-Specific Hardware Features of My Target?
@@ -63,22 +76,4 @@ In general, platform-specific features will be documented in the target's system
 You may also find what you need by looking at the [community-maintained lisf of libraries](http://nerves-project.org/libraries/) that work well with Nerves.
 
 If you still don't see what you're looking for, please let us know in the #nerves channel on [the Elixir-Lang Slack](https://elixir-slackin.herokuapp.com/), or create an Issue or Pull Request to the [relevant `nerves_system-<target>` repository](https://github.com/nerves-project?query=nerves_system_).
-
-### Is Hardware Platform X Supported by Nerves? If Not, How Do I Work on Adding Support?
-
-The currently-supported target hardware platforms are listed here: https://hexdocs.pm/nerves/targets.html.
-
-In order for Nerves to work, the target hardware needs to be capable of running a full Linux kernel along with the Erlang VM.
-This requires around 32 MB of storage and RAM, ruling out most microcontroller-based platforms like Arduino.
-Microcontrollers can, however, be used alongside a Nerves-based target as a way to achieve real-time control of I/O pins, which is required for some protocols.
-
-If your intended target isn't in the supported targets list but it meets the basic requirements, here's how to get it working:
-
- 1. If the target board is already supported by [the BuildRoot project](https://buildroot.org/), you're already most of the way there.
-    If not, your first step is to figure out what packages and patches are needed to boot your board.
-    Normally, this requires some interaction with the board vendor unless it's very similar to another supported board.
-    The Free Electrons group has some [great learning materials](http://free-electrons.com/training/buildroot/) that we recommend if you want to get started with BuildRoot.
- 2. Mention in the #nerves channel on [the Elixir-Lang Slack](https://elixir-slackin.herokuapp.com/) that you're planning to work on this.
-    Someone else may have already started working on it, saving you some effort.
- 3. Follow the steps in our documentation about [creating a Nerves System](https://github.com/nerves-project/nerves/blob/master/docs/Systems.md#creating-or-modifying-a-nerves-system-with-buildroot).
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -4,7 +4,7 @@ This is a collection of questions that often come up as people are getting start
 If you tried to go through the [Getting Started guide](https://hexdocs.pm/nerves/getting-started.html) or some of the [example projects](https://github.com/nerves-project/nerves-examples) and got stuck, hopefully one of the following answers will help.
 If not, please let us know in the #nerves channel on [the Elixir-Lang Slack](https://elixir-slackin.herokuapp.com/), or [create an Issue or Pull Request to improve this documentation](https://github.com/nerves-project/nerves/tree/master/docs).
 
-### How Do I Connect to the Target using a Serial Cable Instead of Using the HDMI Screen?
+## Using a USB Serial Console
 
 By default, the `iex` console is displayed on the screen attached to the HDMI port, which tends to be easier for new people because they can simply connect their target device to a monitor or TV.
 For troubleshooting start-up issues and for more advanced development workflows, it's often desirable to connect from your development host to the target using a serial port, for example using the popular [FTDI Cable](https://www.sparkfun.com/products/9717).
@@ -46,7 +46,7 @@ For example, for the Raspberry Pi 3 target, you can find the [hardware descripti
       You may need to specify the baud rate as well, for example: `screen /dev/tty<device> 115200`.
     * On Windows, use the `Serial` option to connect to `COM<device>`.
 
-### How do I Configure What Happens on Failure?
+## Change Behavior on BEAM Failure
 
 Similar to the previous question, we have chosen to have the device default to halting on certain kinds of failures that cause the Erlang VM to crash.
 This allows you to more easily read the error and diagnose the problem during development.
@@ -69,7 +69,7 @@ You can also have the device drop into a shell when the Erlang VM crashes, allow
 #--run-on-exit /bin/sh
 ```
 
-### How do I Use the Platform-Specific Hardware Features of My Target?
+## Platform-Specific Hardware Support
 
 Some target hardware has particular features that can be used from your application, but they're not covered in the general Nerves documentation.
 In general, platform-specific features will be documented in the target's system documentation.

--- a/docs/Getting Started.md
+++ b/docs/Getting Started.md
@@ -73,7 +73,7 @@ $ MIX_TARGET=rpi3 mix deps.get
 
 Once the dependencies are fetched, you can build a Nerves Firmware (a bundle that contains a minimal Linux platform and your application, packaged as an OTP release).
 The first time you ask any dependencies or your application to compile, Nerves will fetch the System and Toolchain from one of our cache mirrors.
-These Artifacts are cached locally in `~/.nerves/artifacts` so they can be shared across projects.
+These artifacts are cached locally in `~/.nerves/artifacts` so they can be shared across projects.
 
 ``` bash
 $ mix firmware # -OR- # MIX_TARGET=rpi3 mix firmware

--- a/docs/Getting Started.md
+++ b/docs/Getting Started.md
@@ -49,7 +49,7 @@ After downloading the required dependencies, Nerves will generate a default rele
 If you chose not to fetch dependencies during project generation, you will need to do that yourself.
 
 As described by the project generator, the next step is to change to the project directory, choose a target, and fetch the target-specific dependencies.
-Visit the [Targets Page](targets.html) for more information on what target name to use for the boards that Nerves supports.
+Visit the [Targets Page](targets.html) for more information on what target name to use for each of the boards that Nerves supports.
 
 The target is chosen using a shell environment variable, so if you use the `export` command, it will remain in effect as long as you leave that window open.
 Alternatively, you can prefix each command with the environment variable.
@@ -71,7 +71,7 @@ $ MIX_TARGET=rpi3 mix deps.get
 
 ## Building and Deploying Firmware
 
-Once the dependencies are fetched, you can build a Nerves Firmware (a bundle that contains a Nerves-based Linux platform and your application, packaged as an OTP release).
+Once the dependencies are fetched, you can build a Nerves Firmware (a bundle that contains a minimal Linux platform and your application, packaged as an OTP release).
 The first time you ask any dependencies or your application to compile, Nerves will fetch the System and Toolchain from one of our cache mirrors.
 These Artifacts are cached locally in `~/.nerves/artifacts` so they can be shared across projects.
 
@@ -79,18 +79,16 @@ These Artifacts are cached locally in `~/.nerves/artifacts` so they can be share
 $ mix firmware # -OR- # MIX_TARGET=rpi3 mix firmware
 ```
 
-This will result in a `hello_nerves.fw` firmware bundle file, which is a compressed package of everything that will end up on your target SD card along with some metadata.
+This will result in a `hello_nerves.fw` firmware bundle file.
 To create a bootable SD card, use the following command:
 
 ``` bash
 $ mix firmware.burn # -OR- # MIX_TARGET=rpi3 mix firmware.burn
 ```
 
-This command will attempt to automatically discover the SD card inserted in your host machine.
-There may be situations where this command does not discover your SD card.
-This may occur if you have more than one SD card inserted into the machine, or you have disk images mounted at the same time.
-If this happens, you can specify which device to write to by passing the `-d <device>` argument to the command.
-This command wraps `fwup`, so any extra arguments passed to it will be forwarded along to `fwup`.
+This command will attempt to automatically discover the SD card inserted in your host.
+This may fail to correctly detect your SD card, for example, if you have more than one SD card inserted or you have disk images mounted.
+If this happens, you can specify the intended device by passing the `-d <device>` argument to the command.
 
 ``` bash
 # For example:
@@ -100,14 +98,17 @@ $ mix firmware.burn -d /dev/rdisk3
 > NOTE: You can also use `-d <filename>` to specify an output file that is a raw image of the SD card.
 This binary image can be burned to an SD card using `fwup`, `dd`, `Win32DiskImager`, or some other image copying utility.
 
-Now that you have your SD card burned, you can insert it into your device and boot it up.
-For Raspberry Pi, connect it to an HDMI display and USB keyboard and you should see it boot to the IEx Console.
-
-If you are sure there is only one SD card inserted, you can also add the `-y` flag to skip the confirmation that it is the correct SD card.
+The `mix firmware.burn` task uses the `fwup` tool internally; any extra arguments passed to it will be forwarded along to `fwup`.
+For example, if you are sure there is only one SD card inserted, you can also add the `-y` flag to skip the confirmation that it is the correct device.
 
 ``` bash
 $ mix firmware.burn -y # -OR- # MIX_TARGET=rpi3 mix firmware.burn -y
 ```
+
+You can read about the other supported options in the [`fwup` documentation](https://github.com/fhunleth/fwup#invoking).
+
+Now that you have your SD card burned, you can insert it into your device and boot it up.
+For Raspberry Pi, be sure to connect it to an HDMI display and USB keyboard so you can see it boot to the IEx console.
 
 ## Nerves Examples
 
@@ -117,7 +118,7 @@ Visit the [Targets Page](targets.html) for more information on what target name 
 
 The `nerves-examples` repository contains several example projects to get you started.
 The simplest example is Blinky, known as the "Hello World" of hardware because all it does is blink an LED indefinitely.
-If you are ever curious about project structuring or can't get something running, check out Blinky and run it on your target.
+If you are ever curious about project structuring or can't get something running, check out Blinky and run it on your target to confirm that it works in the simplest case.
 
 ``` bash
 $ git clone https://github.com/nerves-project/nerves-examples

--- a/docs/Getting Started.md
+++ b/docs/Getting Started.md
@@ -74,6 +74,25 @@ $ MIX_TARGET=rpi3 mix deps.get
 Once the dependencies are fetched, you can build a Nerves Firmware (a bundle that contains a minimal Linux platform and your application, packaged as an OTP release).
 The first time you ask any dependencies or your application to compile, Nerves will fetch the System and Toolchain from one of our cache mirrors.
 These artifacts are cached locally in `~/.nerves/artifacts` so they can be shared across projects.
+ 
+### Generating a release config file
+
+You must generate a _release config file_ before generating a firmware bundle.
+Normally, it will be created for you by the `mix nerves.new` task, but if not, you will get a warning like this:
+
+```bash
+** (Mix)   You are missing a release config file. Run  nerves.release.init task first
+```
+
+You can generate the file using this Mix task:
+
+```bash
+$ mix nerves.release.init
+```
+
+### Create the firmware bundle
+
+You can create the firmware bundle with the following command:
 
 ``` bash
 $ mix firmware # -OR- # MIX_TARGET=rpi3 mix firmware

--- a/docs/Getting Started.md
+++ b/docs/Getting Started.md
@@ -2,7 +2,9 @@
 
 ## Introduction
 
-Nerves defines an entirely new way to build embedded systems using Elixir. It is specifically designed for embedded systems, not desktop or server systems. You can think of Nerves as containing three parts:
+Nerves defines an entirely new way to build embedded systems using Elixir.
+It is specifically designed for embedded systems, not desktop or server systems.
+You can think of Nerves as containing three parts:
 
 **Platform** - a customized, minimal Buildroot-derived Linux that boots directly to the BEAM VM.
 
@@ -14,7 +16,7 @@ Taken together, the Nerves platform, framework, and tooling provide a highly spe
 
 ## Common Terms
 
-In the following guides, support channels, and forums you may hear the following terms being used.
+In the following guides, support channels, and forums, you may hear the following terms being used.
 
 Term | Definition
 --- | ---
@@ -28,118 +30,99 @@ firmware image | Built from a firmware bundle and contains the partition table, 
 
 ## Creating a New Nerves App
 
-Before you start using Nerves, it is important that you take a minute to read the [Installation Guide](installation.html). It will help you get your machine configured for running Nerves.
+Before you start using Nerves, it is important that you take a minute to read the [Installation Guide](installation.html).
+It will help you get your machine configured for running Nerves.
 
-Let's create a new project. The `nerves.new` project generator can be called from anywhere and can take either an absolute path or a relative path. The new project generator requires that you specify the default target you want the project to use. This allows you to omit the `--target` option when building firmware for the default target. Visit the [Targets Page](targets.html) for more information on what target name to use for the boards that Nerves supports.
+Let's create a new project.
+The `nerves.new` project generator can be called from anywhere and can take either an absolute path or a relative path.
 
-```
-$ mix nerves.new hello_nerves --target rpi3
-* creating hello_nerves/config/config.exs
-* creating hello_nerves/lib/my_app.ex
-* creating hello_nerves/test/test_helper.exs
-* creating hello_nerves/test/my_app_test.exs
-* creating hello_nerves/rel/vm.args
-* creating hello_nerves/rel/.gitignore
-* creating hello_nerves/.gitignore
-* creating hello_nerves/mix.exs
-* creating hello_nerves/README.md
+> NOTE: If you've used Nerves in the past, you may have noticed that you no longer need to specify a `--target` option when creating a new project.
+> Since Nerves Bootstrap 0.3.0, the default target is `host` unless you specify a different target in your environment.
+> This allows for more seamless interaction with tools on your host without cross-compilers getting in the way until you're ready to build firmware for a particular target.
+
+``` bash
+$ mix nerves.new hello_nerves
 ```
 
-Nerves will generate the required files and directory structure needed for your application.
-You will need to generate a release configuration as follows.
-The defaults will work to get you started, but you will probably want to come back later and modify some of them for your project.
+Nerves will generate the required files and directory structure for your application.
+After downloading the required dependencies, Nerves will generate a default release configuration file using the `mix nerves.release.init` task.
+If you chose not to fetch dependencies during project generation, you will need to do that yourself.
 
-```
+As described by the project generator, the next step is to change to the project directory, choose a target, and fetch the target-specific dependencies.
+Visit the [Targets Page](targets.html) for more information on what target name to use for the boards that Nerves supports.
+
+The target is chosen using a shell environment variable, so if you use the `export` command, it will remain in effect as long as you leave that window open.
+Alternatively, you can prefix each command with the environment variable.
+We find that it's easiest to have two shell windows open: one remaining defaulted to the `host` target and one with the desired `MIX_TARGET` variable set.
+This allows you quick access to use host-based tooling in the former and deploy updated firmware from the latter, all without having to modify the `MIX_TARGET` variable in your shell.
+
+``` bash
 $ cd hello_nerves
-$ mix nerves.release.init
-```
-
-Next, fetch the dependencies.
-
-```
+$ export MIX_TARGET=rpi3
 $ mix deps.get
 ```
 
-> It is important to note that Nerves supports multi-target projects. This means that the same code base can support running on a variety of different target boards. Because of this, It is very important that your mix file only includes a single `nerves_system` at any time. For more information check out the [Targets Page](targets.html#target-dependencies)
+**OR**
 
-Once the dependencies are fetched, you can start to compile your project. The goal is to make a Nerves Firmware (a bundle that contains a Nerves-based Linux platform and your application). As a first step, you need to fetch both the System and Toolchain for your Target. This task is done for you by Mix using the `nerves_bootstrap` utility in a special stage called `precompile`. This means that the first time you ask any dependencies or your application to compile, Nerves will fetch the System and Toolchain from one of our cache mirrors. Lets start the process and get a coffee...
-
-```
-$ mix compile
-Nerves Precompile Start
-...
-Compile Nerves toolchain
-Downloading from Github Cache
-Unpacking toolchain to build dir
-...
-Generated nerves_system_rpi3 app
-[nerves_system][compile]
-[nerves_system][http] Downloading system from cache
-[nerves_system][http] System Downloaded
-[nerves_system][http] Unpacking System
-...
-Nerves Env loaded
-Nerves Precompile End
+``` bash
+$ cd hello_nerves
+$ MIX_TARGET=rpi3 mix deps.get
 ```
 
-At this point, the Nerves System and Toolchain have been pulled down to your host machine and your Mix environment has been bootstrapped to use them when you build a firmware. You can verify that Nerves is ready with the correct System and Toolchain by getting it to print out the locations of these new assets.
+## Building and Deploying Firmware
 
-```
-$ NERVES_DEBUG=1 mix compile
-Nerves Env loaded
-------------------
-Nerves Environment
-------------------
-target:     rpi3
-toolchain:  _build/rpi3/dev/nerves/toolchain
-system:     _build/rpi3/dev/nerves/system
-app:        /Users/nerves/hello_nerves
+Once the dependencies are fetched, you can build a Nerves Firmware (a bundle that contains a Nerves-based Linux platform and your application, packaged as an OTP release).
+The first time you ask any dependencies or your application to compile, Nerves will fetch the System and Toolchain from one of our cache mirrors.
+These Artifacts are cached locally in `~/.nerves/artifacts` so they can be shared across projects.
+
+``` bash
+$ mix firmware # -OR- # MIX_TARGET=rpi3 mix firmware
 ```
 
-You'll notice that subsequent calls to `compile` will not fetch or build the system because they're already cached on your host computer.
+This will result in a `hello_nerves.fw` firmware bundle file, which is a compressed package of everything that will end up on your target SD card along with some metadata.
+To create a bootable SD card, use the following command:
 
-## Making Firmware
-
-Now that you have a compiled Nerves application, you can produce firmware. Nerves firmware is the product of turning your application into an OTP release, adding it to the system image, and laying out a partition scheme. You can create the firmware bundle with the following command:
-
-```
-$ mix firmware
-Nerves Env loaded
-Nerves Firmware Assembler
-...
-Building _images/rpi3/hello_nerves.fw...
+``` bash
+$ mix firmware.burn # -OR- # MIX_TARGET=rpi3 mix firmware.burn
 ```
 
-This will eventually output a firmware bundle file `_images/rpi3/hello_nerves.fw`. This file is an archive-formatted bundle and metadata about your firmware release. To create a bootable SD card, you can use the following command:
+This command will attempt to automatically discover the SD card inserted in your host machine.
+There may be situations where this command does not discover your SD card.
+This may occur if you have more than one SD card inserted into the machine, or you have disk images mounted at the same time.
+If this happens, you can specify which device to write to by passing the `-d <device>` argument to the command.
+This command wraps `fwup`, so any extra arguments passed to it will be forwarded along to `fwup`.
 
-```
-$ mix firmware.burn
-Burn rpi3-0.0.1 to SD card at /dev/rdisk3, Proceed? [Y/n]
-```
-
-This command will attempt to automatically discover the SD card inserted in your host machine. There may be situations where this command does not discover your SD card. This may occur if you have more than one SD card inserted into the machine, or you have disk images mounted at the same time. If this happens, you can specify which device to write to by passing the `-d <device>` argument to the command. This command wraps `fwup`, so any extra arguments passed to it will be forwarded along to `fwup`.
-
-```
+``` bash
+# For example:
 $ mix firmware.burn -d /dev/rdisk3
 ```
 
-> Note: You can also use `-d <filename>` to specify an output file. This will allow you to create a binary image that you can burn later using `dd` or some other image copying utility.
+> NOTE: You can also use `-d <filename>` to specify an output file that is a raw image of the SD card.
+This binary image can be burned to an SD card using `fwup`, `dd`, `Win32DiskImager`, or some other image copying utility.
 
-Now that you have your SD card burned, you can insert it into your device and boot it up. For Raspberry Pi, connect it to your HDMI display and USB keyboard and you should see it boot to the IEx Console.
+Now that you have your SD card burned, you can insert it into your device and boot it up.
+For Raspberry Pi, connect it to an HDMI display and USB keyboard and you should see it boot to the IEx Console.
 
-> Note: If you are sure there is only one SD card inserted, you can add the `-y` flag to skip the prompt making sure it is the right SD card.
+If you are sure there is only one SD card inserted, you can also add the `-y` flag to skip the confirmation that it is the correct SD card.
 
-```
-$ mix firmware.burn -y
+``` bash
+$ mix firmware.burn -y # -OR- # MIX_TARGET=rpi3 mix firmware.burn -y
 ```
 
 ## Nerves Examples
 
-To get up and running quickly, you can check out our collection of example projects. Be sure to set your `NERVES_TARGET` environment variable appropriately as the examples use this to determine the target when building firmware. Visit the [Targets Page](targets.html) for more information on what target name to use for the boards that Nerves supports.
-```
+To get up and running quickly, you can check out our [collection of example projects](https://github.com/nerves-project/nerves-examples).
+Be sure to set your `MIX_TARGET` environment variable appropriately for the target hardware you have.
+Visit the [Targets Page](targets.html) for more information on what target name to use for the boards that Nerves supports.
+
+The `nerves-examples` repository contains several example projects to get you started.
+The simplest example is Blinky, known as the "Hello World" of hardware because all it does is blink an LED indefinitely.
+If you are ever curious about project structuring or can't get something running, check out Blinky and run it on your target.
+
+``` bash
 $ git clone https://github.com/nerves-project/nerves-examples
+$ export MIX_TARGET=rpi3
 $ cd nerves-examples/blinky
-$ NERVES_TARGET=rpi3 mix do deps.get, firmware
+$ mix do deps.get, firmware, firmware.burn
 ```
 
-The example projects contain an app called Blinky, known as "The Hello World of Hardware". If you are ever curious about project structuring or can't get something running, it is advised to check out Blinky and run it on your target.

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -25,7 +25,7 @@ Now skip to the instructions for all platforms below.
 ## Linux
 
 We've found quite a bit of variation between Linux distributions.
-Nerves requires Erlang versions `>= 19.0` and Elixir versions `>= 1.2.4`.
+Nerves requires Erlang versions `>= 19.0` and Elixir versions `>= 1.4.0`.
 If you need to install Erlang, see the prebuilt versions and guides provided by [Erlang Solutions](https://www.erlang-solutions.com/resources/download.html).
 For Elixir, please reference the Elixir [Installation Page](http://elixir-lang.org/install.html).
 

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -1,6 +1,10 @@
 # Installation
 
-Nerves requires a number of programs on your system to work. These include Erlang, Elixir, and a few other tools for packaging your programs into firmware images. Nerves is actively used on MacOS and various Linux distributions. For Windows users, some people have had success with Linux in VM and the Windows 10 Bash Shell. If you are experiencing issues with any of the tooling, it is important to reference this list to ensure that your system is fully configured to run the Nerves tooling.
+Nerves requires a number of programs on your system to work.
+These include Erlang, Elixir, and a few tools for packaging firmware images.
+Nerves is actively used on MacOS and various Linux distributions.
+For Windows users, some people have had success running Linux in a virtual machine or using the Windows Subsystem for Linux available in Windows 10.
+If you have issues with any of the tooling after following the steps below, we recommend you reach out to us in [the #nerves channel on the Elixir Slack](https://elixir-slackin.herokuapp.com/).
 
 ## MacOS
 
@@ -17,11 +21,15 @@ Now skip to the instructions for all platforms below.
 
 ## Linux
 
-We've found quite a bit of variation between Linux distributions. Nerves requires Erlang versions `>= 19.0` and Elixir versions `>= 1.2.4`.
-If you need to install Erlang, see the prebuilt versions and guides provided by [Erlang Solutions](https://www.erlang-solutions.com/resources/download.html)
+We've found quite a bit of variation between Linux distributions.
+Nerves requires Erlang versions `>= 19.0` and Elixir versions `>= 1.2.4`.
+If you need to install Erlang, see the prebuilt versions and guides provided by [Erlang Solutions](https://www.erlang-solutions.com/resources/download.html).
 For Elixir, please reference the Elixir [Installation Page](http://elixir-lang.org/install.html).
 
-Next install the `fwup` utility. Nerves uses `fwup` to create, distribute, and install firmware images of your programs. You can install fwup using the instructions found on the [Installation Page](https://github.com/fhunleth/fwup#installing). Installing the prebuilt `.deb` or `.rpm` files is recommended.
+Next, install the `fwup` utility.
+Nerves uses `fwup` to create, distribute, and install firmware images of your programs.
+You can install `fwup` using the instructions found on the [Installation Page](https://github.com/fhunleth/fwup#installing).
+Installing the pre-built `.deb` or `.rpm` files is recommended.
 
 The `ssh-askpass` package is also required on Linux so that the `mix firmware.burn` step will be able to use `sudo` to gain the required permission to write directly to an SD card:
 
@@ -29,8 +37,9 @@ The `ssh-askpass` package is also required on Linux so that the `mix firmware.bu
 $ sudo apt-get install ssh-askpass
 ```
 
-Finally, install `squashfs-tools` using your distribution's package manager. For
-example:
+Finally, install `squashfs-tools` using your distribution's package manager.
+For example:
+
 ```
 $ sudo apt-get install squashfs-tools
 ```
@@ -39,27 +48,31 @@ Now continue to the instructions for all platforms below.
 
 ## All platforms
 
-It is important to update the versions of `hex` and `rebar` used by Elixir. This is critical even if you didn't need to install Elixir:
+It is important to update the versions of `hex` and `rebar` used by Elixir, **even if you already had Elixir installed**.
 
 ```
 $ mix local.hex
 $ mix local.rebar
 ```
-If you have your own version of `rebar` in the path, be sure that it is up to date.
 
-You can now add the `nerves_bootstrap` archive to your mix environment. This archive allows Nerves to bootstrap the Mix environment, ensuring that your code is properly compiled using the right cross-compiler for the target. The `nerves_bootstrap` archive also includes a new project generator, which you can use to create new Nerves projects. To install the `nerves_bootstrap` archive:
+If you have your own version of `rebar` in your path, be sure that it is up-to-date.
+
+You can now add the `nerves_bootstrap` archive to your Mix environment.
+This archive allows Nerves to bootstrap the Mix environment, ensuring that your code is properly compiled using the right cross-compiler for the target.
+The `nerves_bootstrap` archive also includes a project generator, which you can use to create new Nerves projects.
+To install the `nerves_bootstrap` archive:
 
 ```
 $ mix archive.install https://github.com/nerves-project/archives/raw/master/nerves_bootstrap.ez
 ```
 
-If the archive fails to install properly using this command, you can download the archive directly and then do:
+If the archive fails to install properly using this command, or you need to perform an offline installation, you can download the `.ez` file and install it like this:
 
 ```
 $ mix archive.install /path/to/nerves_bootstrap.ez
 ```
 
-Once installed, you can upgrade `nerves_bootstrap` by doing:
+Once installed, you can later upgrade `nerves_bootstrap` by doing:
 
 ```
 mix local.nerves

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -47,6 +47,17 @@ For example:
 $ sudo apt-get install squashfs-tools
 ```
 
+Optionally, if you want to build custom Nerves Systems, you need a few more build tools.
+Because Linux can build natively rather than inside a container, you need to have all of the dependencies installed on your host.
+On Debian and Ubuntu, run the following:
+
+```bash
+sudo apt-get install git g++ libssl-dev libncurses5-dev bc m4 make unzip cmake
+```
+
+> For other host Linux distributions, you will need to install equivalent packages, but we don't have the exact list documented.
+> If you'd like to help out, [send us an improvement to this page](https://github.com/nerves-project/nerves/blob/master/docs/Systems.md) and let us know what worked for you!
+
 Now continue to the instructions for all platforms below.
 
 ## All platforms

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -8,14 +8,17 @@ If you have issues with any of the tooling after following the steps below, we r
 
 ## MacOS
 
-The easiest installation route on MacOS is to use [Homebrew](brew.sh). Just run the following:
+The easiest installation route on MacOS is to use [Homebrew](brew.sh).
+Just run the following:
 
-```
+```bash
 $ brew update
 $ brew install erlang
 $ brew install elixir
 $ brew install fwup squashfs coreutils
 ```
+
+Optionally, if you want to build custom Nerves Systems, you'll also need to install [Docker for Mac](https://www.docker.com/products/overview#/install_the_platform).
 
 Now skip to the instructions for all platforms below.
 
@@ -33,14 +36,14 @@ Installing the pre-built `.deb` or `.rpm` files is recommended.
 
 The `ssh-askpass` package is also required on Linux so that the `mix firmware.burn` step will be able to use `sudo` to gain the required permission to write directly to an SD card:
 
-```
+```bash
 $ sudo apt-get install ssh-askpass
 ```
 
 Finally, install `squashfs-tools` using your distribution's package manager.
 For example:
 
-```
+```bash
 $ sudo apt-get install squashfs-tools
 ```
 
@@ -50,7 +53,7 @@ Now continue to the instructions for all platforms below.
 
 It is important to update the versions of `hex` and `rebar` used by Elixir, **even if you already had Elixir installed**.
 
-```
+```bash
 $ mix local.hex
 $ mix local.rebar
 ```
@@ -62,18 +65,18 @@ This archive allows Nerves to bootstrap the Mix environment, ensuring that your 
 The `nerves_bootstrap` archive also includes a project generator, which you can use to create new Nerves projects.
 To install the `nerves_bootstrap` archive:
 
-```
+```bash
 $ mix archive.install https://github.com/nerves-project/archives/raw/master/nerves_bootstrap.ez
 ```
 
 If the archive fails to install properly using this command, or you need to perform an offline installation, you can download the `.ez` file and install it like this:
 
-```
+```bash
 $ mix archive.install /path/to/nerves_bootstrap.ez
 ```
 
 Once installed, you can later upgrade `nerves_bootstrap` by doing:
 
-```
+```bash
 mix local.nerves
 ```

--- a/docs/Systems.md
+++ b/docs/Systems.md
@@ -233,21 +233,3 @@ make system
 
 This will create a `<system>.tar.gz` file that can be hosted on a web server and referenced from a Hex package just like the official Nerves Systems are.
 
-### Supporting New Target Hardware
-
-If you're trying to support a new Target, there may be quite a bit more work involved, depending on how mature the support for that hardware is in the Buildroot community.
-If you're not familiar with [Buildroot](https://buildroot.org/), you should learn about that first, using the excellent training materials on their website.
-
-If you can find an existing Buildroot configuration for your intended hardware and you want to get it working with Nerves:
-
-1.  Follow their procedure and confirm your target boots (independent of Nerves).
-
-2.  Figure out how to get everything working with the version of Buildroot Nerves uses. See [the `NERVES_BR_VERSION` variable in `create-build.sh`](https://github.com/nerves-project/nerves_system_br/blob/master/create-build.sh).
-
-  * Look for packages and board configs can need to be copied into your System.
-  * Look for patches to existing packages that are needed.
-
-3. Create a defconfig that mimics the one from step 1, and get `nerves_system_br` to build it.
-
-> NOTE: You probably want to disable any userland packages that may be included by default to avoid distraction.
-

--- a/docs/Systems.md
+++ b/docs/Systems.md
@@ -1,104 +1,86 @@
 # Systems
 
 ## Using a Nerves System
-**Single Target**
 
-To use a Nerves system in project with a single target, you can directly include it as part of your application dependencies.
-
-```elixir
-# mix.exs
-
-def deps do
-  [{:nerves_system_bbb, ">=0.0.0"}]
-end
-```
-
-**Multi Target**
-
-Multi target configurations can be handled a number of ways. You can allow all `nerves_system_*` projects by interpolating `target`
-```elixir
-def deps(target) do
-  [{:"nerves_system_#{target}", ">=0.0.0"}]
-end
-```
-
-Or you could switch between different configurations of the same target.
-```elixir
-def deps(:dev = env) do
-  [{:my_custom_bbb_dev, ">=0.0.0"}]
-end
-
-def deps(:prod = env) do
-  [{:my_custom_bbb_prod, ">=0.0.0"}]
-end
-```
-
-Since its all done in Elixir, you can choose which configuration works best for you. Just be sure that there is only ever one `system` present when compiling your Nerves application.
-
-## Designing a Nerves System
-
-Nerves System dependencies are a collection of configurations to be fed into the the system build platform. Currently, Nerves Systems are all built using the Buildroot platform. The project structure of a Nerves System is as follows:
-
-```
-# nerves_system_*
-mix.exs
-nerves_defconfig
-nerves.exs
-rootfs-additions
-VERSION
-```
-
-The mix file will contain the dependencies the System has. Typically, all that is included here is the Toolchain and the build platform. Here is an example of the Raspberry Pi 3 `nerves_system` definition:
+When you generate a new Nerves project using the `mix nerves.new` task, you will end up with the following section in your `mix.exs` configuration:
 
 ```elixir
-defmodule NervesSystemRpi3.Mixfile do
-  use Mix.Project
+  @target System.get_env("MIX_TARGET") || "host"
 
-  @version Path.join(__DIR__, "VERSION")
-    |> File.read!
-    |> String.strip
+  [...]
 
-  def project do
-    [app: :nerves_system_rpi3,
-     version: @version,
-     elixir: "~> 1.2",
-     compilers: Mix.compilers ++ [:nerves_system],
-     description: description,
-     package: package,
-     deps: deps]
+  def deps do
+    [...]
+    deps(@target)
   end
 
-  def application do
-   []
+  # Specify target specific dependencies
+  def deps("host"), do: []
+  def deps(target) do
+    [{:"nerves_system_#{target}", ">= 0.0.0"}]
   end
+```
 
-  defp deps do
-    [{:nerves_system, "~> 0.1.2"},
-     {:nerves_system_br, "~> 0.5.0"},
-     {:nerves_toolchain_arm_unknown_linux_gnueabihf, "~> 0.6.0"}]
-  end
+This allows Nerves to load one or more Target-specific dependencies when a `MIX_TARGET` is specificied.
+The official `nerves_system-*` dependencies contain the standard Buildroot configuration for the Nerves platform on a given hardware target and have a dependency on the appropriate Toolchain for that target.
+The System and Toolchain also reference a pre-compiled version of the relevant Artifact so that Mix can simply download them instead of having to compile them (which takes quite a while).
 
-  defp package do
-   [maintainers: ["Frank Hunleth", "Justin Schneck"],
-    files: ["LICENSE", "mix.exs", "nerves_defconfig", "nerves.exs", "README.md", "VERSION", "rootfs-additions"],
-    licenses: ["Apache 2.0"],
-    links: %{"Github" => "https://github.com/nerves-project/nerves_system_rpi3"}]
-  end
+## Anatomy of a Nerves System
 
+Nerves System dependencies are a collection of configurations to be fed into the the system build platform.
+Currently, Nerves Systems are all built using the Buildroot platform.
+The project structure of a Nerves System is as follows:
+
+```plain
+nerves_system_rpi3
+├── LICENSE
+├── README.md
+├── VERSION
+├── cmdline.txt
+├── config.txt
+├── fwup.conf
+├── linux-4.4.defconfig
+├── mix.exs
+├── nerves.exs
+├── nerves_defconfig
+├── post-createfs.sh
+└── rootfs-additions
+    ├── etc
+    │   └── erlinit.config
+    └── lib
+        └── firmware
+```
+
+The `mix.exs` defines the Toolchain and build platform.
+Here is an example from `nerves_system_rpi3`:
+
+```elixir
+def project do
+  [[...]
+   compilers: Mix.compilers ++ [:nerves_package],
+   aliases: ["deps.precompile": ["nerves.env", "deps.precompile"]]]
 end
 
+defp deps do
+  [{:nerves, "~> 0.4.0"},
+   {:nerves_system_br, "~> 0.9.2"},
+   {:nerves_toolchain_arm_unknown_linux_gnueabihf, "~> 0.9.0"}]
+end
 ```
 
 Nerves Systems have a few requirements in the mix file:
 1. The compilers must include the `:nerves_system` compiler after the `Mix.compilers` have executed.
-2. There must be a dependency for the toolchain and the build platform.
+2. There must be a dependency for the Toolchain and the build platform.
 3. You need to list all files in the `package` `files:` list so they are present when downloading from Hex.
 
 ## Package Configuration
 
-In addition to the mix file, Nerves packages read from a special `nerves.exs` configuration file in the root of the package names. This file contains configuration information that Nerves loads before any application or dependency code is compiled. It is used to store metadata about a package. Here is an example from the `nerves.exs` file for `rpi3`:
+In addition to the mix file, Nerves packages read from a special `nerves.exs` configuration file in the root of the package names.
+This file contains configuration information that Nerves loads before any application or dependency code is compiled.
+It is used to store metadata about a package.
+Here is an example from the `nerves.exs` file for `nerves_system_rpi3`:
 
-```
+```elixir
 use Mix.Config
 
 version =
@@ -106,84 +88,59 @@ version =
   |> File.read!
   |> String.strip
 
-config :nerves_system_rpi3, :nerves_env,
-  type: :system,
-  mirrors: [
-    "https://github.com/nerves-project/nerves_system_rpi3/releases/download/v#{version}/nerves_system_rpi3-v#{version}.tar.gz"],
-  build_platform: Nerves.System.Platforms.BR,
-  build_config: [
-    defconfig: "nerves_defconfig",
-    package_files: [
-      "rootfs-additions"
-    ]
-  ]
+pkg = :nerves_system_rpi3
 
+config pkg, :nerves_env,
+  type: :system,
+  version: version,
+  compiler: :nerves_package,
+  artifact_url: [
+    "https://github.com/nerves-project/#{pkg}/releases/download/v#{version}/#{pkg}-v#{version}.tar.gz",
+  ],
+  platform: Nerves.System.BR,
+  platform_config: [
+    defconfig: "nerves_defconfig",
+  ],
+  checksum: [
+    "nerves_defconfig",
+    "rootfs-additions",
+    "linux-4.4.defconfig",
+    "fwup.conf",
+    "cmdline.txt",
+    "config.txt",
+    "post-createfs.sh",
+    "VERSION"
+  ]
 ```
 
 There are a few important and required keys present in this file:
 
-**type** The type of Nerves Package. Options are: `system`, `system_compiler`, `system_platform`, `system_package`, `toolchain`, `toolchain_compiler`, `toolchain_platform`.
+`type`: The type of Nerves Package.
+Options are: `system`, `system_compiler`, `system_platform`, `system_package`, `toolchain`, `toolchain_compiler`, `toolchain_platform`.
 
-**mirrors** The URL(s) of cached assets. For nerves systems, we upload the finalized assets to Github releases so others can download them.
+`artifact_url`: The URL(s) of cached assets.
+For Nerves Systems and Toolchains, we upload the Artifacts to GitHub Releases.
 
-**build_platform** The build platform to use for the system or toolchain.
+`platform`: The build platform to use for the System or Toolchain.
 
-**build_config** The collection of configuration files. This collection contains the following keys:
+`platform_config`: Configuration options for the build platform.
+In this example, the `defconfig` option for `Nerves.System.Platforms.BR` points to the Buildroot defconfig fragment file used to build the System.
 
-  * **defconfig** For `Nerves.System.Platforms.BR`, this is the Buildroot defconfig fragment used to build the system.
-
-  * **kconfig** Buildroot requires a `Config.in` kconfig file to be present in the config directory. If this is omitted, a default empty file is used.
-
-  * **package_files** Additional files required to be present for the defconfig. Directories listed here will be expanded and all subfiles and directories will be copied over, too.
-
-## Building Nerves Systems
-
-Nerves system dependencies are light-weight, configuration-based dependencies that, at compile time, request to either download from cache, or locally build the dependency. You can control which route `nerves_system` will take by setting some environment variables on your machine:
-
-`NERVES_SYSTEM_CACHE` Options are `none`, `http`, `local`
-
-`NERVES_SYSTEM_COMPILER` Options are `none`, `local`
-
-Currently, Nerves systems can only be compiled using the `local` compiler on a specially-configured Linux machine.
-
-Nerves cache and compiler adhere to the `Nerves.System.Provider` behaviour. Therefore, the system is laid out to allow additional compiler and cache providers, to facilitate other options in the future like Vagrant or Docker. This will be helpful when you want to start a Buildroot build on your Mac or Windows host machine.
-
-### Using Local Cache Provider
-
-Nerves systems can take up a lot of space on your machine. This is because the dependency needs to be fetched for each project | target | env. To save space, you can enable the local cache.
-
-```
-$ export NERVES_SYSTEM_CACHE=local
-```
-
-With the local cache enabled, Nerves will attempt to find a cached version of the system in the cache dir. The default cache dir is located at `~/.nerves/cache/system` You can override this location by setting `NERVES_SYSTEM_CACHE_DIR` env variable.
-
-If the system your project is attempting to use is not present in the cache, mix will prompt you asking if you would like to download it.
-
-```
-$ mix compile
-...
-==> nerves_system_rpi3
-[nerves_system][compile]
-[nerves_system][local] Checking Cache for nerves_system_rpi3-0.5.1
-nerves_system_rpi3-0.5.1 was not found in your cache.
-cache dir: /Users/jschneck/.nerves/cache/system
-
-Would you like to download the system to your cache? [Yn] Y
-```
-
-This will invoke the http provider and attempt to resolve the dependency.
+`checksum`: The list of files for which checksums are calculated and stored in the Artifact cache.
+This checksum is used to match the cached Nerves Artifact on disk with its source files, so that it will be re-compiled instead of using the cache if the source files no longer match.
 
 ## Creating or Modifying a Nerves System with Buildroot
 
 For some applications, the pre-built Nerves Systems won't meet your needs.
-For example, you may want to include one or more additional Linux packages or run on hardware that isn't in the list of [Nerves-supported Targets](https://hexdocs.pm/nerves/targets.html) yet.
-In order to build a customized system, you'll need to either use Linux (e.g. in a virtual machine or container).
+For example, you may want to include additional Linux packages or run on hardware that isn't in the list of [Nerves-supported Targets](https://hexdocs.pm/nerves/targets.html) yet.
+In order to build a customized system, you'll need to use Linux, either natively, in virtual machine, or in a container.
+
+### Building on Linux
 
 First, make sure that you have all of the dependencies.
 On Debian and Ubuntu, run the following:
 
-```
+```bash
 sudo apt-get install git g++ libssl-dev libncurses5-dev bc m4 make unzip cmake
 ```
 
@@ -192,37 +149,37 @@ In the example below, we use the `nerves_build` directory, but this can be anyth
 The `nerves_system_br` project contains the base scripts and configuration for using Buildroot with Nerves.
 Go to the working directory and clone the repository:
 
-```
+```bash
 mkdir nerves_build
 cd nerves_build
 git clone https://github.com/nerves-project/nerves_system_br.git
 ```
 
 While you can start a System build from scratch, it is easiest to modify an existing one and then rename it later when you have something to share or save.
-For example, if you're targeting a Raspberry Pi 2, do the following:
+For example, if you're targeting a Raspberry Pi 3, do the following:
 
-```
-git clone https://github.com/nerves-project/nerves_system_rpi2.git
+```bash
+git clone https://github.com/nerves-project/nerves_system_rpi3.git
 ```
 
 Once that completes, create an output directory for the build products.
-The name of the output directory is up to you, but we will just call it `rpi2_out` in this example.
+The name of the output directory is up to you, but we will just call it `custom_rpi3` in this example.
 It is also possible to have multiple output directories if you have several configurations that you would like to work with simultaneously.
 
-```
-./nerves_system_br/create-build.sh nerves_system_rpi2/nerves_defconfig rpi2_out
+```bash
+./nerves_system_br/create-build.sh nerves_system_rpi3/nerves_defconfig custom_rpi3
 
 ```
 
 The `create-build.sh` script will prompt you with the next steps:
 
-```
-cd rpi2_out
+```bash
+cd custom_rpi3
 make
 ```
 
 This process will take quite a while (about 30 minutes).
-When it finishes, you will have confirmed that you can successfully build the standard `rpi2` System.
+When it finishes, you will have confirmed that you can successfully build an equivalent of the standard `rpi3` System.
 The next section will describe how to make changes and re-build the System.
 
 If you ever update `nerves_system_br`, be sure to run the `create-build.sh` script again.
@@ -257,28 +214,20 @@ The various Nerves System repositories have examples of many common use cases, s
 
 ### How to Use Your New System
 
-By default, Nerves downloads pre-built Systems from the Internet and caches them on your hard drive.
-To force a local build and not cache (so you can re-build it), set the following environment variables:
-
-```
-NERVES_SYSTEM_CACHE=none
-NERVES_SYSTEM_COMPILER=local
-```
-
 To use your new System in your firmware build, specify it with the `NERVES_SYSTEM` environment variable.
 Assuming you followed the steps in the previous section, you can do this:
 
-```
-cd rpi2_out
+```bash
+cd custom_rpi3
 export NERVES_SYSTEM=$PWD
 ```
 
 Then, when you do the `mix firmware` step from your project directory, your custom System will be used.
-Make sure you still specify the matching `NERVES_TARGET` (`rpi2` in this example) in your project's `mix.exs` configuration, since it won't be automatically detected for a custom System like this.
+Make sure you still specify the appropriate `MIX_TARGET` (`rpi3` in this example) in your environment when you run `mix deps.get` and `mix firmware` because it will not be detected automatically for custom Systems.
 
-Once you're happy with your System, you can package it by changing to the `rpi2_out` directory and running:
+Once you're happy with your System, you can package it by changing to the `custom_rpi3` directory and running:
 
-```
+```bash
 make system
 ```
 

--- a/docs/Systems.md
+++ b/docs/Systems.md
@@ -69,13 +69,13 @@ end
 ```
 
 Nerves Systems have a few requirements in the mix file:
-1. The compilers must include the `:nerves_system` compiler after the `Mix.compilers` have executed.
+1. The `compilers` must include the `:nerves_system` compiler after the `Mix.compilers` have executed.
 2. There must be a dependency for the Toolchain and the build platform.
 3. You need to list all files in the `package` `files:` list so they are present when downloading from Hex.
 
 ## Package Configuration
 
-In addition to the mix file, Nerves packages read from a special `nerves.exs` configuration file in the root of the package names.
+In addition to the mix file, Nerves packages read from a special `nerves.exs` configuration file in the root of the package directory.
 This file contains configuration information that Nerves loads before any application or dependency code is compiled.
 It is used to store metadata about a package.
 Here is an example from the `nerves.exs` file for `nerves_system_rpi3`:
@@ -113,13 +113,13 @@ config pkg, :nerves_env,
   ]
 ```
 
-There are a few important and required keys present in this file:
+There are a few required keys in this file:
 
 `type`: The type of Nerves Package.
 Options are: `system`, `system_compiler`, `system_platform`, `system_package`, `toolchain`, `toolchain_compiler`, `toolchain_platform`.
 
 `artifact_url`: The URL(s) of cached assets.
-For Nerves Systems and Toolchains, we upload the Artifacts to GitHub Releases.
+For official Nerves Systems and Toolchains, we upload the Artifacts to GitHub Releases.
 
 `platform`: The build platform to use for the System or Toolchain.
 
@@ -129,64 +129,123 @@ In this example, the `defconfig` option for `Nerves.System.Platforms.BR` points 
 `checksum`: The list of files for which checksums are calculated and stored in the Artifact cache.
 This checksum is used to match the cached Nerves Artifact on disk with its source files, so that it will be re-compiled instead of using the cache if the source files no longer match.
 
-## Creating or Modifying a Nerves System with Buildroot
+## Customizing Your Own Nerves System
 
 For some applications, the pre-built Nerves Systems won't meet your needs.
 For example, you may want to include additional Linux packages or run on hardware that isn't in the list of [Nerves-supported Targets](https://hexdocs.pm/nerves/targets.html) yet.
-In order to build a customized system, you'll need to use Linux, either natively, in virtual machine, or in a container.
+In order to make the build process consistent across host platforms, Nerves uses a Docker container behind the scenes to perform the build on non-Linux hosts.
+This makes it possible for the steps below to apply to whatever host platform you're using for development, as long as you have Docker for Mac or Docker for Windows installed on those platforms.
 
-### Building on Linux
-
-First, make sure that you have all of the dependencies.
-On Debian and Ubuntu, run the following:
-
-```bash
-sudo apt-get install git g++ libssl-dev libncurses5-dev bc m4 make unzip cmake
-```
-
-Then, set up a working directory.
-In the example below, we use the `nerves_build` directory, but this can be anything.
-The `nerves_system_br` project contains the base scripts and configuration for using Buildroot with Nerves.
-Go to the working directory and clone the repository:
+While you could design a System from scratch, it is easiest to copy and modify an existing one, renaming it to distinguish it from the official release.
+For example, if you're targeting a Raspberry Pi 3 board, do the following:
 
 ```bash
-mkdir nerves_build
-cd nerves_build
-git clone https://github.com/nerves-project/nerves_system_br.git
+$ git clone https://github.com/nerves-project/nerves_system_rpi3.git
+$ mv nerves_system_rpi3 custom_rpi3
 ```
 
-While you can start a System build from scratch, it is easiest to modify an existing one and then rename it later when you have something to share or save.
-For example, if you're targeting a Raspberry Pi 3, do the following:
+The name of the System directory is up to you, but we will just call it `custom_rpi3` in this example.
+It's recommended that you check your custom System into your version control system before making changes.
+This makes it easier to merge in upstream changes from the official Systems.
 
 ```bash
-git clone https://github.com/nerves-project/nerves_system_rpi3.git
+# After creating an empty custom_rpi3 repository in your GitHub account
+
+$ git remote rename origin upstream
+$ git remote add origin git@github.com:YourGitHubUserName/custom_rpi3.git
+$ git push origin master
 ```
 
-Once that completes, create an output directory for the build products.
-The name of the output directory is up to you, but we will just call it `custom_rpi3` in this example.
-It is also possible to have multiple output directories if you have several configurations that you would like to work with simultaneously.
+Next, tweak the metadata for your System so it won't conflict with the official one:
+
+```elixir
+# custom_rpi3/nerves.exs
+use Mix.Config
+
+# =vvv= Update the package name and remove (or replace) the artifact_url list
+
+pkg = :custom_rpi3
+
+config pkg, :nerves_env,
+  type: :system,
+  version: version,
+  compiler: :nerves_package,
+#   artifact_url: [
+#     "...",
+#   ],
+    platform: Nerves.System.BR,
+    platform_config: [
+      defconfig: "nerves_defconfig"
+    ],
+
+# =^^^=
+
+...
+```
+
+```elixir
+# custom_rpi3/mix.exs
+
+# =vvv= Update the module and application names
+defmodule CustomRpi3.Mixfile do
+
+  ...
+
+  def project do
+   [app: :custom_rpi3,
+    version: @version,
+    ...
+  end
+# =^^^=
+
+...
+
+# =vvv= Update the maintainer and project information
+  defp package do
+   [maintainers: ["Your Name"],
+    files: [...],
+    licenses: ["Your License"],
+    links: %{"Github" => "https://github.com/YourGitHubUserName/custom_rpi3"}]
+  end
+# =^^^=
+end
+```
+
+Now that the custom System directory is prepared, you just need to point to it from your project's `mix.exs`.
+
+```elixir
+# mix.exs
+
+# Specify target specific dependencies
+def deps("host"), do: []
+# =vvv= Add this section for your custom System
+def deps("custom_rpi3") do
+  [{:custom_rpi3, path: "/path/to/your/custom_rpi3"}]
+end
+# =^^^=
+def deps(target) do
+  [{:"nerves_system_#{target}", ">= 0.0.0"}]
+end
+```
+
+Set your `MIX_TARGET` to refer to your custom system and build your firmware.
 
 ```bash
-./nerves_system_br/create-build.sh nerves_system_rpi3/nerves_defconfig custom_rpi3
-
+$ export MIX_TARGET=custom_rpi3
+$ mix deps.get
+$ mix firmware
 ```
 
-The `create-build.sh` script will prompt you with the next steps:
-
-```bash
-cd custom_rpi3
-make
-```
-
-This process will take quite a while (about 30 minutes).
+This process will take quite a bit longer than a normal firmware build (15 to 30 minutes) the first time.
 When it finishes, you will have confirmed that you can successfully build an equivalent of the standard `rpi3` System.
-The next section will describe how to make changes and re-build the System.
+After your custom System has been built, you can modify your application and re-build firmware normally.
+The custom System will automatically re-build if you make changes to the System itself.
 
-If you ever update `nerves_system_br`, be sure to run the `create-build.sh` script again.
-You can point it to the same location and it will update properly.
-It is best to `make clean` and then `make` to rebuild everything after updating `nerves_system_br`.
+## Package Configuration
 
-### Additional Package Configuration
+> NOTE: Currently, the following process only works on Linux.
+> We're working on a method to make this work via Docker, but it's not ready yet.
+> You can still modify the various `defconfig` fragments manually, if you know what you're doing, but the simpler `make menuconfig` process currently won't work.
 
 The workflow for customizing a Nerves System is the standard Buildroot procedure using `make menuconfig`.
 The packages are divided into three categories:
@@ -211,25 +270,3 @@ To save them back in your System, follow the appropriate steps below:
 
 The Buildroot [user manual](http://nightly.buildroot.org/manual.html) can be very helpful especially if you need to add a package.
 The various Nerves System repositories have examples of many common use cases, so check them out as well.
-
-### How to Use Your New System
-
-To use your new System in your firmware build, specify it with the `NERVES_SYSTEM` environment variable.
-Assuming you followed the steps in the previous section, you can do this:
-
-```bash
-cd custom_rpi3
-export NERVES_SYSTEM=$PWD
-```
-
-Then, when you do the `mix firmware` step from your project directory, your custom System will be used.
-Make sure you still specify the appropriate `MIX_TARGET` (`rpi3` in this example) in your environment when you run `mix deps.get` and `mix firmware` because it will not be detected automatically for custom Systems.
-
-Once you're happy with your System, you can package it by changing to the `custom_rpi3` directory and running:
-
-```bash
-make system
-```
-
-This will create a `<system>.tar.gz` file that can be hosted on a web server and referenced from a Hex package just like the official Nerves Systems are.
-

--- a/docs/Systems.md
+++ b/docs/Systems.md
@@ -151,6 +151,7 @@ This makes it easier to merge in upstream changes from the official Systems.
 ```bash
 # After creating an empty custom_rpi3 repository in your GitHub account
 
+$ cd custom_rpi3
 $ git remote rename origin upstream
 $ git remote add origin git@github.com:YourGitHubUserName/custom_rpi3.git
 $ git push origin master
@@ -214,7 +215,7 @@ end
 Now that the custom System directory is prepared, you just need to point to it from your project's `mix.exs`.
 
 ```elixir
-# mix.exs
+# your_project/mix.exs
 
 # Specify target specific dependencies
 def deps("host"), do: []
@@ -231,6 +232,7 @@ end
 Set your `MIX_TARGET` to refer to your custom system and build your firmware.
 
 ```bash
+$ cd /path/to/your/nerves/project
 $ export MIX_TARGET=custom_rpi3
 $ mix deps.get
 $ mix firmware

--- a/docs/Targets.md
+++ b/docs/Targets.md
@@ -19,3 +19,23 @@ Intel Galileo 2 | [nerves_system_galileo](https://github.com/nerves-project/nerv
 Lego EV3 | [nerves_system_ev3](https://github.com/nerves-project/nerves_system_ev3) | `ev3`
 QEmu Arm | [nerves_system_qemu_arm](https://github.com/nerves-project/nerves_system_qemu_arm) | `qemu_arm`
 
+## Supporting New Target Hardware
+
+If you're trying to support a new Target, there may be quite a bit more work involved, depending on how mature the support for that hardware is in the Buildroot community.
+If you're not familiar with [Buildroot](https://buildroot.org/), you should learn about that first, using the excellent training materials on their website.
+
+If you can find an existing Buildroot configuration for your intended hardware and you want to get it working with Nerves, you will need to make a custom System as follows:
+
+1.  Follow their procedure and confirm your target boots (independent of Nerves).
+
+2.  Figure out how to get everything working with the version of Buildroot Nerves uses.
+    See [the `NERVES_BR_VERSION` variable in `create-build.sh`](https://github.com/nerves-project/nerves_system_br/blob/master/create-build.sh).
+
+  * Look for packages and board configs can need to be copied into your System.
+  * Look for patches to existing packages that are needed.
+
+3. Create a defconfig that mimics the one from step 1, and get `nerves_system_br` to build it.
+   See the section in the [System](systems.html) documentation about customizing Nerves Systems.
+
+> NOTE: You probably want to disable any userland packages that may be included by default to avoid distraction.
+

--- a/docs/Targets.md
+++ b/docs/Targets.md
@@ -1,91 +1,21 @@
 # Targets
 
-Nerves provides support for a set of common targets. Each target is referenced with a unique tag name. These tags are used when instructing Nerves which target you would like to compile for. It is important to note that a single tag name may offer support for more than one target board.
+Nerves provides support for a set of common Targets.
+Each Target is referenced with a unique tag name.
+These tags are used when choosing which System and Toolchain to compile with.
+It is important to note that a single tag may offer support for more than one board.
 
 ## Supported Targets and Systems
 
 Target | System | Tag
 --- | --- | ---
-Raspberry Pi A+, B, B+ and Zero | [nerves_system_rpi](https://github.com/nerves-project/nerves_system_rpi) | rpi
-Raspberry Pi 2 | [nerves_system_rpi2](https://github.com/nerves-project/nerves_system_rpi2) | rpi2
-Raspberry Pi 3 | [nerves_system_rpi3](https://github.com/nerves-project/nerves_system_rpi3) | rpi3
-BeagleBone Black | [nerves_system_bbb](https://github.com/nerves-project/nerves_system_bbb) | bbb
-Alix | [nerves_system_alix](https://github.com/nerves-project/nerves_system_alix) | alix
-AG150 | [nerves_system_ag150](https://github.com/nerves-project/nerves_system_ag150) | ag150
-Intel Galileo 2 | [nerves_system_galileo](https://github.com/nerves-project/nerves_system_galileo) | galileo
-Lego EV3 | [nerves_system_ev3](https://github.com/nerves-project/nerves_system_ev3) | ev3
-QEmu Arm | [nerves_system_qemu_arm](https://github.com/nerves-project/nerves_system_qemu_arm) | qemu_arm
+Raspberry Pi A+, B, B+ and Zero | [nerves_system_rpi](https://github.com/nerves-project/nerves_system_rpi) | `rpi`
+Raspberry Pi 2 | [nerves_system_rpi2](https://github.com/nerves-project/nerves_system_rpi2) | `rpi2`
+Raspberry Pi 3 | [nerves_system_rpi3](https://github.com/nerves-project/nerves_system_rpi3) | `rpi3`
+BeagleBone Black | [nerves_system_bbb](https://github.com/nerves-project/nerves_system_bbb) | `bbb`
+Alix | [nerves_system_alix](https://github.com/nerves-project/nerves_system_alix) | `alix`
+AG150 | [nerves_system_ag150](https://github.com/nerves-project/nerves_system_ag150) | `ag150`
+Intel Galileo 2 | [nerves_system_galileo](https://github.com/nerves-project/nerves_system_galileo) | `galileo`
+Lego EV3 | [nerves_system_ev3](https://github.com/nerves-project/nerves_system_ev3) | `ev3`
+QEmu Arm | [nerves_system_qemu_arm](https://github.com/nerves-project/nerves_system_qemu_arm) | `qemu_arm`
 
-## Changing Targets
-
-Nerves projects are configured to allow you to switch between targets by changing the value for the environment variable `NERVES_TARGET`. We configure our project to include the correct system for the target you choose by interpolating it into a string atom for the system reference.
-
-```
-def system(target) do
-  [{:"nerves_system_#{target}", ">= 0.0.0"}]
-end
-```
-
-Targets can be set and persisted several ways.
-
-**Global Level** In your shell, you can `export NERVES_TARGET=rpi3`. This is useful if you only own a certain board and want to checkout and play with a variety of published nerves projects.
-
-**Project Level** At the top of the mix file for a Nerves project, you can specify a default target tag:
-```
-@target System.get_env("NERVES_TARGET") || "rpi3"
-```
-
-**Run Level** You can switch targets at the issue of every mix command by specifying, for example, `NERVES_TARGET=rpi3 mix compile`
-
-A Run Level setting will override a Project Level setting, which will override a Global Level setting.
-
-### Example
-
-If you started your nerves project with `mix nerves.new hello_nerves --target rpi3`, and wish to compile for the Raspberry Pi 0, you can do so with:
-
-```
-NERVES_TARGET=rpi mix compile
-NERVES_TARGET=rpi mix firmware
-NERVES_TARGET=rpi mix firmware.burn
-```
-
-These commands will successively compile the code, create the firmware, and burn it to the SD card, for the `rpi` target (which covers the Raspberry Pi 0).
-
-Note: if you want to change the target for the current shell session, you can type: `export NERVES_TARGET=rpi`. For the rest of your shell session, you won't need to type `NERVES_TARGET=rpi` before your commands. If you wish to change the target permanently, you need to edit `mix.exs`.
-
-```
-@target System.get_env("NERVES_TARGET") || "rpi3"
-```
-
-## Target Dependencies
-
-It is important to note that, although Nerves supports multiple targets for a single application codebase, only one `nerves_system` can be included in a given firmware. Because of this, we recommend taking the following approach for including the system dependency separately from your application dependencies.
-
-First, tell the project configuration to concatenate the global application dependencies from the system dependencies:
-
-```
-def project do
-  [app: :hello_nerves,
-   version: "0.0.1",
-   target: @target,
-   archives: [nerves_bootstrap: "0.1.2"],
-   deps_path: "deps/#{@target}",
-   build_path: "_build/#{@target}",
-   build_embedded: Mix.env == :prod,
-   start_permanent: Mix.env == :prod,
-   aliases: aliases,
-   deps: deps ++ system(@target)]
-end
-```
-
-This allows you to keep the `nerves_system` separate form the rest of your dependencies:
-
-```
-def deps do
-  [{:nerves, "~> 0.3.0"}]
-end
-
-def system(target) do
-  [{:"nerves_system_#{target}", ">= 0.0.0"}]
-end
-```

--- a/docs/Targets.md
+++ b/docs/Targets.md
@@ -17,6 +17,7 @@ Alix | [nerves_system_alix](https://github.com/nerves-project/nerves_system_alix
 AG150 | [nerves_system_ag150](https://github.com/nerves-project/nerves_system_ag150) | `ag150`
 Intel Galileo 2 | [nerves_system_galileo](https://github.com/nerves-project/nerves_system_galileo) | `galileo`
 Lego EV3 | [nerves_system_ev3](https://github.com/nerves-project/nerves_system_ev3) | `ev3`
+Linkit Smart 7688 (and Duo) | [nerves_system_linkit](https://github.com/nerves-project/nerves_system_linkit) | `linkit`
 QEmu Arm | [nerves_system_qemu_arm](https://github.com/nerves-project/nerves_system_qemu_arm) | `qemu_arm`
 
 ## Supporting New Target Hardware

--- a/docs/User Interfaces.md
+++ b/docs/User Interfaces.md
@@ -2,22 +2,21 @@
 
 ## Phoenix Web Interfaces
 
-Phoenix makes an excellent companion to Nerves applications by offering an easy-to-use, powerful framework to create user interfaces in parallel with Nerves device code. The easiest way to handle this is to layout your application as an Umbrella. Lets get started...
+Phoenix makes an excellent companion to Nerves applications by offering an easy-to-use, powerful framework to create user interfaces in parallel with Nerves device code.
+The easiest way to handle this is to lay out your application as an Umbrella.
 
 First, generate a new umbrella app, called `nervy` in this case:
 
-```
+```bash
 $ mix new nervy --umbrella
 ```
 
 Next, create your sub-applications for Nerves and for Phoenix:
 
-```
+```bash
 $ cd nervy/apps
-$ mix nerves.new fw --target rpi3
-...
+$ mix nerves.new fw
 $ mix phoenix.new ui --no-ecto --no-brunch
-...
 ```
 
 Now, add the Phoenix `ui` app and the `nerves_networking` library to the `fw` app as dependencies:
@@ -28,24 +27,14 @@ Now, add the Phoenix `ui` app and the `nerves_networking` library to the `fw` ap
 ...
 defp deps do
   [{:ui, in_umbrella: true},
-   {:nerves_networking, github: "nerves-project/nerves_networking"}]
+   {:nerves_networking, "~> 0.6.0"}]
 end
 ...
 ```
 
-and remember to add them to the OTP-configuration in the `fw` app:
-
-```elixir
-# nervy/apps/fw/mix.exs
-
-...
-applications: [:logger,
-               :ui,
-               :nerves_networking]]
-...
-```
-
-And in order to start networking when the fw boots add a child worker that sets up networking. This example sets up the networking using DHCP. For more network settings check the `nerves_networking` project.
+In order to start networking when `fw` boots, add a worker that sets up networking.
+This example sets up the networking using DHCP.
+For more network settings, check the [`nerves_networking` project](https://github.com/nerves-project/nerves_networking).
 
 ```elixir
 # nervy/apps/fw/lib/fw.ex
@@ -77,26 +66,24 @@ config :ui, Ui.Endpoint,
 config :logger, level: :debug
 ```
 
-There you have it! A Phoenix web application ready for your Nerves device. By separating the Phoenix application from the Nerves application, you can distribute the development between resources and continue to leverage the features we have all come to love from Phoenix, like live code reloading.
+There you have it!
+A Phoenix web application ready to run on your Nerves device.
+By separating the Phoenix application from the Nerves application, you could easily distribute the development between team members and continue to leverage the features we have all come to love from Phoenix, like live code reloading.
 
 When developing your UI, you can simply run the phoenix server from the UI application:
 
-```
-# nervy/apps/ui
+```bash
+$ cd nervy/apps/ui
 $ mix phoenix.server
 ```
 
 When it's time to create your firmware:
-```
-# nervy/apps/fw
+
+```bash
+$ cd nervy/apps/fw
+$ export MIX_TARGET=rpi3
 $ mix deps.get
 $ mix firmware
-
-# and in order to burn it
 $ mix firmware.burn
 ```
 
-__Note__: You will need to have the latest version of rebar installed in order for `mix firmware` to work because we are using features that aren't included in the older releases. If you encounter an error that stating `unrecognized command line option '-flat_namespace'` then you can use the following command to install a later version of rebar which should get you past this error.
-```
-mix local.rebar
-```


### PR DESCRIPTION
Prepping documentation for release of `nerves` 0.5.0 and `nerves_bootstrap` 0.3.0.

- [x] Getting Started page
- [x] Installation page
- [x] Systems page
- [x] Targets page
- [x] User Interfaces page
- [x] Advanced Configuration page
- [x] FAQ page
- [x] How to use the Docker provider
  - [x] in Installation
  - [x] in Systems