### PR TITLE
Remove system artifact dir only when instructed by mix nerves.clean

### DIFF
--- a/lib/nerves/package/providers/local.ex
+++ b/lib/nerves/package/providers/local.ex
@@ -1,6 +1,6 @@
 defmodule Nerves.Package.Providers.Local do
   @moduledoc """
-  Builds an artifact locally.
+  Builds an artifact locally.
 
   This provider will only function on certain Linux host configurations
   """
@@ -11,7 +11,7 @@ defmodule Nerves.Package.Providers.Local do
   import Mix.Nerves.Utils
 
   @doc """
-  Builds an artifact locally.
+  Builds an artifact locally.
   """
   @spec artifact(Nerves.Package.t, Nerves.Package.t, term) :: :ok
   def artifact(pkg, toolchain, opts) do
@@ -19,15 +19,15 @@ defmodule Nerves.Package.Providers.Local do
     build(type, pkg, toolchain, opts)
   end
 
-  def clean(_pkg) do
-    :ok
+  def clean(pkg) do
+    dest = Artifact.dir(pkg, Nerves.Env.toolchain)
+    File.rm_rf(dest)
+    File.mkdir_p!(dest)
   end
 
   defp build(:linux, pkg, toolchain, _opts) do
     System.delete_env("BINDIR")
     dest = Artifact.dir(pkg, toolchain)
-    File.rm_rf(dest)
-    File.mkdir_p!(dest)
 
     script = Path.join(Nerves.Env.package(:nerves_system_br).path, "create-build.sh")
     platform_config = pkg.config[:platform_config][:defconfig]


### PR DESCRIPTION
This affects only the local provider.  Previously it was removing the system artifact folder on every build, causing the build to start over from scratch every time.

This changes the behavior so that the system artifact folder is only removed when `mix nerves.clean <system>` or `mix nerves.clean --all` is called.