### PR TITLE
Allow the nerves_package compiler to safely be invoked on an individual package

### DIFF
--- a/bootstrap/lib/mix/tasks/nerves/precompile.ex
+++ b/bootstrap/lib/mix/tasks/nerves/precompile.ex
@@ -7,7 +7,17 @@ defmodule Mix.Tasks.Nerves.Precompile do
 
     System.put_env("NERVES_PRECOMPILE", "1")
     Mix.Tasks.Nerves.Env.run []
-    Mix.Tasks.Deps.Compile.run [to_string(Nerves.Env.system.app), "--include-children"]
+    parent = Mix.Project.config[:app]
+    Nerves.Env.ensure_loaded parent
+    system_app = Nerves.Env.system.app
+    {m, f, a} =
+      if parent == system_app do
+        {Mix.Tasks.Compile, :run, [["--no-deps-check"]]}
+      else
+        system_app_name = to_string(system_app)
+        {Mix.Tasks.Deps.Compile, :run, [[system_app_name, "--include-children"]]}
+      end
+    apply(m, f, a)
     Mix.Task.reenable "deps.compile"
     System.put_env("NERVES_PRECOMPILE", "0")
 

--- a/lib/nerves/env.ex
+++ b/lib/nerves/env.ex
@@ -88,16 +88,12 @@ defmodule Nerves.Env do
     {:ok, Nerves.Package.t} | {:error, term}
   def ensure_loaded(app, path \\ nil) do
     path = path || File.cwd!
-    config? =
-      Package.config_path(path)
-      |> File.exists?
-    if config? do
+    if File.exists?(Package.config_path(path)) do
       packages = Agent.get(__MODULE__, &(&1))
       case Enum.find(packages, & &1.app == app) do
         nil ->
           case Package.load_config({app, path}) do
             %Package{} = package ->
-              IO.inspect package
               Agent.update(__MODULE__, fn(packages) ->
                 [package | packages]
               end)


### PR DESCRIPTION
This fixes an issue where nerves.precompile could not be called when the mix project on the top of the stack is the nerves_system_*. This will also safely check for a nerves package config before trying to load it when calling `ensure_loaded/2`