### PR TITLE
Spell out mix environment

### DIFF
--- a/bootstrap/templates/new/mix.exs
+++ b/bootstrap/templates/new/mix.exs
@@ -3,7 +3,7 @@ defmodule <%= app_module %>.Mixfile do
 
   @target System.get_env("MIX_TARGET") || "host"
   Mix.shell.info([:green, """
-  Env
+  Mix environment
     MIX_TARGET:   #{@target}
     MIX_ENV:      #{Mix.env}
   """, :reset])


### PR DESCRIPTION
Granted that this is some bikeshedding, but the environment was referred to as the "Mix environment" in the `Installation.md` doc. I could only find the shortened version of "env" in code rather than English docs. To me, this looks better and more consistent.