### PR TITLE
Pass +Bc in vm.args to avoid accidental CTRL+C

### DIFF
--- a/bootstrap/templates/new/rel/vm.args
+++ b/bootstrap/templates/new/rel/vm.args
@@ -7,6 +7,10 @@
 # -name <%= app_name %>@0.0.0.0
 -setcookie <%= cookie %>
 
+## Use Ctrl-C to interrupt the current shell rather than invoking the emulator's
+## break handler and possibly exiting the VM.
++Bc
+
 ## Start the Elixir shell
 
 -noshell


### PR DESCRIPTION
Here's a sample session of the new behavior:

iex(8)> # Press CTRL+C
iex(9)> ** (EXIT) interrupted
iex(9)> ** (EXIT) interrupted
iex(9)> ** (EXIT) interrupted
iex(9)> :timer.sleep(1232421414)
** (EXIT) interrupted
iex(9)>
User switch command
 --> s sh
 --> c
Nerves Interactive Command Shell

Type Ctrl+G to exit the shell and return to Erlang job control.
This is not a normal shell, so try not to type Ctrl+C.

/srv/erlang[1]> ls
releases
lib

/srv/erlang[2]> Interrupted
/srv/erlang[2]> Interrupted