### PR TITLE
Stringify the Mix.env before passing it to Path.join

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Release Notes
 
+## Nerves v0.8.1
+
+* Bug Fixes
+  * Fixed an error in the `Nerves` Distillery plugin that was causing the following error message:
+    ```
+    Plugin failed: no function clause matching in IO.chardata_to_string/1
+    ```
+
 ## Nerves v0.8.0
 
 * Enhancements

--- a/lib/nerves.ex
+++ b/lib/nerves.ex
@@ -7,7 +7,7 @@ defmodule Nerves do
       profile =
         release.profile
         |> Map.put(:dev_mode, false)
-        |> Map.put(:output_dir, Path.join([project_config[:build_path], Mix.env, "rel"]))
+        |> Map.put(:output_dir, Path.join([project_config[:build_path], to_string(Mix.env), "rel"]))
         |> Map.put(:include_src, false)
         |> Map.put(:include_erts, System.get_env("ERL_LIB_DIR"))
         |> Map.put(:include_system_libs, System.get_env("ERL_SYSTEM_LIB_DIR"))

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule Nerves.Mixfile do
      name: "Nerves",
      source_url: "https://github.com/nerves-project/nerves",
      homepage_url: "http://nerves-project.org/",
-     version: "0.8.0",
+     version: "0.8.1",
      archives: [nerves_bootstrap: "~> 0.6"],
      elixir: "~> 1.4",
      elixirc_paths: elixirc_paths(Mix.env),


### PR DESCRIPTION
`Path.join` doesn't work for atoms, and `Mix.env` is an atom, like `:dev` or `:test`.
It was causing `mix firmware` to fail with an error like:

```
Plugin failed: no function clause matching in IO.chardata_to_string/1
```

By shimming an `Exception.format_stacktrace(System.stacktrace)` into Distillery, I was able to get the following clue as to what the problem was:

```
before_assembly
    (elixir) lib/io.ex:445: IO.chardata_to_string(:dev)
    (elixir) lib/path.ex:500: Path.do_join/3
    (elixir) lib/path.ex:495: Path.join/2
    (elixir) lib/path.ex:472: Path.join/1
    lib/nerves.ex:10: Nerves.before_assembly/2
    (distillery) lib/mix/lib/releases/plugins/plugin.ex:174: Mix.Releases.Plugin.call/3
    (distillery) lib/mix/lib/releases/assembler.ex:30: Mix.Releases.Assembler.assemble/1
    (distillery) lib/distillery/tasks/release.ex:93: Mix.Tasks.Release.do_release/2
```