### PR TITLE
Remove archive installation failure instructions

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -120,15 +120,7 @@ to create new Nerves projects. To install the `nerves_bootstrap` archive:
 $ mix archive.install hex nerves_bootstrap
 ```
 
-If the archive fails to install properly using this command, or you need to
-perform an offline installation, you can download the `.ez` file and install it
-like this:
-
-```bash
-$ mix archive.install /path/to/nerves_bootstrap.ez
-```
-
-Once installed, you can later upgrade `nerves_bootstrap` by doing:
+Once installed, you can upgrade `nerves_bootstrap` by running:
 
 ```bash
 $ mix local.nerves


### PR DESCRIPTION
It's not obvious anymore where to get the .ez file. To support users
with old versions of nerves_bootstrap, we still have it posted on the
archives Github, but that will hopefully go away and we don't link to it
anyway. If users get an error from the hex install, I'd think that it
would be something that wouldn't be resolved by a manual download.