### PR TITLE
Propogate mix.exs configuration to .fw metadata

### DIFF
--- a/lib/mix/tasks/firmware.ex
+++ b/lib/mix/tasks/firmware.ex
@@ -102,8 +102,19 @@ defmodule Mix.Tasks.Firmware do
       |> Path.join("rel/#{otp_app}")
     output = [release_path]
     args = args ++ fwup_conf ++ rootfs_additions ++ fw ++ output
+    env = standard_fwup_variables(config)
 
-    shell(cmd, args)
+    shell(cmd, args, env: env)
     |> result
+  end
+
+  defp standard_fwup_variables(config) do
+    # Assuming the fwup.conf file respects these variable like the official
+    # systems do, this will set the .fw metadata to what's in the mix.exs.
+    [{"NERVES_FW_VERSION", config[:version]},
+     {"NERVES_FW_PRODUCT", config[:name]},
+     {"NERVES_FW_DESCRIPTION", config[:description]},
+     {"NERVES_FW_AUTHOR", config[:author]},
+    ]
   end
 end


### PR DESCRIPTION
I'm looking for feedback on fields and naming as well. Since firmware metadata is going to become a lot easier to access and useful thanks to `Nerves.Runtime.KV`, I attempted to fill in some of it. This only works if you're using the `fw_metadata` branch of `nerves_system_rpi0` and branches of `nerves_runtime`, so don't merge!

Here's an example on the target:
```
iex(10)> Nerves.Runtime.KV.get_all
%{"a.nerves_fw_application_part0_devpath" => "/dev/mmcblk0p3",
  "a.nerves_fw_application_part0_fstype" => "ext4",
  "a.nerves_fw_application_part0_target" => "/root",
  "a.nerves_fw_architecture" => "arm", "a.nerves_fw_author" => "Yours truly",
  "a.nerves_fw_description" => "New and improved",
  "a.nerves_fw_platform" => "rpi",
  "a.nerves_fw_product" => "My Bestest Product",
  "a.nerves_fw_version" => "0.1.0", "nerves_fw_active" => "a",
  "nerves_fw_devpath" => "/dev/mmcblk0"}
iex(11)> 
```