### PR TITLE
Support the new release of Docker

### DIFF
--- a/lib/nerves/package/providers/docker.ex
+++ b/lib/nerves/package/providers/docker.ex
@@ -67,7 +67,7 @@ defmodule Nerves.Package.Providers.Docker do
 
   alias Nerves.Package.Artifact
 
-  @version "~> 1.12 or ~> 1.12.0-rc2"
+  @version "~> 1.12 or ~> 1.12.0-rc2 or ~> 17.0"
   @tag "nervesproject/nerves_system_br:0.8.0"
 
   @dockerfile File.cwd!


### PR DESCRIPTION
Docker has changed their version scheme to use date-based versions with a suffix that looks like a pre-release. For example, the version that was just release is `17.3.0-ce` (`-ce` is for Community Edition, as opposed to
Enterprise Edition).

The version requirement needs to be `~> 17.0` instead of `~> 17.3` because the `-ce` suffix makes it decode as if it were a pre-release of `17.3.0`, so it doesn't count as being newer than that.

Unfortunately, this means that we'll need to update annually to support the new year, unless we just change to `>= 0.0.0` or `>= 17.0.0` at some point.