### PR TITLE
Add option to enable shell history to template

### DIFF
--- a/bootstrap/templates/new/rel/vm.args
+++ b/bootstrap/templates/new/rel/vm.args
@@ -11,6 +11,10 @@
 ## break handler and possibly exiting the VM.
 +Bc
 
+## Save the shell history between reboots
+## See http://erlang.org/doc/man/kernel_app.html for additional options
+-kernel shell_history enabled
+
 ## Start the Elixir shell
 
 -noshell


### PR DESCRIPTION
Shell history with OTP 20 is now controlled via a commandline option.
This enables it by default in new projects.