### PR TITLE
Bump doc and distillery deps in mix.lock

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -26,9 +26,9 @@ defmodule Nerves.Mixfile do
 
   defp deps do
     [
-      {:distillery, "~> 1.0"},
-      {:earmark, "~> 1.0", only: :dev},
-      {:ex_doc, "~> 0.14", only: :dev},
+      {:distillery, "~> 1.2"},
+      {:earmark, "~> 1.2", only: :dev},
+      {:ex_doc, "~> 0.15", only: :dev},
       {:nerves_bootstrap, path: "bootstrap", only: [:test, :dev]}
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,3 @@
-%{"distillery": {:hex, :distillery, "1.1.0", "e9943bd29557e9c252a051d8ac4b47e597cd9bf2a74332b8628eab4954eb51d7", [:mix], []},
-  "earmark": {:hex, :earmark, "1.1.0", "8c2bf85d725050a92042bc1edf362621004d43ca6241c756f39612084e95487f", [:mix], []},
-  "ex_doc": {:hex, :ex_doc, "0.14.5", "c0433c8117e948404d93ca69411dd575ec6be39b47802e81ca8d91017a0cf83c", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]}}
+%{"distillery": {:hex, :distillery, "1.2.2", "d5a52920cbe2378c8a21dfc83b526b4225944b9dce7bf170fe5f5cddda81ffb3", [:mix], []},
+  "earmark": {:hex, :earmark, "1.2.0", "bf1ce17aea43ab62f6943b97bd6e3dc032ce45d4f787504e3adf738e54b42f3a", [:mix], []},
+  "ex_doc": {:hex, :ex_doc, "0.15.0", "e73333785eef3488cf9144a6e847d3d647e67d02bd6fdac500687854dd5c599f", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, optional: false]}]}}


### PR DESCRIPTION
This clears up a ton of warnings when generating the documentation.