### PR TITLE
Clean up artifact dir before unpacking

### DIFF
--- a/lib/nerves/package/providers/docker.ex
+++ b/lib/nerves/package/providers/docker.ex
@@ -224,6 +224,7 @@ defmodule Nerves.Package.Providers.Docker do
 
     if File.exists?(tar_file) do
       dir = Artifact.dir(pkg, toolchain)
+      File.rm_rf(dir)
       File.mkdir_p(dir)
 
       cwd = base_dir


### PR DESCRIPTION
When building a custom System with the Docker Provider, files were not being properly overwritten when re-building and unpacking a new Artifact. This change removes any existing files for the artifact before unpacking the one that was just built.