### PR TITLE
include the system in the runtime

### DIFF
--- a/bootstrap/templates/new/mix.exs
+++ b/bootstrap/templates/new/mix.exs
@@ -62,7 +62,7 @@ defmodule <%= app_module %>.Mixfile do
   def deps("host"), do: []
   def deps(target) do
     [{:nerves_runtime, "~> <%= runtime_vsn %>"},
-     {:"nerves_system_#{target}", "~> 0.10", runtime: false}]
+     {:"nerves_system_#{target}", "~> 0.10"}]
   end
 
   # We do not invoke the Nerves Env when running on the Host


### PR DESCRIPTION
Systems contain configuration and therefore they can be interesting to include as part of the runtime. 

