### PR TITLE
Remove checksum from docker container name

### DIFF
--- a/bootstrap/lib/mix/tasks/nerves/clean.ex
+++ b/bootstrap/lib/mix/tasks/nerves/clean.ex
@@ -1,9 +1,13 @@
 defmodule Mix.Tasks.Nerves.Clean do
   use Mix.Task
 
-  def run(_argv) do
+  @switches [package: :string]
+
+  def run(argv) do
+    {opts, _, _} = OptionParser.parse(argv, switches: @switches)
+    package = opts[:package]
     Mix.Tasks.Nerves.Env.run([])
-    Nerves.Env.clean()
+    Nerves.Env.clean(package)
   end
 
 end

--- a/bootstrap/lib/mix/tasks/nerves/clean.ex
+++ b/bootstrap/lib/mix/tasks/nerves/clean.ex
@@ -1,6 +1,8 @@
 defmodule Mix.Tasks.Nerves.Clean do
   use Mix.Task
 
+  @shortdoc "Clean artifacts for a Nerves package"
+
   @switches [package: :string]
 
   def run(argv) do

--- a/bootstrap/lib/mix/tasks/nerves/clean.ex
+++ b/bootstrap/lib/mix/tasks/nerves/clean.ex
@@ -2,7 +2,6 @@ defmodule Mix.Tasks.Nerves.Clean do
   use Mix.Task
 
   def run(_argv) do
-    IO.puts "Nerves Clean"
     Mix.Tasks.Nerves.Env.run([])
     Nerves.Env.clean()
   end

--- a/bootstrap/lib/mix/tasks/nerves/clean.ex
+++ b/bootstrap/lib/mix/tasks/nerves/clean.ex
@@ -1,0 +1,10 @@
+defmodule Mix.Tasks.Nerves.Clean do
+  use Mix.Task
+
+  def run(_argv) do
+    IO.puts "Nerves Clean"
+    Mix.Tasks.Nerves.Env.run([])
+    Nerves.Env.clean()
+  end
+
+end

--- a/bootstrap/lib/mix/tasks/nerves/env.ex
+++ b/bootstrap/lib/mix/tasks/nerves/env.ex
@@ -12,15 +12,7 @@ defmodule Mix.Tasks.Nerves.Env do
     end
     # Env moved to :nerves, try to start it otherwise, compile
     #  :nerves_system and call initialize
-    try do
-      Nerves.Env.start()
-    rescue
-      UndefinedFunctionError ->
-        unless Code.ensure_compiled?(Nerves.Env) do
-          Mix.Tasks.Deps.Compile.run ["nerves_system", "--include-children"]
-        end
-        Nerves.Env.initialize()
-    end
+    Nerves.Env.start()
     debug_info "Env End"
     if opts[:info], do: print_env()
   end

--- a/bootstrap/lib/mix/tasks/nerves/env.ex
+++ b/bootstrap/lib/mix/tasks/nerves/env.ex
@@ -10,8 +10,6 @@ defmodule Mix.Tasks.Nerves.Env do
     unless Code.ensure_compiled?(Nerves.Env) do
       Mix.Tasks.Deps.Compile.run ["nerves", "--include-children"]
     end
-    # Env moved to :nerves, try to start it otherwise, compile
-    #  :nerves_system and call initialize
     Nerves.Env.start()
     debug_info "Env End"
     if opts[:info], do: print_env()

--- a/lib/nerves/env.ex
+++ b/lib/nerves/env.ex
@@ -69,7 +69,8 @@ defmodule Nerves.Env do
   end
 
   @doc """
-  Cleans the artifacts for the package providers of a package or all packages
+  Cleans the artifacts for the package providers of specified package.
+  If no package is provided, it will call clean on all packages.
   """
   @spec clean(Nerves.Package.t) :: :ok | {:error, term}
   def clean(pkg \\ nil) do

--- a/lib/nerves/env.ex
+++ b/lib/nerves/env.ex
@@ -69,6 +69,15 @@ defmodule Nerves.Env do
   end
 
   @doc """
+  Cleans the artifacts for the package providers of a package or all packages
+  """
+  @spec clean(Nerves.Package.t) :: :ok | {:error, term}
+  def clean(pkg \\ nil) do
+    ([pkg] || packages)
+    |> Enum.each(&Package.clean/1)
+  end
+
+  @doc """
   Ensures that an application which contins a Nerves package config has
   been loaded into the environment agent.
 

--- a/lib/nerves/env.ex
+++ b/lib/nerves/env.ex
@@ -73,7 +73,14 @@ defmodule Nerves.Env do
   """
   @spec clean(Nerves.Package.t) :: :ok | {:error, term}
   def clean(pkg \\ nil) do
-    packages = if pkg, do: [pkg], else: packages()
+    packages =
+      if pkg do
+        pkg = String.to_atom(pkg)
+        if pkg = package(pkg), do: [pkg], else: []
+      else
+        packages()
+      end
+
     packages
     |> Enum.each(&Package.clean/1)
   end

--- a/lib/nerves/env.ex
+++ b/lib/nerves/env.ex
@@ -73,7 +73,8 @@ defmodule Nerves.Env do
   """
   @spec clean(Nerves.Package.t) :: :ok | {:error, term}
   def clean(pkg \\ nil) do
-    ([pkg] || packages)
+    packages = if pkg, do: [pkg], else: packages()
+    packages
     |> Enum.each(&Package.clean/1)
   end
 

--- a/lib/nerves/package.ex
+++ b/lib/nerves/package.ex
@@ -165,6 +165,14 @@ defmodule Nerves.Package do
   end
 
   @doc """
+  Cleans the artifacts for the package providers of all packages
+  """
+  @spec clean(Nerves.Package.t) :: :ok | {:error, term}
+  def clean(pkg) do
+    Enum.each(pkg.provider, fn({provider, _}) -> provider.clean(pkg) end)
+  end
+
+  @doc """
   Determines if the artifact for a package is stale and needs to be rebuilt.
   """
   @spec stale?(Nerves.Package.t, Nerves.Package.t) :: boolean

--- a/lib/nerves/package.ex
+++ b/lib/nerves/package.ex
@@ -169,7 +169,7 @@ defmodule Nerves.Package do
   """
   @spec clean(Nerves.Package.t) :: :ok | {:error, term}
   def clean(pkg) do
-    IO.inspect pkg
+    Mix.shell.info("Cleaning Nerves Package #{pkg.app}")
     Enum.each(pkg.provider, fn({provider, _}) -> provider.clean(pkg) end)
   end
 

--- a/lib/nerves/package/provider.ex
+++ b/lib/nerves/package/provider.ex
@@ -9,10 +9,7 @@ defmodule Nerves.Package.Provider do
   @callback artifact(package :: Nerves.Package.t, toolchain :: atom, opts :: term) ::
     :ok | {:error, error :: term}
 
-  # @callback shell(package :: Nerves.Package.t, opts :: term) ::
-  #   :ok | {:error, error :: term}
-  #
-  # @callback clean(package :: Nerves.Package.t, opts :: term) ::
-  #   :ok | {:error, error :: term}
-  
+  @callback clean(package :: Nerves.Package.t) ::
+    :ok | {:error, error :: term}
+
 end

--- a/lib/nerves/package/provider.ex
+++ b/lib/nerves/package/provider.ex
@@ -7,9 +7,9 @@ defmodule Nerves.Package.Provider do
   """
 
   @callback artifact(package :: Nerves.Package.t, toolchain :: atom, opts :: term) ::
-    :ok | {:error, error :: term}
+    :ok | {:error, reason :: term}
 
   @callback clean(package :: Nerves.Package.t) ::
-    :ok | {:error, error :: term}
+    :ok | {:error, reason :: term}
 
 end

--- a/lib/nerves/package/providers/docker.ex
+++ b/lib/nerves/package/providers/docker.ex
@@ -101,6 +101,8 @@ defmodule Nerves.Package.Providers.Docker do
   def clean(pkg) do
     container_name(pkg)
     |> container_delete
+    Artifact.base_dir(pkg)
+    |> File.rm_rf
   end
 
   defp preflight(pkg) do
@@ -394,9 +396,10 @@ defmodule Nerves.Package.Providers.Docker do
   defp container_stop(name) do
     cmd = "docker"
     args = ["stop", name]
-    case System.cmd(cmd, args) do
+    case System.cmd(cmd, args, stderr_to_stdout: true) do
       {_, 0} -> :ok
       {<<"Error response from daemon: ", response :: binary>>, _} ->
+
         if response =~ "No such container" do
           :ok
         else

--- a/lib/nerves/package/providers/docker.ex
+++ b/lib/nerves/package/providers/docker.ex
@@ -108,7 +108,7 @@ defmodule Nerves.Package.Providers.Docker do
   # end
 
   defp preflight(pkg) do
-    checksum = Nerves.Package.checksum(pkg)
+    #checksum = Nerves.Package.checksum(pkg)
 
     id_file =
       Mix.Project.build_path
@@ -125,7 +125,7 @@ defmodule Nerves.Package.Providers.Docker do
         id
       end
 
-    name = "#{id}-#{pkg.app}-#{checksum}"
+    name = "#{id}-#{pkg.app}"
 
     _ = host_check()
     _ = config_check(pkg, name)

--- a/lib/nerves/package/providers/http.ex
+++ b/lib/nerves/package/providers/http.ex
@@ -24,6 +24,10 @@ defmodule Nerves.Package.Providers.HTTP do
     Logger.debug "#{__MODULE__}: artifact: #{inspect pkg}"
   end
 
+  def clean(_pkg) do
+    :ok
+  end
+
   # def shell(_pkg, _opts) do
   #   :ok
   # end

--- a/lib/nerves/package/providers/local.ex
+++ b/lib/nerves/package/providers/local.ex
@@ -19,6 +19,10 @@ defmodule Nerves.Package.Providers.Local do
     build(type, pkg, toolchain, opts)
   end
 
+  def clean(_pkg) do
+    :ok
+  end
+
   defp build(:linux, pkg, toolchain, _opts) do
     System.delete_env("BINDIR")
     dest = Artifact.dir(pkg, toolchain)

--- a/lib/nerves/package/providers/path.ex
+++ b/lib/nerves/package/providers/path.ex
@@ -5,4 +5,8 @@ defmodule Nerves.Package.Providers.Path do
     # Verify the artifact is at the location passed
     :ok
   end
+
+  def clean(_pkg) do
+    :ok
+  end
 end


### PR DESCRIPTION
This will fix a few things with the docker provider. Instead of  adding the checksum to the container name, the same container will be used for the life cycle of the application. It also adds the functionality to clean the artifacts, starting with the docker provider. You can call `mix nerves.clean` and if a container has been made, it will remove it. This process could be hooked into `mix clean` but we might want to play around with it a little before making it happen always on ever clean.