### PR TITLE
Unify checks for NERVES_SYSTEM & NERVES_TOOLCHAIN

### DIFF
--- a/lib/mix/nerves/utils.ex
+++ b/lib/mix/nerves/utils.ex
@@ -72,4 +72,17 @@ defmodule Mix.Nerves.Utils do
       Mix.shell.info(msg)
     end
   end
+
+  def check_nerves_system_is_set! do
+    System.get_env("NERVES_SYSTEM") || Mix.raise """
+      Environment variable $NERVES_SYSTEM is not set
+    """
+
+  end
+
+  def check_nerves_toolchain_is_set! do
+    System.get_env("NERVES_TOOLCHAIN") || Mix.raise """
+      Environment variable $NERVES_TOOLCHAIN is not set
+    """
+  end
 end

--- a/lib/mix/tasks/firmware.burn.ex
+++ b/lib/mix/tasks/firmware.burn.ex
@@ -48,13 +48,9 @@ defmodule Mix.Tasks.Firmware.Burn do
       (config[:images_path] || Path.join([Mix.Project.build_path, "nerves", "images"]))
       |> Path.expand
 
-    System.get_env("NERVES_SYSTEM") || raise """
-      Environment variable $NERVES_SYSTEM is not set
-    """
+    check_nerves_system_is_set!()
 
-    System.get_env("NERVES_TOOLCHAIN") || raise """
-      Environment variable $NERVES_TOOLCHAIN is not set
-    """
+    check_nerves_toolchain_is_set!()
 
     fw = "#{images_path}/#{otp_app}.fw"
     unless File.exists?(fw) do

--- a/lib/mix/tasks/firmware.ex
+++ b/lib/mix/tasks/firmware.ex
@@ -23,13 +23,9 @@ defmodule Mix.Tasks.Firmware do
     preflight()
     debug_info "Nerves Firmware Assembler"
 
-    system_path = System.get_env("NERVES_SYSTEM") || Mix.raise """
-      Environment variable $NERVES_SYSTEM is not set
-    """
+    system_path = check_nerves_system_is_set!()
 
-    System.get_env("NERVES_TOOLCHAIN") || Mix.raise """
-      Environment variable $NERVES_TOOLCHAIN is not set
-    """
+    check_nerves_toolchain_is_set!()
 
     rel_config =
       File.cwd!

--- a/lib/mix/tasks/firmware.image.ex
+++ b/lib/mix/tasks/firmware.image.ex
@@ -36,13 +36,9 @@ defmodule Mix.Tasks.Firmware.Image do
       (config[:images_path] || Path.join([Mix.Project.build_path, "nerves", "images"]))
       |> Path.expand
 
-    System.get_env("NERVES_SYSTEM") || raise """
-      Environment variable $NERVES_SYSTEM is not set
-    """
+    check_nerves_system_is_set!()
 
-    System.get_env("NERVES_TOOLCHAIN") || raise """
-      Environment variable $NERVES_TOOLCHAIN is not set
-    """
+    check_nerves_toolchain_is_set!()
 
     fw = "#{images_path}/#{otp_app}.fw"
     unless File.exists?(fw) do


### PR DESCRIPTION
This is the first step in drying up this code so that we can add a more
helpful message when the user simply forgot to set the `MIX_TARGET`
before running mix.firmware and related Mix tasks.

Background:

<img width="995" alt="screenshot 2017-11-13 20 45 16" src="https://user-images.githubusercontent.com/551858/32760380-9fe97974-c8b3-11e7-9e6d-669a8f5632c8.png">

Thanks!