### PR TITLE
Add comment explaining SUDO_ASKPASS

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ $ mix firmware      # Cross-compile dependencies and create a .fw file
 $ mix firmware.burn # Burn firmware to an inserted SD card
 ```
 
+**Note:** The `mix firmware.burn` target relies on the presence of `ssh-askpass`. Some
+users may need to export the `SUDO_ASKPASS` environment variable to point to their askpass
+binary.  On Arch Linux systems, this is in `/usr/lib/ssh/ssh-askpass`
+
+
 ## Docs
 
 [Installation Docs](https://hexdocs.pm/nerves/installation.html)


### PR DESCRIPTION
This environment variable is read in
`nerves/lib/mix/tasks/firmware.burn.ex` but not documented anywhere. On
Arch Linux systems, `ssh-askpass` is not located in `/usr/bin` (or even
on the path!). This commit updates the documentation with a note
explaining how to solve this situation.