### PR TITLE
Enable colors in IEx by default

### DIFF
--- a/bootstrap/templates/new/rel/vm.args
+++ b/bootstrap/templates/new/rel/vm.args
@@ -20,6 +20,9 @@
 -noshell
 -user Elixir.IEx.CLI
 
+## Enable colors in the shell
+-elixir ansi_enabled true
+
 ## Options added after -extra are interpreted as plain arguments and
 ## can be retrieved using :init.get_plain_arguments().
 -extra --no-halt


### PR DESCRIPTION
Previously, colors were disabled by default, but it seems like most
people will have terminals that support the ANSI escape sequences and
they look nicer.