### PR TITLE
handle fwup dev versions as well

### DIFF
--- a/lib/mix/nerves/utils.ex
+++ b/lib/mix/nerves/utils.ex
@@ -1,5 +1,5 @@
 defmodule Mix.Nerves.Utils do
-  @fwup_semver "~> 0.8"
+  @fwup_semver "~> 0.8 or ~> 1.0.0-dev"
 
   def shell(cmd, args, opts \\ []) do
     stream = opts[:stream] || IO.binstream(:standard_io, :line)
@@ -30,10 +30,10 @@ defmodule Mix.Nerves.Utils do
       """
     end
 
-    {:ok, req} = Version.parse_requirement(@fwup_semver)
     with {_, 0} <- System.cmd(which_or_where, ["fwup"]),
          {vsn, 0} <- System.cmd("fwup", ["--version"]),
          vsn = String.trim(vsn),
+         {:ok, req} = Version.parse_requirement(@fwup_semver),
          true <- Version.match?(vsn, req) do
     else
       false ->


### PR DESCRIPTION
This patch allows for the latest version of [fwup](https://github.com/fhunleth/fwup) which is `1.0.0-dev` to work with nerves.