### PR TITLE
Update docs for Phoenix UI

### DIFF
--- a/docs/User Interfaces.md
+++ b/docs/User Interfaces.md
@@ -3,7 +3,40 @@
 ## Phoenix Web Interfaces
 
 Phoenix makes an excellent companion to Nerves applications by offering an easy-to-use, powerful framework to create user interfaces in parallel with Nerves device code.
-The easiest way to handle this is to lay out your application as an Umbrella.
+
+### Set up your application
+
+Although it's possible to lay out your application as an Umbrella project, the preferred way is to use poncho projects, i.e. a side-by-side project layout. For the reasoning behind this, please read the [Poncho Projects](http://embedded-elixir.com/post/2017-05-19-poncho-projects/) blog post by Greg Mefford.
+
+We'll cover the use of both approaches here, but we encourage you to use ponchos.
+
+#### Using a poncho project layout
+
+First, generate the two new apps in a containing folder:
+
+```bash
+$ mkdir nervy && cd nervy
+$ mix nerves.new fw
+$ mix phx.new ui --no-ecto --no-brunch
+```
+
+Now, add the Phoenix `ui` app and the `nerves_network` library to the `fw` app as dependencies:
+
+```elixir
+# fw/mix.exs
+
+# ...
+def deps do
+  [{:nerves_network, "~> 0.3"},
+   {:ui, path: "../ui"}]
+end
+# ...
+```
+
+Next: [Configure Networking](#configure-networking)
+
+
+#### Using an umbrella project layout
 
 First, generate a new umbrella app, called `nervy` in this case:
 
@@ -22,42 +55,73 @@ $ mix phx.new ui --no-ecto --no-brunch
 Now, add the Phoenix `ui` app and the `nerves_network` library to the `fw` app as dependencies:
 
 ```elixir
-# nervy/apps/fw/mix.exs
+# apps/fw/mix.exs
 
-...
+# ...
 def deps do
   [{:ui, in_umbrella: true},
    {:nerves_network, "~> 0.3"}]
 end
-...
+# ...
 ```
+
+##### Specifying configuration order
+
+By default, the main config loads the application configs in an unordered way: `import_config "../apps/*/config/config.exs`. This can cause problems if the  `ui` config is applied last: we may lose overrides applied in the `fw` config. You need to force the order in which the config files get imported:
+
+```elixir
+# nervy/config/config.exs
+
+use Mix.Config
+
+import_config "../apps/ui/config/config.exs"
+import_config "../apps/fw/config/config.exs"
+```
+
+
+### Configure networking
 
 In order to start the network when `fw` boots, add `nerves_network` to the `bootloader` configuration in `config.exs`.
 
 ```elixir
+# fw/config/config.exs
+
+# ...
 config :bootloader,
   init: [:nerves_runtime, :nerves_network]
+# ...
 ```
 
 To set the default networking configuration:
 
 ```elixir
+# fw/config/config.exs
+
+# ...
+# Use your ISO 3166-1 alpha-2 country code below
+
+config :nerves_network,
+  regulatory_domain: "US"
+
 config :nerves_network, :default,
   eth0: [
     ipv4_address_method: :dhcp
   ]
+
+# ...
 ```
 
 For more network settings, see the [`nerves_network`](https://github.com/nerves-project/nerves_network) project.
 
 
-In order to build the `ui` Phoenix application into the nerves `fw` app, you need to add some configuration to your firmware config:
+### Configure Phoenix
+
+In order to build the `ui` Phoenix app into the Nerves `fw` app, you need to add some configuration to your firmware config:
 
 ```elixir
-# nervy/apps/fw/config/config.exs
+# fw/config/config.exs
 
-use Mix.Config
-
+# ...
 config :ui, UiWeb.Endpoint,
   url: [host: "localhost"],
   http: [port: 80],
@@ -69,40 +133,25 @@ config :ui, UiWeb.Endpoint,
   code_reloader: false
 
 config :logger, level: :debug
+# ...
 ```
 
-By default,
-the main config loads the application configs in an unordered way: `import_config "../apps/*/config/config.exs`.   This can cause problems if the  `ui` config is applied last: we loose the overrides we just added in the previous step.  You need to force the order in which the config files get imported:
-
-```elixir
-# nervy/config/config.exs
-
-use Mix.Config
-
-# By default, the umbrella project as well as each child
-# application will require this configuration file, ensuring
-# they all use the same configuration. While one could
-# configure all applications here, we prefer to delegate
-# back to each application for organization purposes.
-import_config "../apps/ui/config/config.exs"
-import_config "../apps/fw/config/config.exs"
-```
 
 There you have it!
 A Phoenix web application ready to run on your Nerves device.
 By separating the Phoenix application from the Nerves application, you could easily distribute the development between team members and continue to leverage the features we have all come to love from Phoenix, like live code reloading.
 
-When developing your UI, you can simply run the phoenix server from the UI application:
+When developing your UI, you can simply run the Phoenix server from the UI application:
 
 ```bash
-$ cd nervy/apps/ui
+$ cd path/to/ui
 $ mix phoenix.server
 ```
 
 When it's time to create your firmware:
 
 ```bash
-$ cd nervy/apps/fw
+$ cd path/to/fw
 $ export MIX_TARGET=rpi3
 $ mix deps.get
 $ mix firmware


### PR DESCRIPTION
Initially I was just going to update the docs for umbrella project layout w/ phoenix 1.3 and nerves_network, but then found #196 and learned of the poncho projects. So instead of wholly removing the umbrella project configuration, I've attempted to separate the project organization from the configuration of networking and phoenix. I've followed these steps in both project configurations with success.
* phoenix -> 1.3
* nerves_networking 0.6.0 -> nerves_network 0.3
* poncho projects recommendation
