### PR TITLE
Nerves.Util.HTTPClient: Don't blow up on missing Content-Disposition.

### DIFF
--- a/lib/nerves/utils/http_client.ex
+++ b/lib/nerves/utils/http_client.ex
@@ -56,16 +56,21 @@ defmodule Nerves.Utils.HTTPClient do
       |> to_string()
       |> Integer.parse()
 
-    {_, filename} =
-      headers
-      |> Enum.find(fn({key, _}) -> key == 'content-disposition' end)
-    filename =
-      filename
-      |> to_string
-      |> String.split(";")
-      |> List.last
-      |> String.trim
-      |> String.trim("filename=")
+    cd = headers
+         |> Enum.find(fn({key, _}) -> key == 'content-disposition' end)
+
+    filename = case cd do
+      nil ->
+        Path.basename(s.url)
+      {_, filename} ->
+        filename
+        |> to_string
+        |> String.split(";")
+        |> List.last
+        |> String.trim
+        |> String.trim("filename=")
+    end
+
     {:noreply, %{s | content_length: content_length, filename: filename}}
   end
 


### PR DESCRIPTION
If the Content-Disposition header is missing when downloading an artifact, infer the filename from the URL instead of blowing up. This adresses #143.

I'm not sure if using Path.basename/1 with an URL is too neanderthal, but it works.