### PR TITLE
Configure bootloader with the app name derived from Mix.Project.config

### DIFF
--- a/bootstrap/templates/new/config/config.exs
+++ b/bootstrap/templates/new/config/config.exs
@@ -18,7 +18,7 @@ use Mix.Config
 # involved with firmware updates.
 config :bootloader,
   init: [:nerves_runtime],
-  app: :<%= app_name %>
+  app: Mix.Project.config[:app]
 
 # Import target specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.


### PR DESCRIPTION
If you have two firmware projects in the same umbrella, as they share much of the same code, then by default bootloader will only work for one of them. This is due to the way umbrellas are configured to load the configs from apps in the umbrella.

It's a bit of an edge case, but I think it's a reasonable way to structure a project for co-operating but different devices.

This fix ensure that the bootloader is configured from the project in which you're running `mix firmware`.