### PR TITLE
check the download_dir location for a tar before downloading one

### DIFF
--- a/lib/nerves/env.ex
+++ b/lib/nerves/env.ex
@@ -53,6 +53,18 @@ defmodule Nerves.Env do
   end
 
   @doc """
+  The download location for artifacts.
+
+  Placing an artifact tar in this location will bypass the need for it to
+  be downloaded.
+  """
+  @spec download_dir() :: path :: String.t
+  def download_dir do
+    (System.get_env("NERVES_DL_DIR") || "~/.nerves/dl")
+    |> Path.expand
+  end
+
+  @doc """
   Re evaluates the mix file under a different target.
 
   This allows you to start in one target, like host, but then


### PR DESCRIPTION
The cache dir is set by defining `NERVES_DL_DIR` env var or it will default to  `~/.nerves/dl` if undefined. Before the http provider attempts to fetch an artifact, it will check in the download dir for one. If it does end up downloading an artifact, it will be downloaded to the download_dir location and unpacked in the artifact_dir as to follow the current workflow. Does not break backwards compatibility. 