### PR TITLE
Clarify linux and busybox configuration in Nerves System Shell

### DIFF
--- a/docs/Systems.md
+++ b/docs/Systems.md
@@ -437,25 +437,50 @@ appropriate steps below:
 
 2. After `make linux-menuconfig`:
 
+    Assuming you're using the Nerves System Shell via Docker on a non-Linux host
+    and your custom system source directory is called `custom_rpi3`, you'll need
+    to do something like the following (the version identifiers might be
+    different for you).
+
     ```bash
     make linux-savedefconfig
-    cp build/linux-x.y.z/defconfig <your system>/linux-x.y_defconfig
+    cp build/linux-04c8e47067d4873c584395e5cb260b4f170a99ea/ /nerves/env/custom_rpi3/linux-4.4.defconfig
     ```
 
-    If your system doesn't contain a custom Linux configuration yet, you'll need
-    to update the Buildroot configuration (using `make menuconfig`) to point to
-    the new Linux defconfig in your system directory. The path is usually
-    something like `$(NERVES_DEFCONFIG_DIR)/linux-x.y_defconfig`.
+    If you're using Linux, the destination for the `cp` will simply be something
+    like `$(NERVES_DEFCONFIG_DIR)/linux-4.4.defconfig`.
+
+    > NOTE: If your system doesn't contain a custom Linux configuration yet,
+    you'll need to update the Buildroot configuration (using `make menuconfig`)
+    to point to the new Linux defconfig in your system directory. The path is
+    usually something like `$(NERVES_DEFCONFIG_DIR)/linux-x.y_defconfig`.
 
 3. After `make busybox-menuconfig`:
 
+    Unfortunately, there's not currently an easy way to save a busybox defconfig.
+    What you have to do instead is save the full busybox config and configure it
+    to be included in your `nerves_defconfig`.
+
+    Assuming you're using the Nerves System Shell via Docker on a non-Linux host
+    and your custom system source directory is called `custom_rpi3`, you'll need
+    to do something like the following (the version identifiers might be
+    different for you).
+
     ```bash
-    make busybox-savedefconfig
-    cp build/busybox-x.y.z/defconfig <your system>/busybox-x.y_defconfig
+    cp build/busybox-1.27.2/.config /nerves/env/custom_rpi3/busybox_defconfig
     ```
 
     Like the Linux configuration, the Buildroot configuration will need to be
-    updated to point to the custom config if it isn't already.
+    updated to point to the custom config if it isn't already. This can be done
+    via `make menuconfig` and navigating to **Target Packages** and finding the
+    **Additional BusyBox configuration fragment files** option under the
+    **BusyBox** package, which should already be enabled and already have a base
+    configuration specified. If you're following along with this example, the
+    correct configuration value should look like this:
+
+    ```bash
+    ${NERVES_DEFCONFIG_DIR}/busybox_defconfig
+    ```
 
 The [Buildroot user manual](http://nightly.buildroot.org/manual.html) can be
 very helpful, especially if you need to add a package. The various Nerves system
@@ -469,11 +494,11 @@ Nerves system and you are ready to make a release you can create an artifact.
 An artifact is a pre-compiled version of your Nerves system that can be
 retrieved when calling `mix deps.get`. Artifacts will attempt to be retrieved
 using one of the helpers specified in the `artifact_sites` list in
-the `nerves_package` config. 
+the `nerves_package` config.
 
-There are currently three different helpers, 
-`{:github_releases, "orginization/repo"}`, 
-`{:github_api, "orginization/repo", username: "", token: "", tag: ""}`, and 
+There are currently three different helpers,
+`{:github_releases, "orginization/repo"}`,
+`{:github_api, "orginization/repo", username: "", token: "", tag: ""}`, and
 `{:prefix, "url", opts \\ []}` . `artifact_sites` only declare the path of the location to
 the artifact. This is because the name of the artifact is defined by Nerves and
 used to download the correct one. The artifact name for a Nerves system follows


### PR DESCRIPTION
We've had a few people (myself included) recently confused by this documentation.
I've tried to make the documentation as good as it can be, given how the process actually works.

@fhunleth I'm not much of a Makefile wizard, but do you see an easy way to make these steps "just work" more transparently, so people don't need to manually save a defconfig and copy the result to the right place? It seems like with all of the official systems, the paths will be consistent, so it would only be "unsafe" if they're doing something unusual in a custom system. Even in that case, they'd likely have source control in place that could allow them to put the file where they actually intended and un-do the damage to any accidentally trampled files.