### PR TITLE
Correct code_reloader parameter

### DIFF
--- a/docs/User Interfaces.md
+++ b/docs/User Interfaces.md
@@ -62,7 +62,7 @@ config :ui, Ui.Endpoint,
   server: true,
   render_errors: [accepts: ~w(html json)],
   pubsub: [name: Nerves.PubSub],
-  code_reload: false
+  code_reloader: false
 
 config :logger, level: :debug
 ```


### PR DESCRIPTION
I'm not sure if phoenix renamed this parameter at some point (See https://github.com/phoenixframework/phoenix/blob/master/installer/templates/new/config/dev.exs#L25), but now it's `code_reloader`. Incorrectly naming the parameter in this example causes Phoenix to crash, since live_reload isn't available on the device.