### PR TITLE
recompile regex before executing

### DIFF
--- a/bootstrap/lib/mix/tasks/nerves/new.ex
+++ b/bootstrap/lib/mix/tasks/nerves/new.ex
@@ -135,6 +135,14 @@ defmodule Mix.Tasks.Nerves.New do
     end)
   end
 
+  def recompile(regex) do
+    if Code.ensure_loaded?(Regex) and function_exported?(Regex, :recompile!, 1) do
+      apply(Regex, :recompile!, [regex])
+    else
+      regex
+    end
+  end
+
   defp cmd(cmd) do
     Mix.shell.info [:green, "* running ", :reset, cmd]
     case Mix.shell.cmd(cmd, [quiet: true]) do
@@ -182,7 +190,7 @@ defmodule Mix.Tasks.Nerves.New do
   defp switch_to_string({name, val}), do: name <> "=" <> val
 
   defp check_application_name!(name, from_app_flag) do
-    unless name =~ ~r/^[a-z][\w_]*$/ do
+    unless name =~ recompile(~r/^[a-z][\w_]*$/) do
       extra =
         if !from_app_flag do
           ". The application name is inferred from the path, if you'd like to " <>
@@ -197,7 +205,7 @@ defmodule Mix.Tasks.Nerves.New do
   end
 
   defp check_module_name_validity!(name) do
-    unless name =~ ~r/^[A-Z]\w*(\.[A-Z]\w*)*$/ do
+    unless name =~ recompile(~r/^[A-Z]\w*(\.[A-Z]\w*)*$/) do
       Mix.raise "Module name must be a valid Elixir alias (for example: Foo.Bar), got: #{inspect name}"
     end
   end


### PR DESCRIPTION
regex sigils precompile is causing issues with the installer producing false positives. Recompiling regex fixes the issue.

Info from elixir
https://hexdocs.pm/elixir/Regex.html#module-precompilation

Solved in Phoenix installer
https://github.com/phoenixframework/phoenix/commit/effdd2b40e194d1017d4a35235cdd99e4ee7a78e