### PR TITLE
Move Nerves config from nerves.exs to mix.exs

### DIFF
--- a/lib/nerves/env.ex
+++ b/lib/nerves/env.ex
@@ -293,10 +293,7 @@ defmodule Nerves.Env do
   defp load_packages do
     Mix.Project.deps_paths
     |> Map.put(Mix.Project.config[:app], File.cwd!)
-    |> Enum.filter(fn({_, path}) ->
-      Package.config_path(path)
-      |> File.exists?
-    end)
+    |> Enum.filter(&nerves_package?/1)
     |> Enum.map(&Package.load_config/1)
     |> validate_packages
   end
@@ -371,5 +368,12 @@ defmodule Nerves.Env do
   @doc false
   def deps_by_type(type), do: packages_by_type(type)
   ## End Pre 0.4.0 Legacy
-
+  defp nerves_package?({app, path}) do
+    try do
+      Package.config(app, path)[:nerves_package] != nil
+    rescue
+    _e ->
+      File.exists?(Package.config_path(path))
+    end
+  end
 end


### PR DESCRIPTION
The config can be read in form the mix file and packages can be identified with backwards compatibility (until after 1.0).

TL;DR
Turns this:
```elixir
# nerves.exs
use Mix.Config

version =
  Path.join(__DIR__, "VERSION")
  |> File.read!
  |> String.trim

pkg = :nerves_system_rpi0

config pkg, :nerves_env,
  type: :system,
  version: version,
  compiler: :nerves_package,
  artifact_url: [
    "https://github.com/nerves-project/#{pkg}/releases/download/v#{version}/#{pkg}-v#{version}.tar.gz",
  ],
  platform: Nerves.System.BR,
  platform_config: [
    defconfig: "nerves_defconfig"
  ],
  checksum: [
    "nerves_defconfig",
    "rootfs_overlay",
    "linux-4.4.defconfig",
    "fwup.conf",
    "cmdline.txt",
    "config.txt",
    "post-createfs.sh",
    "VERSION"
  ]
```
Into this:
```elixir
# mix.exs
defmodule NervesSystemRpi0.Mixfile do
  use Mix.Project
  
  @app :nerves_system_rpi0
  @version "0.17.0"

  def project do
    [app: @app,
     version: @version,
     nerves_package: nerves_package(),
     #..
     aliases: ["deps.precompile": ["nerves.env", "deps.precompile"]]]
  end

  def nerves_package do
    [type: :system,
     artifact_url: [
       "https://github.com/nerves-project/#{@app}/releases/download/v#{@version}/#{@app}-v#{@version}.tar.gz",
     ],
     platform: Nerves.System.BR,
     platform_config: [
       defconfig: "nerves_defconfig"
     ]]
  end
#..
end

```

Packages are currently identified as being a `Nerves.Package` if they declare their config in the `nerves.exs` file in source path. This PR changes the load process to first look in `Mix.Project.config[:nerves_package]` for the config. 

This also adds a deprecation warning to any packages that are loading the `nerves.exs` file.