### PR TITLE
Refer to Systems.md from Nerves.Package module docs

### DIFF
--- a/docs/Systems.md
+++ b/docs/Systems.md
@@ -114,7 +114,7 @@ Nerves systems have a few requirements in the mix file:
 2. There must be a dependency for the toolchain and the build platform.
 3. The `package` must specify all the required `files` so they are present when
    downloading from Hex.
-4. The `nerves_package` key should contain nerves package configuration metadata as 
+4. The `nerves_package` key should contain nerves package configuration metadata as
    described in the next section.
 
 ## Package Configuration
@@ -157,14 +157,14 @@ def nerves_package do
 end
 ```
 
-There are a few required keys in this file:
+The following keys are supported:
 
 1.  `type`: The type of Nerves Package.
 
     Options are: `system`, `system_compiler`, `system_platform`,
     `system_package`, `toolchain`, `toolchain_compiler`, `toolchain_platform`.
 
-2.  `artifact_url`: The URL(s) of cached assets.
+2.  `artifact_url` (optional): The URL(s) of cached assets.
 
     For official Nerves systems and toolchains, we upload the artifacts to
     GitHub Releases.
@@ -173,7 +173,7 @@ There are a few required keys in this file:
 
 4.  `platform_config`: Configuration options for the build platform.
 
-    In this example, the `defconfig` option for the `Nerves.System.Platforms.BR`
+    In this example, the `defconfig` option for the `Nerves.System.BR`
     platform points to the Buildroot defconfig fragment file used to build the
     system.
 

--- a/lib/nerves/package.ex
+++ b/lib/nerves/package.ex
@@ -2,57 +2,9 @@ defmodule Nerves.Package do
   @moduledoc """
   Defines a Nerves package struct and helper functions.
 
-  A Nerves package is an application which defines a Nerves package
-  configuration file at the root of the application path. The configuration
-  file is `nerves.exs` and uses Mix.Config to list configuration values.
-
-  ## Example Configuration
-  ```
-    use Mix.Config
-
-    version =
-      Path.join(__DIR__, "VERSION")
-      |> File.read!
-      |> String.trim
-
-    pkg =
-
-    config pkg, :nerves_env,
-      type: :system,
-      version: version,
-      artifact_url: [
-        "https://github.com/nerves-project/\#{pkg}/releases/download/v\#{version}/\#{pkg}-v\#{version}.tar.gz",
-      ],
-      platform: Nerves.System.BR,
-      platform_config: [
-        defconfig: "nerves_defconfig",
-      ],
-      checksum: [
-        "linux",
-        "rootfs_overlay",
-        "uboot",
-        "bbb-busybox.config",
-        "fwup.conf",
-        "nerves_defconfig",
-        "nerves.exs",
-        "post-createfs.sh",
-        "uboot-script.cmd",
-        "VERSION"
-      ]
-  ```
-
-  ## Keys
-
-  ** Required **
-
-    * `:type` - The Nerves package type. Can be any one of the following
-      * `:system` - A Nerves system.
-      * `:system_platform` - A set of build tools for a Nerves system.
-      * `:toolchain` - A Nerves toolchain
-      * `:toolchain_platform` - A set of build tools for a Nerves toolchain.
-    * `:version` - The package version
-    * `:platform` - The application which is the packages build platform.
-    * `:checksum` - A list of files and top level folders to expand paths for use when calculating the checksum of the package source.
+  A Nerves package is a Mix application that defines the configuration for a
+  Nerves system or Nerves toolchain. For more details, see the Nerves
+  [system documentation](https://hexdocs.pm/nerves/systems.html#package-configuration)
   """
 
   defstruct [app: nil, path: nil, dep: nil, type: nil, version: nil, platform: nil, provider: nil, config: []]
@@ -103,7 +55,7 @@ defmodule Nerves.Package do
              |> File.write!(checksum(pkg))
       {:error, error} ->
           Mix.raise """
-          
+
           Nerves encountered an error while constructing the artifact
           #{error}
           """


### PR DESCRIPTION
This was out-of-sync after removing the `nerves.exs` docs in #221. Rather than updating this file as well, I just referred to those docs so we don't have to maintain it in two places.

This should finish up #207.