### PR TITLE
Add python to the requirements for building custom systems

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -52,7 +52,7 @@ Because Linux can build natively rather than inside a container, you need to hav
 On Debian and Ubuntu, run the following:
 
 ```bash
-sudo apt-get install git g++ libssl-dev libncurses5-dev bc m4 make unzip cmake
+sudo apt-get install git g++ libssl-dev libncurses5-dev bc m4 make unzip cmake python
 ```
 
 > For other host Linux distributions, you will need to install equivalent packages, but we don't have the exact list documented.


### PR DESCRIPTION
I just found out that on a fresh Ubuntu 16.04 server, python is not included. This led to this error:

```
** (FunctionClauseError) no function clause matching in String.replace_suffix/3
    (nerves_bootstrap) lib/mix/tasks/nerves/loadpaths.ex:16: Mix.Tasks.Nerves.Loadpaths.run/1
    (nerves_bootstrap) lib/mix/tasks/nerves/precompile.ex:25: Mix.Tasks.Nerves.Precompile.run/1
    (mix) lib/mix/task.ex:300: Mix.Task.run_task/3
    (mix) lib/mix/task.ex:332: Mix.Task.run_alias/3
    (mix) lib/mix/task.ex:265: Mix.Task.run/2
    (mix) lib/mix/tasks/deps.compile.ex:62: Mix.Tasks.Deps.Compile.compile/2
    (mix) lib/mix/tasks/deps.loadpaths.ex:83: Mix.Tasks.Deps.Loadpaths.deps_check/2
    (mix) lib/mix/tasks/deps.loadpaths.ex:27: Mix.Tasks.Deps.Loadpaths.run/1
```

The clue was:

```
umask 0022 && make -C /home/orestis/dev/nerves-examples/hello_phoenix/deps/custom_rpi3/nerves_system_br/buildroot-2017.05 O=/home/orestis/dev/custom_rpi3/.nerves/artifacts/custom_rpi3-0.14.1-dev.arm_unknown_linux_gnueabihf/.
You must install 'python' on your build machine
support/dependencies/dependencies.mk:22: recipe for target 'core-dependencies' failed
make[1]: *** [core-dependencies] Error 1
Makefile:16: recipe for target '_all' failed
make: *** [_all] Error 2
```