### PR TITLE
Update Nerves for Elixir 1.5 deprecations

### DIFF
--- a/docs/Systems.md
+++ b/docs/Systems.md
@@ -86,7 +86,7 @@ use Mix.Config
 version =
   Path.join(__DIR__, "VERSION")
   |> File.read!
-  |> String.strip
+  |> String.trim
 
 pkg = :nerves_system_rpi3
 

--- a/lib/mix/tasks/firmware.burn.ex
+++ b/lib/mix/tasks/firmware.burn.ex
@@ -92,7 +92,7 @@ defmodule Mix.Tasks.Firmware.Burn do
       Mix.raise "Could not auto detect your SD card"
     end
     result
-    |> String.strip
+    |> String.trim
     |> String.split("\n")
     |> Enum.map(&String.split(&1, ","))
   end
@@ -116,7 +116,7 @@ defmodule Mix.Tasks.Firmware.Burn do
           end)
           |> Enum.reverse
         choice = Mix.shell.prompt("Discovered devices:\n#{Enum.join(choices, "\n")}\nWhich device do you want to burn to?")
-        |> String.strip
+        |> String.trim
         idx =
           case Integer.parse(choice) do
             {idx, _} -> idx

--- a/lib/nerves/package.ex
+++ b/lib/nerves/package.ex
@@ -13,7 +13,7 @@ defmodule Nerves.Package do
     version =
       Path.join(__DIR__, "VERSION")
       |> File.read!
-      |> String.strip
+      |> String.trim
 
     pkg =
 

--- a/lib/nerves/package/providers/docker.ex
+++ b/lib/nerves/package/providers/docker.ex
@@ -228,9 +228,9 @@ defmodule Nerves.Package.Providers.Docker do
       File.mkdir_p(dir)
 
       cwd = base_dir
-      |> String.to_char_list
+      |> String.to_charlist
 
-      String.to_char_list(tar_file)
+      String.to_charlist(tar_file)
       |> :erl_tar.extract([:compressed, {:cwd, cwd}])
 
       File.rm!(tar_file)

--- a/lib/nerves/package/squashfs.ex
+++ b/lib/nerves/package/squashfs.ex
@@ -185,12 +185,12 @@ defmodule Nerves.Package.Squashfs do
     permissions = parse_permissions(permissions)
     [own, tail] = String.split(tail, " ", parts: 2)
     own = parse_own(own)
-    tail = String.strip(tail)
+    tail = String.trim(tail)
 
     {attr, tail} =
     if type in @device_types do
       [major, tail] = String.split(tail, ",", parts: 2)
-      tail = String.strip(tail)
+      tail = String.trim(tail)
       [minor, tail] = String.split(tail, " ", parts: 2)
       {{major, minor}, tail}
     else
@@ -199,11 +199,11 @@ defmodule Nerves.Package.Squashfs do
     end
 
     <<_modified :: binary-size(16), tail :: binary>> = tail
-    <<"squashfs-root", file :: binary>> = String.strip(tail)
+    <<"squashfs-root", file :: binary>> = String.trim(tail)
     file =
       if type == "l" do
         [file, _] = String.split(file, "->")
-        String.strip(file)
+        String.trim(file)
       else
         file
       end

--- a/lib/nerves/utils/http_client.ex
+++ b/lib/nerves/utils/http_client.ex
@@ -42,7 +42,7 @@ defmodule Nerves.Utils.HTTPClient do
 
     http_opts = [timeout: :infinity, autoredirect: false] ++ Nerves.Utils.Proxy.config(url)
     opts = [stream: :self, receiver: self(), sync: false]
-    :httpc.request(:get, {String.to_char_list(url), headers}, http_opts, opts, :nerves)
+    :httpc.request(:get, {String.to_charlist(url), headers}, http_opts, opts, :nerves)
     {:noreply, %{s | url: url, caller: from}}
   end
 

--- a/lib/nerves/utils/http_client.ex
+++ b/lib/nerves/utils/http_client.ex
@@ -64,7 +64,7 @@ defmodule Nerves.Utils.HTTPClient do
       |> to_string
       |> String.split(";")
       |> List.last
-      |> String.strip
+      |> String.trim
       |> String.trim("filename=")
     {:noreply, %{s | content_length: content_length, filename: filename}}
   end

--- a/lib/nerves/utils/proxy.ex
+++ b/lib/nerves/utils/proxy.ex
@@ -16,7 +16,7 @@ defmodule Nerves.Utils.Proxy do
     uri = URI.parse(proxy)
 
     if uri.host && uri.port do
-      host = String.to_char_list(uri.host)
+      host = String.to_charlist(uri.host)
       :httpc.set_options([{scheme(scheme), {{host, uri.port}, []}}], :nerves)
     end
 
@@ -42,8 +42,8 @@ defmodule Nerves.Utils.Proxy do
   defp auth(%URI{userinfo: auth}) do
     destructure [user, pass], String.split(auth, ":", parts: 2)
 
-    user = String.to_char_list(user)
-    pass = String.to_char_list(pass || "")
+    user = String.to_charlist(user)
+    pass = String.to_charlist(pass || "")
 
     [proxy_auth: {user, pass}]
   end

--- a/lib/nerves/utils/stream.ex
+++ b/lib/nerves/utils/stream.ex
@@ -52,7 +52,7 @@ defmodule Nerves.Utils.Stream do
     trim <> bin
     |> String.split(split)
     |> List.first
-    |> String.strip
+    |> String.trim
     |> IO.write
     reset_timer(s)
   end

--- a/test/fixtures/package/mix.exs
+++ b/test/fixtures/package/mix.exs
@@ -3,7 +3,7 @@ defmodule Package.Fixture.Mixfile do
 
   @version Path.join(__DIR__, "VERSION")
            |> File.read!
-           |> String.strip
+           |> String.trim
 
   def project do
     [app: :package,

--- a/test/fixtures/package/nerves.exs
+++ b/test/fixtures/package/nerves.exs
@@ -3,7 +3,7 @@ use Mix.Config
 version =
   Path.join(__DIR__, "VERSION")
   |> File.read!
-  |> String.strip
+  |> String.trim
 
 config :package, :nerves_env,
   type: :package,

--- a/test/fixtures/system/mix.exs
+++ b/test/fixtures/system/mix.exs
@@ -3,7 +3,7 @@ defmodule System.Fixture.Mixfile do
 
   @version Path.join(__DIR__, "VERSION")
            |> File.read!
-           |> String.strip
+           |> String.trim
 
   def project do
     [app: :system,

--- a/test/fixtures/system/nerves.exs
+++ b/test/fixtures/system/nerves.exs
@@ -3,7 +3,7 @@ use Mix.Config
 version =
   Path.join(__DIR__, "VERSION")
   |> File.read!
-  |> String.strip
+  |> String.trim
 
 config :system, :nerves_env,
   type: :system,

--- a/test/fixtures/system_platform/mix.exs
+++ b/test/fixtures/system_platform/mix.exs
@@ -3,7 +3,7 @@ defmodule SystemPlatform.Fixture.Mixfile do
 
   @version Path.join(__DIR__, "VERSION")
            |> File.read!
-           |> String.strip
+           |> String.trim
 
   def project do
     [app: :system_platform,

--- a/test/fixtures/system_platform/nerves.exs
+++ b/test/fixtures/system_platform/nerves.exs
@@ -3,7 +3,7 @@ use Mix.Config
 version =
   Path.join(__DIR__, "VERSION")
   |> File.read!
-  |> String.strip
+  |> String.trim
 
 config :system_platform, :nerves_env,
   type: :system_platform,

--- a/test/fixtures/system_v1/mix.exs
+++ b/test/fixtures/system_v1/mix.exs
@@ -3,7 +3,7 @@ defmodule SystemV1.Fixture.Mixfile do
 
   @version Path.join(__DIR__, "VERSION")
            |> File.read!
-           |> String.strip
+           |> String.trim
 
   def project do
     [app: :system_v1,

--- a/test/fixtures/system_v1/nerves.exs
+++ b/test/fixtures/system_v1/nerves.exs
@@ -3,7 +3,7 @@ use Mix.Config
 version =
   Path.join(__DIR__, "VERSION")
   |> File.read!
-  |> String.strip
+  |> String.trim
 
 config :system_v1, :nerves_env,
   type: :system,

--- a/test/fixtures/toolchain/mix.exs
+++ b/test/fixtures/toolchain/mix.exs
@@ -3,7 +3,7 @@ defmodule Toolchain.Fixture.Mixfile do
 
   @version Path.join(__DIR__, "VERSION")
            |> File.read!
-           |> String.strip
+           |> String.trim
 
   def project do
     [app: :toolchain,

--- a/test/fixtures/toolchain/nerves.exs
+++ b/test/fixtures/toolchain/nerves.exs
@@ -3,7 +3,7 @@ use Mix.Config
 version =
   Path.join(__DIR__, "VERSION")
   |> File.read!
-  |> String.strip
+  |> String.trim
 
 config :toolchain, :nerves_env,
   type: :toolchain,

--- a/test/fixtures/toolchain_platform/mix.exs
+++ b/test/fixtures/toolchain_platform/mix.exs
@@ -3,7 +3,7 @@ defmodule ToolchainPlatform.Fixture.Mixfile do
 
   @version Path.join(__DIR__, "VERSION")
            |> File.read!
-           |> String.strip
+           |> String.trim
 
   def project do
     [app: :toolchain_platform,

--- a/test/fixtures/toolchain_platform/nerves.exs
+++ b/test/fixtures/toolchain_platform/nerves.exs
@@ -3,7 +3,7 @@ use Mix.Config
 version =
   Path.join(__DIR__, "VERSION")
   |> File.read!
-  |> String.strip
+  |> String.trim
 
 config :toolchain_platform, :nerves_env,
   type: :toolchain_platform,

--- a/test/fixtures/toolchain_v1/mix.exs
+++ b/test/fixtures/toolchain_v1/mix.exs
@@ -3,7 +3,7 @@ defmodule ToolchainV1.Fixture.Mixfile do
 
   @version Path.join(__DIR__, "VERSION")
            |> File.read!
-           |> String.strip
+           |> String.trim
 
   def project do
     [app: :toolchain_v1,

--- a/test/fixtures/toolchain_v1/nerves.exs
+++ b/test/fixtures/toolchain_v1/nerves.exs
@@ -3,7 +3,7 @@ use Mix.Config
 version =
   Path.join(__DIR__, "VERSION")
   |> File.read!
-  |> String.strip
+  |> String.trim
 
 config :toolchain_v1, :nerves_env,
   type: :toolchain


### PR DESCRIPTION
## Why?
I was doing some work w/ `Elixir 1.5.0-dev` and I noticed a whole bunch of deprecation warnings on `Nerves` when I built a nerves project. I figured I'd put a PR to start the process of cleanup in prep for the new release of `Elixir`. I know `Nerves` loves to live at the bleeding edge ;)

## What?
- Two changes to the `String` API:
  - `String.strip` -> `String.trim`
  - `String.to_char_list` -> `String.to_charlist`