### PR TITLE
Add more helpful error message to loadpaths task.

### DIFF
--- a/bootstrap/lib/mix/tasks/nerves/loadpaths.ex
+++ b/bootstrap/lib/mix/tasks/nerves/loadpaths.ex
@@ -13,7 +13,7 @@ defmodule Mix.Tasks.Nerves.Loadpaths do
             env_info()
           rescue
             e ->
-              raise e
+              reraise e, System.stacktrace()
           end
         false ->
           debug_info "Env not loaded"


### PR DESCRIPTION
My project was borken, erroring on this `raise`. it originally gave me this: 
```
** (FunctionClauseError) no function clause matching in System.put_env/2                       
    (nerves_bootstrap) lib/mix/tasks/nerves/loadpaths.ex:16: Mix.Tasks.Nerves.Loadpaths.run/1  
    (nerves_bootstrap) lib/mix/tasks/nerves/precompile.ex:25: Mix.Tasks.Nerves.Precompile.run/1
    (mix) lib/mix/task.ex:294: Mix.Task.run_task/3                                             
    (mix) lib/mix/task.ex:326: Mix.Task.run_alias/3                                            
    (mix) lib/mix/task.ex:259: Mix.Task.run/2  
    (mix) lib/mix/tasks/deps.compile.ex:62: Mix.Tasks.Deps.Compile.compile/2                   
    (mix) lib/mix/tasks/deps.loadpaths.ex:83: Mix.Tasks.Deps.Loadpaths.deps_check/2            
    (mix) lib/mix/tasks/deps.loadpaths.ex:27: Mix.Tasks.Deps.Loadpaths.run/1
  
```

which means more or less notthing. `reraise`ing with a `stacktrace` gives:
```
** (FunctionClauseError) no function clause matching in System.put_env/2                       
    (elixir) lib/system.ex:395: System.put_env("ERTS_DIR", nil)                                
    nerves/nerves_system_br/nerves_env.exs:98: (file)                                          
    (elixir) lib/code.ex:370: Code.require_file/2                                              
    (nerves_bootstrap) lib/mix/tasks/nerves/loadpaths.ex:12: Mix.Tasks.Nerves.Loadpaths.run/1  
    (nerves_bootstrap) lib/mix/tasks/nerves/precompile.ex:25: Mix.Tasks.Nerves.Precompile.run/1 
```
Which is much more helpful.