### PR TITLE
Add shortdocs and minor help text updates

### DIFF
--- a/lib/mix/tasks/firmware.burn.ex
+++ b/lib/mix/tasks/firmware.burn.ex
@@ -5,6 +5,8 @@ defmodule Mix.Tasks.Firmware.Burn do
   @switches [device: :string, task: :string]
   @aliases [d: :device, t: :task]
 
+  @shortdoc "Write a firmware image to an SDCard"
+
   @moduledoc """
   Writes the generated firmware image to an attached SDCard or file.
 

--- a/lib/mix/tasks/firmware.ex
+++ b/lib/mix/tasks/firmware.ex
@@ -2,6 +2,8 @@ defmodule Mix.Tasks.Firmware do
   use Mix.Task
   import Mix.Nerves.Utils
 
+  @shortdoc "Build a firmware bundle"
+
   @moduledoc """
   Build a firmware image for the selected target platform.
 

--- a/lib/mix/tasks/firmware.image.ex
+++ b/lib/mix/tasks/firmware.image.ex
@@ -2,6 +2,8 @@ defmodule Mix.Tasks.Firmware.Image do
   use Mix.Task
   import Mix.Nerves.Utils
 
+  @shortdoc "Create a firmware image file"
+
   @moduledoc """
   Writes the generated firmware image to an output file.
 

--- a/lib/mix/tasks/firmware.image.ex
+++ b/lib/mix/tasks/firmware.image.ex
@@ -5,13 +5,17 @@ defmodule Mix.Tasks.Firmware.Image do
   @shortdoc "Create a firmware image file"
 
   @moduledoc """
-  Writes the generated firmware image to an output file.
+  Create a firmware image file that can be copied byte-for-byte to an SDCard
+  or other memory device.
 
-  ## Examples
+  ## Example
 
   ```
-  # Create an image file from a .fw file for use with dd(1)
+  # Create the image file
   mix firmware.image my_image.img
+
+  # Write it to a MicroSD card in Linux
+  dd if=my_image.img of=/dev/sdc bs=1M
   ```
   """
   def run([file]) do

--- a/lib/mix/tasks/nerves.release.init.ex
+++ b/lib/mix/tasks/nerves.release.init.ex
@@ -1,6 +1,8 @@
 defmodule Mix.Tasks.Nerves.Release.Init do
   use Mix.Task
 
+  @shortdoc "Prepare a new project for use with releases"
+
   @moduledoc """
   Prepares a new project for use with releases.
   By default, this forwards the call to

--- a/lib/mix/tasks/nerves.release.init.ex
+++ b/lib/mix/tasks/nerves.release.init.ex
@@ -6,10 +6,10 @@ defmodule Mix.Tasks.Nerves.Release.Init do
   @moduledoc """
   Prepares a new project for use with releases.
   By default, this forwards the call to
-    mix release.init --template /path/to/nerves/release_template.eex
+      mix release.init --template /path/to/nerves/release_template.eex
 
-  For more information on additional args, reference
-    mix help release.init
+  For more information on additional args, see
+      mix help release.init
   """
 
   @spec run(OptionParser.argv) :: no_return


### PR DESCRIPTION
Most of the Nerves mix tasks didn't appear in `mix help`. This fixes that.