### PR TITLE
Error out when package version or type are missing

### DIFF
--- a/lib/nerves/package.ex
+++ b/lib/nerves/package.ex
@@ -119,9 +119,18 @@ defmodule Nerves.Package do
     load_nerves_config(path)
     config = Application.get_env(app, :nerves_env)
     version = config[:version]
-    unless version, do: Mix.shell.error "The Nerves package #{app} does not define its version"
+    unless version do
+      Mix.shell.error "The Nerves package #{app} does not define a version.\n\n" <>
+                      "Verify that the key exists in '#{config_path(path)}'\n" <>
+                      "and that the package name is correct."
+      exit({:shutdown, 1})
+    end
     type = config[:type]
-    unless type, do: Mix.shell.error "The Nerves package #{app} does not define a type"
+    unless type do
+      Mix.shell.error "The Nerves package #{app} does not define a type.\n\n" <>
+                      "Verify that the key exists in '#{config_path(path)}'.\n"
+      exit({:shutdown, 1})
+    end
     platform = config[:platform]
     provider = provider(app, type)
     compiler = config[:compiler]

--- a/test/nerves/artifact_test.exs
+++ b/test/nerves/artifact_test.exs
@@ -19,22 +19,6 @@ defmodule Nerves.ArtifactTest do
     end
   end
 
-  test "Resolve v1 artifact path" do
-    in_fixture "simple_app_v1", fn ->
-      packages =
-        ~w(system_v1 toolchain_v1)
-
-      _ = load_env(packages)
-      system = Env.package(:system_v1)
-      toolchain = Env.package(:toolchain_v1)
-      artifact_dir = Artifact.dir(system, toolchain)
-      v1_system_path =
-        Mix.Project.build_path
-        |> Path.join("nerves/system")
-      assert artifact_dir == v1_system_path
-    end
-  end
-
   test "Resolve artifact path" do
     in_fixture "simple_app", fn ->
       packages =


### PR DESCRIPTION
I ran into this based on a typo. Previously, the message was printed and
processing carried on. If you were lucky, it would crash, but on
something later. This exits `mix` as soon as it's detected and provides
some info on where to look for what's probably a typo.