### PR TITLE
Updates whitespace in bootstrap files

### DIFF
--- a/bootstrap/templates/new/lib/app_name.ex
+++ b/bootstrap/templates/new/lib/app_name.ex
@@ -1,3 +1,3 @@
 defmodule <%= app_module %> do
-  
+
 end

--- a/bootstrap/templates/new/mix.exs
+++ b/bootstrap/templates/new/mix.exs
@@ -12,14 +12,14 @@ defmodule <%= app_module %>.Mixfile do
      version: "0.1.0",
      elixir: "<%= elixir_req %>",
      target: @target,
-     archives: [nerves_bootstrap: "~> <%= bootstrap_vsn %>"],<%= if in_umbrella do %>
-     deps_path: "../../deps/#{@target}",
+     archives: [nerves_bootstrap: "~> <%= bootstrap_vsn %>"],
+<%= if in_umbrella do %>     deps_path: "../../deps/#{@target}",
      build_path: "../../_build/#{@target}",
      config_path: "../../config/config.exs",
-     lockfile: "../../mix.lock",<% else %>
-     deps_path: "deps/#{@target}",
-     build_path: "_build/#{@target}",<% end %>
-     build_embedded: Mix.env == :prod,
+     lockfile: "../../mix.lock",
+<% else %>     deps_path: "deps/#{@target}",
+     build_path: "_build/#{@target}",
+<% end %>     build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      aliases: aliases(@target),
      deps: deps()]

--- a/bootstrap/templates/new/mix.exs
+++ b/bootstrap/templates/new/mix.exs
@@ -2,11 +2,13 @@ defmodule <%= app_module %>.Mixfile do
   use Mix.Project
 
   @target System.get_env("MIX_TARGET") || "host"
+
   Mix.shell.info([:green, """
   Env
     MIX_TARGET:   #{@target}
     MIX_ENV:      #{Mix.env}
   """, :reset])
+
   def project do
     [app: :<%= app_name %>,
      version: "0.1.0",


### PR DESCRIPTION
When using `mix nerves.new some_project` I noticed the generated `mix.exs` file had some extra newlines and trailing whitespace.

![2017-03-23-1947-31](https://cloud.githubusercontent.com/assets/770755/24275624/2f9d1898-1007-11e7-92d7-96f69b7c6726.png)

After updating the relevant template, the output now looks like this:

![2017-03-23-2025-54](https://cloud.githubusercontent.com/assets/770755/24275631/3d50037e-1007-11e7-835c-ef87752df404.png)

Additionally I removed some trailing whitespace from the `app_name.ex` template.