### PR TITLE
remove legacy compiler key from package struct

### DIFF
--- a/docs/Systems.md
+++ b/docs/Systems.md
@@ -209,7 +209,6 @@ pkg = :custom_rpi3
 config pkg, :nerves_env,
   type: :system,
   version: version,
-  compiler: :nerves_package,
 #   artifact_url: [
 #     "...",
 #   ],

--- a/lib/nerves/package.ex
+++ b/lib/nerves/package.ex
@@ -20,7 +20,6 @@ defmodule Nerves.Package do
     config pkg, :nerves_env,
       type: :system,
       version: version,
-      compiler: :nerves_package,
       artifact_url: [
         "https://github.com/nerves-project/\#{pkg}/releases/download/v\#{version}/\#{pkg}-v\#{version}.tar.gz",
       ],
@@ -52,15 +51,11 @@ defmodule Nerves.Package do
       * `:toolchain` - A Nerves toolchain
       * `:toolchain_platform` - A set of build tools for a Nerves toolchain.
     * `:version` - The package version
-
-  ** Optional **
-
-    * `:compiler` - The Mix.Project compiler for the package. Example: `:nerves_package`
     * `:platform` - The application which is the packages build platform.
     * `:checksum` - A list of files and top level folders to expand paths for use when calculating the checksum of the package source.
   """
 
-  defstruct [app: nil, path: nil, dep: nil, type: nil, version: nil, platform: nil, provider: nil, compiler: nil, config: []]
+  defstruct [app: nil, path: nil, dep: nil, type: nil, version: nil, platform: nil, provider: nil, config: []]
 
   alias __MODULE__
   alias Nerves.Package.{Artifact, Providers}
@@ -77,7 +72,6 @@ defmodule Nerves.Package do
                               :git,
                     platform: atom,
                     provider: atom,
-                    compiler: atom,
                      version: Version.t,
                       config: Keyword.t}
 
@@ -131,8 +125,7 @@ defmodule Nerves.Package do
     end
     platform = config[:nerves_package][:platform]
     provider = provider(app, type)
-    compiler = config[:nerves_package][:compiler]
-    config = Enum.reject(config[:nerves_package], fn({k, _v}) -> k in @required end)
+    config = Enum.reject(config, fn({k, _v}) -> k in @required end)
 
     %Package{
       app: app,
@@ -142,7 +135,6 @@ defmodule Nerves.Package do
       dep: dep_type(app),
       path: path,
       version: version,
-      compiler: compiler,
       config: config}
   end
 

--- a/lib/nerves/package/artifact.ex
+++ b/lib/nerves/package/artifact.ex
@@ -56,7 +56,6 @@ defmodule Nerves.Package.Artifact do
     else
       base_dir(pkg)
       |> Path.join(name(pkg, toolchain))
-      |> protocol_vsn(pkg)
     end
   end
 
@@ -102,21 +101,4 @@ defmodule Nerves.Package.Artifact do
   def ext(%{type: :toolchain}), do: "tar.xz"
   def ext(_), do: "tar.gz"
 
-  defp protocol_vsn(dir, pkg) do
-    if pkg.compiler == :nerves_package do
-      dir
-    else
-      build_path =
-        Mix.Project.build_path
-        |> Path.join("nerves")
-        |> Path.expand
-        case pkg.type do
-        :toolchain ->
-          Path.join(build_path, "toolchain")
-        :system ->
-          Path.join(build_path, "system")
-        type -> Mix.raise "Cannot determine artifact path for #{type}"
-      end
-    end
-  end
 end

--- a/test/nerves/artifact_test.exs
+++ b/test/nerves/artifact_test.exs
@@ -68,9 +68,7 @@ defmodule Nerves.ArtifactTest do
   test "tar file error detection" do
       pkg =
       %Nerves.Package{app: :nerves_system_rpi3,
-                      compiler: :nerves_package,
-                      config: [compiler: :nerves_package,
-                               artifact_url: ["https://github.com/nerves-project/nerves_system_rpi3/releases/download/v0.10.0/nerves_system_rpi3-v0.10.0.fw"],
+                      config: [artifact_url: ["https://github.com/nerves-project/nerves_system_rpi3/releases/download/v0.10.0/nerves_system_rpi3-v0.10.0.fw"],
                                platform_config: [defconfig: "nerves_defconfig"],
                                checksum: []],
                       dep: :hex,


### PR DESCRIPTION
This was only needed to support finding artifacts from the `nerves_system` and `nerves_toolchain` compilers which have long been deprecated.