### PR TITLE
Bump fwup requirement to v0.15.x

### DIFF
--- a/lib/mix/nerves/utils.ex
+++ b/lib/mix/nerves/utils.ex
@@ -1,5 +1,5 @@
 defmodule Mix.Nerves.Utils do
-  @fwup_semver "~> 0.8 or ~> 1.0.0-dev"
+  @fwup_semver "~> 0.15 or ~> 1.0.0-dev"
 
   def shell(cmd, args, opts \\ []) do
     stream = opts[:stream] || IO.binstream(:standard_io, :line)


### PR DESCRIPTION
This pulls in the `meta-misc` and `meta-vcs-identifier` support that is
being used for the Nerves system regression tests. This is starting to
cause errors for people who haven't updated `fwup` in a while, so just
catch it here. Plus `fwup` is getting close to 1.0, so catching everyone
up will be useful in exposing any issues in the latest builds.