### PR TITLE
Fix link to contributors graph in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ binary.  On Arch Linux systems, this is in `/usr/lib/ssh/ssh-askpass`
 ## Contributors
 
 This project exists thanks to all the people who contribute.
-<a href="graphs/contributors"><img src="https://opencollective.com/nerves-project/contributors.svg?width=890" /></a>
+<a href="https://github.com/nerves-project/nerves/graphs/contributors"><img src="https://opencollective.com/nerves-project/contributors.svg?width=890" /></a>
 
 
 ## Backers


### PR DESCRIPTION
The relative link doesn't seem to expand correctly.  