### PR TITLE
append system deps as a list

### DIFF
--- a/bootstrap/templates/new/mix.exs
+++ b/bootstrap/templates/new/mix.exs
@@ -62,14 +62,14 @@ defmodule <%= app_module %>.Mixfile do
   # Specify target specific dependencies
   def deps("host"), do: []
   def deps(target) do
-    [ system(target),
+    [
       {:bootloader, "~> <%= bootloader_vsn %>"},
       {:nerves_runtime, "~> <%= runtime_vsn %>"}
-    ]
+    ] ++ system(target)
   end
 
 <%= for target <- targets do %>
-  def system("<%= target %>"), do: {:<%= "nerves_system_#{target}" %>, ">= 0.0.0", runtime: false}
+  def system("<%= target %>"), do: [{:<%= "nerves_system_#{target}" %>, ">= 0.0.0", runtime: false}]
 <% end %>
   def system(target), do: Mix.raise "Unknown MIX_TARGET: #{target}"
 

--- a/bootstrap/test/nerves_new_test.exs
+++ b/bootstrap/test/nerves_new_test.exs
@@ -20,14 +20,14 @@ defmodule Nerves.BootstrapTest do
       assert_file "#{@app_name}/README.md"
       assert_file "#{@app_name}/mix.exs", fn file ->
         assert file =~ "app: :#{@app_name}"
-        assert file =~ "def system(\"rpi\"), do: {:nerves_system_rpi, \">= 0.0.0\""
-        assert file =~ "def system(\"rpi0\"), do: {:nerves_system_rpi0, \">= 0.0.0\""
-        assert file =~ "def system(\"rpi2\"), do: {:nerves_system_rpi2, \">= 0.0.0\""
-        assert file =~ "def system(\"rpi3\"), do: {:nerves_system_rpi3, \">= 0.0.0\""
-        assert file =~ "def system(\"bbb\"), do: {:nerves_system_bbb, \">= 0.0.0\""
-        assert file =~ "def system(\"linkit\"), do: {:nerves_system_linkit, \">= 0.0.0\""
-        assert file =~ "def system(\"ev3\"), do: {:nerves_system_ev3, \">= 0.0.0\""
-        assert file =~ "def system(\"qemu_arm\"), do: {:nerves_system_qemu_arm, \">= 0.0.0\""
+        assert file =~ "def system(\"rpi\"), do: [{:nerves_system_rpi, \">= 0.0.0\""
+        assert file =~ "def system(\"rpi0\"), do: [{:nerves_system_rpi0, \">= 0.0.0\""
+        assert file =~ "def system(\"rpi2\"), do: [{:nerves_system_rpi2, \">= 0.0.0\""
+        assert file =~ "def system(\"rpi3\"), do: [{:nerves_system_rpi3, \">= 0.0.0\""
+        assert file =~ "def system(\"bbb\"), do: [{:nerves_system_bbb, \">= 0.0.0\""
+        assert file =~ "def system(\"linkit\"), do: [{:nerves_system_linkit, \">= 0.0.0\""
+        assert file =~ "def system(\"ev3\"), do: [{:nerves_system_ev3, \">= 0.0.0\""
+        assert file =~ "def system(\"qemu_arm\"), do: [{:nerves_system_qemu_arm, \">= 0.0.0\""
       end
     end
   end
@@ -39,8 +39,8 @@ defmodule Nerves.BootstrapTest do
       assert_file "#{@app_name}/README.md"
       assert_file "#{@app_name}/mix.exs", fn file ->
         assert file =~ "app: :#{@app_name}"
-        assert file =~ "def system(\"rpi\"), do: {:nerves_system_rpi, \">= 0.0.0\""
-        refute file =~ "def system(\"rpi0\"), do: {:nerves_system_rpi0, \">= 0.0.0\""
+        assert file =~ "def system(\"rpi\"), do: [{:nerves_system_rpi, \">= 0.0.0\""
+        refute file =~ "def system(\"rpi0\"), do: [{:nerves_system_rpi0, \">= 0.0.0\""
       end
     end
   end
@@ -52,9 +52,9 @@ defmodule Nerves.BootstrapTest do
       assert_file "#{@app_name}/README.md"
       assert_file "#{@app_name}/mix.exs", fn file ->
         assert file =~ "app: :#{@app_name}"
-        assert file =~ "def system(\"rpi\"), do: {:nerves_system_rpi, \">= 0.0.0\""
-        assert file =~ "def system(\"rpi3\"), do: {:nerves_system_rpi3, \">= 0.0.0\""
-        refute file =~ "def system(\"rpi0\"), do: {:nerves_system_rpi0, \">= 0.0.0\""
+        assert file =~ "def system(\"rpi\"), do: [{:nerves_system_rpi, \">= 0.0.0\""
+        assert file =~ "def system(\"rpi3\"), do: [{:nerves_system_rpi3, \">= 0.0.0\""
+        refute file =~ "def system(\"rpi0\"), do: [{:nerves_system_rpi0, \">= 0.0.0\""
       end
     end
   end


### PR DESCRIPTION
System apps should be appended as a list so there is a clear place for putting deps that are only for a certain system. For example, I have a project with qemu and rpi0 and only rpi0 also needs nerves_init_gadget.

```elixir
# Specify target specific dependencies
  def deps("host"), do: []
  def deps(target) do
    [
      {:bootloader, "~> 0.1"},
      {:nerves_runtime, "~> 0.4"},
    ] ++ system(target)
  end

  #def system("qemu_arm"), do: {:nerves_system_qemu_arm, ">= 0.0.0", runtime: false}
  def system("qemu_arm"), do: [{:nerves_system_qemu_arm, path: "../../nerves_system_qemu_arm"}]
  def system("rpi0") do
    [
      {:nerves_system_rpi0, "~> 0.17.0"},
      {:nerves_init_gadget, github: "fhunleth/nerves_init_gadget"}
    ]
  end
  def system(target), do: Mix.raise "Unknown MIX_TARGET: #{target}"
```