### PR TITLE
Don't override the output_dir in the Distillery Plugin.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release Notes
 
+## Nerves v0.8.2
+
+* Bug Fixes
+  * Don't override the output_dir in the Distillery Plugin.
+
 ## Nerves v0.8.1
 
 * Bug Fixes

--- a/lib/nerves.ex
+++ b/lib/nerves.ex
@@ -3,11 +3,9 @@ defmodule Nerves do
 
   def before_assembly(release, _opts) do
     if nerves_env_loaded?() do
-      project_config = Mix.Project.config
       profile =
         release.profile
         |> Map.put(:dev_mode, false)
-        |> Map.put(:output_dir, Path.join([project_config[:build_path], to_string(Mix.env), "rel"]))
         |> Map.put(:include_src, false)
         |> Map.put(:include_erts, System.get_env("ERL_LIB_DIR"))
         |> Map.put(:include_system_libs, System.get_env("ERL_SYSTEM_LIB_DIR"))

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule Nerves.Mixfile do
      name: "Nerves",
      source_url: "https://github.com/nerves-project/nerves",
      homepage_url: "http://nerves-project.org/",
-     version: "0.8.1",
+     version: "0.8.2",
      archives: [nerves_bootstrap: "~> 0.6"],
      elixir: "~> 1.4",
      elixirc_paths: elixirc_paths(Mix.env),


### PR DESCRIPTION
@mobileoverlord and I are still not sure why this was added originally, but it seems to not be needed and it causes problems when you run `mix firmware` without first running `mix compile`.