### PR TITLE
Set LC_ALL to C.UTF-8

### DIFF
--- a/template/Dockerfile
+++ b/template/Dockerfile
@@ -9,9 +9,7 @@ MAINTAINER Justin Schneck
 ENV -NERVES_BR_DL_DIR=/nerves/cache/buildroot
 
 # Set the locale
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
+ENV LC_ALL C.UTF-8
 
 RUN DEBIAN_FRONTEND=noninteractive \
   dpkg --add-architecture i386 && \
@@ -35,5 +33,4 @@ RUN DEBIAN_FRONTEND=noninteractive \
   libncurses5:i386 \
   libstdc++6:i386 \
   xz-utils && \
-  rm -rf /var/lib/apt/lists/* && \
-  localedef -i en_US -f UTF-8 en_US.UTF-8
+  rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
I don't think we need to set `LANG` and `LANGUAGE` in addition to `LC_ALL`, but I could be wrong: https://www.gnu.org/software/gettext/manual/html_node/Locale-Environment-Variables.html

We also don't need to define the `C.UTF-8` locale at the end because it's already there by default.

Fixes #199.