### PR TITLE
split lock files by target

### DIFF
--- a/bootstrap/templates/new/mix.exs
+++ b/bootstrap/templates/new/mix.exs
@@ -20,7 +20,8 @@ defmodule <%= app_module %>.Mixfile do
      config_path: "../../config/config.exs",
      lockfile: "../../mix.lock",<% else %>
      deps_path: "deps/#{@target}",
-     build_path: "_build/#{@target}",<% end %>
+     build_path: "_build/#{@target}",
+     lockfile: "mix.lock.#{@target}",<% end %>
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      aliases: aliases(@target),

--- a/bootstrap/templates/new/mix.exs
+++ b/bootstrap/templates/new/mix.exs
@@ -18,7 +18,7 @@ defmodule <%= app_module %>.Mixfile do
      deps_path: "../../deps/#{@target}",
      build_path: "../../_build/#{@target}",
      config_path: "../../config/config.exs",
-     lockfile: "../../mix.lock",<% else %>
+     lockfile: "../../mix.lock.#{@target}",<% else %>
      deps_path: "deps/#{@target}",
      build_path: "_build/#{@target}",
      lockfile: "mix.lock.#{@target}",<% end %>


### PR DESCRIPTION
Splitting lock files by target will eliminate cross target dependency issues. 