### PR TITLE
Better error when NERVES_SYSTEM or NERVES_TOOLCHAIN are missing

### DIFF
--- a/lib/mix/nerves/utils.ex
+++ b/lib/mix/nerves/utils.ex
@@ -74,15 +74,22 @@ defmodule Mix.Nerves.Utils do
   end
 
   def check_nerves_system_is_set! do
-    System.get_env("NERVES_SYSTEM") || Mix.raise """
-      Environment variable $NERVES_SYSTEM is not set
-    """
-
+    var_name = "NERVES_SYSTEM"
+    System.get_env(var_name) || raise_env_var_missing(var_name)
   end
 
   def check_nerves_toolchain_is_set! do
-    System.get_env("NERVES_TOOLCHAIN") || Mix.raise """
-      Environment variable $NERVES_TOOLCHAIN is not set
+    var_name = "NERVES_TOOLCHAIN"
+    System.get_env(var_name) || raise_env_var_missing(var_name)
+  end
+
+  defp raise_env_var_missing(name) do
+    Mix.raise """
+    Environment variable $#{name} is not set.
+
+    This variable is usually set for you by Nerves when you specify the
+    $MIX_TARGET. For examples please see
+    https://hexdocs.pm/nerves/getting-started.html#create-the-firmware-bundle
     """
   end
 end


### PR DESCRIPTION
This is a followup to #219. It provides a better error message when `NERVES_SYSTEM` or `NERVES_TOOLCHAIN` are missing when running `mix firmware` and related tasks. It is particularly useful if you are opening multiple terminal tabs and/or use Tmux since the environment variables are not shared between terminal sessions.

Before:
![before](https://i.imgur.com/qpnuRCr.png)

After:
![before](https://i.imgur.com/iGutP8v.png)

Any/all feedback is welcome.

Thanks!