### PR TITLE
v0.9.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Release Notes
 
+## Nerves v0.9.4
+
+  * Bug Fixes
+    * Fix artifact archiver to use `Artifact.download_name/1` instead of 
+      `Artifact.name/1`. Fixes issues with the Docker provider and
+      `mix nerves.artifact`
+
 ## Nerves v0.9.3
 
   * Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
     * Fix artifact archiver to use `Artifact.download_name/1` instead of 
       `Artifact.name/1`. Fixes issues with the Docker provider and
       `mix nerves.artifact`
+    * Fix issue with `nerves.system.shell` not rendering properly
 
 ## Nerves v0.9.3
 

--- a/lib/mix/nerves/shell.ex
+++ b/lib/mix/nerves/shell.ex
@@ -9,8 +9,16 @@ defmodule Mix.Nerves.Shell do
     stdin_port = Port.open({:spawn, "tty_sl -c -e"}, [:binary, :eof, :stream, :in])
 
     # We run the command through the script command to emulate a pty
+    cmd = 
+      "script -q /dev/null " <>
+      case Nerves.Env.host_os() do
+        "linux" ->
+          "-c \"#{command}\""
+        _ -> "#{command}"
+      end
+    
     cmd_port =
-      Port.open({:spawn, "script -q /dev/null -c \"#{command}\" "}, [
+      Port.open({:spawn, cmd}, [
         :binary,
         :eof,
         :stream,

--- a/lib/mix/nerves/shell.ex
+++ b/lib/mix/nerves/shell.ex
@@ -10,7 +10,7 @@ defmodule Mix.Nerves.Shell do
 
     # We run the command through the script command to emulate a pty
     cmd_port =
-      Port.open({:spawn, "script -q /dev/null #{command}"}, [
+      Port.open({:spawn, "script -q /dev/null -c \"#{command}\" "}, [
         :binary,
         :eof,
         :stream,

--- a/lib/nerves/artifact/providers/docker.ex
+++ b/lib/nerves/artifact/providers/docker.ex
@@ -153,7 +153,7 @@ defmodule Nerves.Artifact.Providers.Docker do
   end
 
   defp make_artifact(pkg, stream) do
-    name = Artifact.name(pkg)
+    name = Artifact.download_name(pkg)
     shell_info "Creating artifact archive"
     cmd = [
       "make",
@@ -164,7 +164,7 @@ defmodule Nerves.Artifact.Providers.Docker do
 
   defp copy_artifact(pkg, stream) do
     shell_info "Copying artifact archive to host"
-    name = Artifact.name(pkg) <> Artifact.ext(pkg)
+    name = Artifact.download_name(pkg) <> Artifact.ext(pkg)
     cmd = [
       "cp",
       name,

--- a/lib/nerves/system/br.ex
+++ b/lib/nerves/system/br.ex
@@ -75,7 +75,7 @@ defmodule Nerves.System.BR do
   end
 
   defp make_archive(:linux, pkg, _toolchain, _opts) do
-    name = Artifact.name(pkg)
+    name = Artifact.download_name(pkg)
     dest = Artifact.build_path(pkg)
 
     {:ok, pid} = Nerves.Utils.Stream.start_link(file: "archive.log")

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule Nerves.Mixfile do
      name: "Nerves",
      source_url: "https://github.com/nerves-project/nerves",
      homepage_url: "http://nerves-project.org/",
-     version: "0.9.3",
+     version: "0.9.4",
      archives: [nerves_bootstrap: "~> 0.7"],
      elixir: "~> 1.4",
      elixirc_paths: elixirc_paths(Mix.env),


### PR DESCRIPTION
  * Bug Fixes
    * Fix artifact archiver to use `Artifact.download_name/1` instead of 
      `Artifact.name/1`. Fixes issues with the Docker provider and
      `mix nerves.artifact`
    * Fix issue with `nerves.system.shell` not rendering properly