### PR TITLE
raise when artifact build encounters an error

### DIFF
--- a/lib/nerves/package.ex
+++ b/lib/nerves/package.ex
@@ -107,7 +107,12 @@ defmodule Nerves.Package do
     case ret do
       :ok -> Path.join(Artifact.dir(pkg, toolchain), @checksum)
              |> File.write!(checksum(pkg))
-        _ -> :error
+      {:error, error} ->
+          Mix.raise """
+          
+          Nerves encountered an error while constructing the artifact
+          #{error}
+          """
     end
   end
 

--- a/lib/nerves/package/providers/local.ex
+++ b/lib/nerves/package/providers/local.ex
@@ -62,7 +62,7 @@ defmodule Nerves.Package.Providers.Local do
 
     case shell("make", [], [cd: dest, stream: stream]) do
       {_, 0} -> :ok
-      {error, _} -> {:error, error}
+      {error, _} -> {:error, Nerves.Utils.Stream.history(pid)}
     end
   end
 

--- a/lib/nerves/utils/stream.ex
+++ b/lib/nerves/utils/stream.ex
@@ -11,21 +11,39 @@ defmodule Nerves.Utils.Stream do
     GenServer.stop(pid)
   end
 
+  def history(pid) do
+    GenServer.call(pid, :history)
+  end
+
   def init(opts) do
     file = opts[:file]
+    history_lines = opts[:history_lines] || 100
+
     if file != nil do
       File.write(file, "", [:write])
     end
     {:ok, %{
       file: opts[:file],
-      timer: Process.send_after(self(), :keep_alive, @timer)
+      timer: Process.send_after(self(), :keep_alive, @timer),
+      history: :queue.new(),
+      history_lines: history_lines,
+      history_saved: 0
     }}
+  end
+
+  def handle_call(:history, _from, s) do
+    history = 
+      s.history
+      |> :queue.to_list()
+      |> Enum.join()
+    {:reply, history , s}
   end
 
   def handle_info({:io_request, from, reply_as, {:put_chars, _encoding, chars}} = data, s) do
     if s.file != nil do
       File.write(s.file, chars, [:append])
     end
+    s = save_history(s, chars)
     reply(from, reply_as, :ok)
     {:noreply, stdout(chars, data, s)}
   end
@@ -54,12 +72,23 @@ defmodule Nerves.Utils.Stream do
     |> List.first
     |> String.trim
     |> IO.write
+
     reset_timer(s)
   end
 
   defp reset_timer(s) do
     Process.cancel_timer(s.timer)
     %{s | timer: Process.send_after(self(), :keep_alive, @timer)}
+  end
+
+  defp save_history(%{history_saved: lines, history_lines: lines} = s, line) do
+    history = :queue.in(line, s.history)
+    {_, history} = :queue.out(history)
+    %{s | history: history}
+  end
+  defp save_history(s, line) do
+    history = :queue.in(line, s.history)
+    %{s | history: history, history_saved: s.history_saved + 1}
   end
 
   def reply(from, reply_as, reply) do


### PR DESCRIPTION
When a local build would encounter an error while trying to produce an artifact the command would return with a normal exit status and appear like nothing went wrong. This makes changes to not only raise but to show some of the tail of the build log.