### PR TITLE
ensure dl dir exists before trying to write to it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## Nerves v0.7.4
+* Bug Fixes
+  * Make sure the path NERVES_DL_DIR exists before writing artifacts to it.
+
 ## Nerves v0.7.3
 * Enhancements
   * [mix firmware.image] remove the need to pass an image name. Default to the app name.

--- a/lib/nerves/package/providers/http.ex
+++ b/lib/nerves/package/providers/http.ex
@@ -63,6 +63,7 @@ defmodule Nerves.Package.Providers.HTTP do
   defp result({:ok, body}, artifact, _) do
     shell_info "Artifact #{artifact} Downloaded"
     file = cache_file(artifact)
+    File.mkdir_p(Nerves.Env.download_dir())
     File.write(file, body)
     {:ok, file}
   end
@@ -94,7 +95,7 @@ defmodule Nerves.Package.Providers.HTTP do
   end
 
   defp cache_file(artifact) do
-    Nerves.Env.download_dir
+    Nerves.Env.download_dir()
     |> Path.join(artifact)
     |> Path.expand
   end

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule Nerves.Mixfile do
      name: "Nerves",
      source_url: "https://github.com/nerves-project/nerves",
      homepage_url: "http://nerves-project.org/",
-     version: "0.7.3",
+     version: "0.7.4",
      archives: [nerves_bootstrap: "~> 0.6"],
      elixir: "~> 1.4",
      elixirc_paths: elixirc_paths(Mix.env),


### PR DESCRIPTION
Ensure that the dl dir exists before trying to write to it.
Release 0.7.4