### PR TITLE
Add commented-out instructions for enabling rootfs_additions

### DIFF
--- a/bootstrap/templates/new/config/config.exs
+++ b/bootstrap/templates/new/config/config.exs
@@ -5,6 +5,14 @@
 # is restricted to this project.
 use Mix.Config
 
+# Customize the firmware. Uncomment all or parts of the following
+# to add files to the root filesystem or modify the firmware
+# archive.
+
+# config :nerves, :firmware,
+#   rootfs_additions: "config/rootfs_additions",
+#   fwup_conf: "config/fwup.conf"
+
 # Import target specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 # Uncomment to use target specific configurations


### PR DESCRIPTION
While this information is in the Nerves instructions, having it here as
well is really convenient and saves having to look it up.