### PR TITLE
strip sem ver major, minor, patch before parsing it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## Nerves 0.6.1
+* Bug Fixes
+  * Docker Provider: Fix version parsing issue when major, minor, or patch contains leading zeros.
+
 ## Nerves 0.6.0
 * Bug Fixes
   * Require Nerves Packages to have a version

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule Nerves.Mixfile do
      name: "Nerves",
      source_url: "https://github.com/nerves-project/nerves",
      homepage_url: "http://nerves-project.org/",
-     version: "0.6.1-dev",
+     version: "0.6.1",
      archives: [nerves_bootstrap: "~> 0.3"],
      elixir: "~> 1.4.0",
      elixirc_paths: elixirc_paths(Mix.env),

--- a/test/nerves/provider/docker_test.exs
+++ b/test/nerves/provider/docker_test.exs
@@ -15,8 +15,11 @@ defmodule Nerves.Provider.DockerTest do
   end
 
   test "parse versions with leading zeros" do
-    assert {:ok, _} = Docker.parse_docker_version("17.0.1")
-    assert {:ok, _} = Docker.parse_docker_version("17.03.1")
-    assert {:ok, _} = Docker.parse_docker_version("0017000.00300.00001000-ce")
+    assert {:ok, %{major: 17, minor: 0, patch: 1}} =
+      Docker.parse_docker_version("17.0.1")
+    assert {:ok, %{major: 17, minor: 3, patch: 1}} =
+      Docker.parse_docker_version("17.03.1")
+    assert {:ok, %{major: 17000, minor: 300, patch: 1000, pre: ["ce"]}} =
+      Docker.parse_docker_version("0017000.00300.00001000-ce")
   end
 end

--- a/test/nerves/provider/docker_test.exs
+++ b/test/nerves/provider/docker_test.exs
@@ -1,6 +1,8 @@
 defmodule Nerves.Provider.DockerTest do
   use NervesTest.Case, async: false
 
+  alias Nerves.Package.Providers.Docker
+
   test "Generated docker container Id is valid" do
     id = Nerves.Utils.random_alpha_num(16)
     assert Regex.match?(~r/^[a-zA-Z0-9_]*$/, id)
@@ -10,5 +12,11 @@ defmodule Nerves.Provider.DockerTest do
     id1 = Nerves.Utils.random_alpha_num(16)
     id2 = Nerves.Utils.random_alpha_num(16)
     refute id1 == id2
+  end
+
+  test "parse versions with leading zeros" do
+    assert {:ok, _} = Docker.parse_docker_version("17.0.1")
+    assert {:ok, _} = Docker.parse_docker_version("17.03.1")
+    assert {:ok, _} = Docker.parse_docker_version("0017000.00300.00001000-ce")
   end
 end


### PR DESCRIPTION
Docker has a sem ver version where the minor number contains a leading zero. This is causing `Version.parse/1` to return an `:error` because it does not handle leading zeros.

```
iex(1)> Version.parse("17.0.1")
{:ok, #Version<17.0.1>}
iex(2)> Version.parse("17.03.1")
:error
```

This PR implements a function to strip the leading zeros and compare.