### PR TITLE
Nerves release plugin

### DIFF
--- a/lib/mix/tasks/firmware.ex
+++ b/lib/mix/tasks/firmware.ex
@@ -64,7 +64,7 @@ defmodule Mix.Tasks.Firmware do
   end
 
   defp build_release do
-    Mix.Task.run "release", ["--silent"]
+    Mix.Task.run "release", ["--silent", "--no-tar"]
   end
 
   defp build_firmware(system_path) do

--- a/lib/nerves.ex
+++ b/lib/nerves.ex
@@ -1,4 +1,27 @@
 defmodule Nerves do
+  use Mix.Releases.Plugin
+
+  def before_assembly(release, _opts) do
+    if nerves_env_loaded? do
+      project_config = Mix.Project.config
+      profile =
+        release.profile
+        |> Map.put(:dev_mode, false)
+        |> Map.put(:output_dir, Path.join([project_config[:build_path], Mix.env, "rel"]))
+        |> Map.put(:include_src, false)
+        |> Map.put(:include_erts, System.get_env("ERL_LIB_DIR"))
+        |> Map.put(:include_system_libs, System.get_env("ERL_SYSTEM_LIB_DIR"))
+        |> Map.put_new(:vm_args, "rel/vm.args")
+      %{release | profile: profile}
+    else
+      release
+    end
+  end
+
   def version,        do: unquote(Mix.Project.config[:version])
   def elixir_version, do: unquote(System.version)
+
+  def nerves_env_loaded? do
+    System.get_env("NERVES_PRECOMPILE") != nil
+  end
 end

--- a/priv/templates/release.eex
+++ b/priv/templates/release.eex
@@ -33,24 +33,12 @@ release :<%= Keyword.get(release, :release_name) %> do
     "    #{app}: :#{start_type}"
     end) |> Enum.join(",\n") %>
   ]
-  plugin Bootloader.Plugin
-  if System.get_env("NERVES_SYSTEM") do
-    set dev_mode: false
-    set include_src: false
-    set include_erts: System.get_env("ERL_LIB_DIR")
-    set include_system_libs: System.get_env("ERL_SYSTEM_LIB_DIR")
-    set vm_args: "rel/vm.args"
-  end
+  plugin Bootloader
+  plugin Nerves
 end<% else %>
 release :<%= Keyword.get(release, :release_name) %> do
   set version: current_version(:<%= Keyword.get(release, :release_name)%>)
-  plugin Bootloader.Plugin
-  if System.get_env("NERVES_SYSTEM") do
-    set dev_mode: false
-    set include_src: false
-    set include_erts: System.get_env("ERL_LIB_DIR")
-    set include_system_libs: System.get_env("ERL_SYSTEM_LIB_DIR")
-    set vm_args: "rel/vm.args"
-  end
+  plugin Bootloader
+  plugin Nerves
 end<% end %>
 <% end %>


### PR DESCRIPTION
This will simplify the release config and move the settings for Nerves into a plugin.

Instead of this
```elixir
release :example_proj do
  set version: current_version(:example_proj)
  plugin Bootloader.Plugin
  if System.get_env("NERVES_SYSTEM") do
    set dev_mode: false
    set include_src: false
    set include_erts: System.get_env("ERL_LIB_DIR")
    set include_system_libs: System.get_env("ERL_SYSTEM_LIB_DIR")
    set vm_args: "rel/vm.args"
  end
end
```

we use this
```elixir
release :example_proj do
  set version: current_version(:example_proj)
  plugin Bootloader
  plugin Nerves
end
```

This PR also adds a commit to skip the archival release phase.

Depends on:
https://github.com/nerves-project/bootloader/pull/6