### PR TITLE
Change shell prompt to current directory

### DIFF
--- a/lib/mix/nerves/shell.ex
+++ b/lib/mix/nerves/shell.ex
@@ -36,8 +36,8 @@ defmodule Mix.Nerves.Shell do
     start() {
     echo -e "\\e[17F\\e[0J\\e[1;7m\n  Preparing Nerves Shell  \\e[0m"
     echo -e "\\e]0;Nerves Shell\\a"
-    export PS1="\\e[1;7m Nerves \\e[0;1m \\w > \\e[0m"
-    export PS2="\\e[1;7m Nerves \\e[0;1m \\w ..\\e[0m"
+    export PS1="\\e[1;7m Nerves \\e[0;1m \\W > \\e[0m"
+    export PS2="\\e[1;7m Nerves \\e[0;1m \\W ..\\e[0m"
     #{Enum.join(initial_input, "\n")}
     stty echo
     }; start


### PR DESCRIPTION
The full path is so long that the prompt wraps around and on top of
itself on Linux. This change shortens the path to just the current
directory.