### PR TITLE
Linux installation updates; markdown warning fixes

### DIFF
--- a/docs/Advanced Configuration.md
+++ b/docs/Advanced Configuration.md
@@ -92,7 +92,7 @@ and modify the original file. A trick for doing this is to expand the
 `rootfs.squashfs`. You can do this using `unsquashfs`:
 
 ```bash
-$ unsquashfs ~/.nerves/artifacts/<cached_system_name>/images/rootfs.squashfs
+unsquashfs ~/.nerves/artifacts/<cached_system_name>/images/rootfs.squashfs
 ```
 
 It will be expanded into the current directory under `squashfs-root`
@@ -126,7 +126,6 @@ file-resource cmdline.txt {
 You can use the `NERVES_APP` environment variable to point to the root of your
 Elixir app. This variable is automatically managed for you by
 `nerves_bootstrap`.
-
 
 ### Device Tree Overlays
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -41,7 +41,7 @@ vulnerability, do not open a GitHub Issue!** Please disclose these by emailing
 [security@nerves-project.org] instead, so that we can work on releasing a fix
 before the vulnerability is disclosed publicly.
 
-1.  Pull Request on GitHub
+1. Pull Request on GitHub
 
     If you're able to send us an improvement directly to the [documentation
     source] or [website source] code, that is extremely helpful! Don't worry
@@ -51,7 +51,7 @@ before the vulnerability is disclosed publicly.
     Also, be sure to check out the guidelines below about contributing code and
     documentation changes.
 
-2.  Issues on GitHub
+2. Issues on GitHub
 
     If you think you might have found a bug or documentation problem that you're
     not sure how to solve, open an Issue on the relevant GitHub repository. The
@@ -62,20 +62,20 @@ before the vulnerability is disclosed publicly.
     [Nerves section] on [Elixir Forum] or the #nerves channel on the [Elixir
     Slack].
 
-3.  Questions on [Elixir Forum] (ideally in the [Nerves section])
+3. Questions on [Elixir Forum] (ideally in the [Nerves section])
 
     If questions and answers are captured in a forum like this, it makes them
     much easier for people to find later via search engine, as opposed to
     searching through a real-time conversation stream like Slack.
 
-4.  Blog about your project
+4. Blog about your project
 
     We love to see how people are using Nerves for fun and and for work. If you
     blog about a Nerves-based project, please consider posting a link somewhere
     that the community will notice it, like [Elixir Forum], [ElixirStatus], or
     the #nerves channel on the [Elixir Slack].
 
-5.  Chat with us on Slack
+5. Chat with us on Slack
 
     We have a #nerves channel on the [Elixir Slack]. We'd be happy to have you
     drop in and let us know if you have questions or want to talk about a
@@ -109,9 +109,9 @@ If you see a question posted in the #nerves channel on Slack, you can help by:
 
 * Asking clarifying questions to ensure that others will understand the context
 * Politely reminding the person that the answer will be more easily found later
-by others if it's posted to the [Elixir Forum] instead
+  by others if it's posted to the [Elixir Forum] instead
 * Helping to get it posted to the Forum or converted to a GitHub Issue to
-capture or summarize the discussion in Slack about it
+  capture or summarize the discussion in Slack about it
 
 ## Become a Backer or Sponsor through OpenCollective
 
@@ -184,9 +184,9 @@ reader to more easily differentiate what they need to type from what they should
 expect to see as output. For example:
 
 ```bash
-$ export MIX_TARGET=rpi3
-$ mix firmware
-$ mix firmware.burn
+export MIX_TARGET=rpi3
+mix firmware
+mix firmware.burn
 ```
 
 When showing an exact command to be run, we prefer placing the command line(s)

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -16,7 +16,7 @@ For example, for the Raspberry Pi 3 target, you can find the [hardware descripti
 
  1. Download the default `erlinit.config` file from the system repository for your target.
  2. Place it in your project folder under `rootfs_overlay/etc/erlinit.config`.
- 2. Modify the `-c` console setting to match the value shown in the `UART` row of the hardware description table (`rpi3` example shown):
+ 3. Modify the `-c` console setting to match the value shown in the `UART` row of the hardware description table (`rpi3` example shown):
 
     ```bash
     # rootfs_overlay/etc/erlinit.config
@@ -28,7 +28,7 @@ For example, for the Raspberry Pi 3 target, you can find the [hardware descripti
     -c ttyS0
     ```
 
- 3. Configure your project to replace this file in your firmware.
+ 4. Configure your project to replace this file in your firmware.
 
     ```elixir
     # config/config.exs
@@ -39,8 +39,8 @@ For example, for the Raspberry Pi 3 target, you can find the [hardware descripti
       rootfs_overlay: "rootfs_overlay"
     ```
 
- 4. Connect your USB serial cable to the desired UART pins (per the I/O pin-out for your particular hardware).
- 5. On your development host, connect to the serial console.
+ 5. Connect your USB serial cable to the desired UART pins (per the I/O pin-out for your particular hardware).
+ 6. On your development host, connect to the serial console.
 
     * On Linux and Mac OS, use `screen /dev/tty<device>`.
       You may need to specify the baud rate as well, for example: `screen /dev/tty<device> 115200`.

--- a/docs/Getting Started.md
+++ b/docs/Getting Started.md
@@ -41,7 +41,7 @@ The `nerves.new` project generator can be called from anywhere and can take eith
 > This allows for more seamless interaction with tools on your host without cross-compilers getting in the way until you're ready to build firmware for a particular target.
 
 ``` bash
-$ mix nerves.new hello_nerves
+mix nerves.new hello_nerves
 ```
 
 Nerves will generate the required files and directory structure for your application.
@@ -57,16 +57,16 @@ We find that it's easiest to have two shell windows open: one remaining defaulte
 This allows you quick access to use host-based tooling in the former and deploy updated firmware from the latter, all without having to modify the `MIX_TARGET` variable in your shell.
 
 ``` bash
-$ cd hello_nerves
-$ export MIX_TARGET=rpi3
-$ mix deps.get
+cd hello_nerves
+export MIX_TARGET=rpi3
+mix deps.get
 ```
 
 **OR**
 
 ```bash
-$ cd hello_nerves
-$ MIX_TARGET=rpi3 mix deps.get
+cd hello_nerves
+MIX_TARGET=rpi3 mix deps.get
 ```
 
 ## Building and Deploying Firmware

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -118,9 +118,3 @@ to create new Nerves projects. To install the `nerves_bootstrap` archive:
 ```bash
 mix archive.install hex nerves_bootstrap
 ```
-
-Once installed, you can upgrade `nerves_bootstrap` by running:
-
-```bash
-mix local.nerves
-```

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -24,8 +24,8 @@ The easiest installation route on MacOS is to use [Homebrew](brew.sh).
 Just run the following:
 
 ```bash
-$ brew update
-$ brew install fwup squashfs coreutils
+brew update
+brew install fwup squashfs coreutils
 ```
 
 Optionally, if you want to build custom Nerves Systems, you'll also need to
@@ -41,34 +41,27 @@ Now skip to the instructions for all platforms below.
 
 ## Linux
 
-First, install the `fwup` utility. Nerves uses `fwup` to create, distribute, and
-install firmware images of your programs. You can install `fwup` using the
-instructions found on the [Installation
-Page](https://github.com/fhunleth/fwup#installing). Installing the pre-built
-`.deb` or `.rpm` files is recommended.
-
-The `ssh-askpass` package is also required on Linux so that the `mix
-firmware.burn` step will be able to use `sudo` to gain the required permission
-to write directly to an SD card:
+First, install a few packages using your package manager:
 
 ```bash
-$ sudo apt-get install ssh-askpass
+sudo apt install build-essential automake autoconf git squashfs-tools ssh-askpass
 ```
 
-Finally, install `squashfs-tools` using your distribution's package manager.
-For example:
+If you're curious, `squashfs-tools` will be used by Nerves to create root
+filesystems and `ssh-askpass` will be used to ask for passwords when writing to
+MicroSD cards.
+
+Next, install the `fwup` utility. Nerves uses `fwup` to create, distribute, and
+install firmware images. You can install `fwup` using the instructions found at
+[Installation Page](https://github.com/fhunleth/fwup#installing). Installing the
+pre-built `.deb` or `.rpm` files is recommended.
+
+If you want to build custom Nerves Systems, you need a few more build tools. If
+you skip this step, you'll get an error message with instructions if you ever
+need to build a custom system. On Debian and Ubuntu, run the following:
 
 ```bash
-$ sudo apt-get install squashfs-tools
-```
-
-Optionally, if you want to build custom Nerves Systems, you need a few more
-build tools. Because Linux can build natively rather than inside a container,
-you need to have all of the dependencies installed on your host. On Debian and
-Ubuntu, run the following:
-
-```bash
-$ sudo apt-get install git g++ libssl-dev libncurses5-dev bc m4 make unzip cmake python
+sudo apt install libssl-dev libncurses5-dev bc m4 unzip cmake python
 ```
 
 > For other host Linux distributions, you will need to install equivalent
@@ -81,30 +74,36 @@ Now continue to the instructions for all platforms below.
 
 ## All platforms
 
-First, install the required versions of Erlang/OTP and Elixir using ADSF (more
-details at https://github.com/asdf-vm/asdf/blob/master/README.md#setup).
+First, install the required versions of Erlang/OTP and Elixir using ADSF (see
+the [ASDF docs](https://github.com/asdf-vm/asdf/blob/master/README.md#setup) for
+more.
 
 ```bash
-$ git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch v0.4.0
-# The following steps are for BASH. If you’re using something else, do the
+git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch v0.4.0
+
+# The following steps are for bash. If you’re using something else, do the
 # equivalent for your shell.
-$ echo -e '\n. $HOME/.asdf/asdf.sh' >> ~/.bash_profile
-$ echo -e '\n. $HOME/.asdf/completions/asdf.bash' >> ~/.bash_profile # optional
-$ source ~/.bash_profile
-$ asdf plugin-add erlang https://github.com/asdf-vm/asdf-erlang.git
-$ asdf plugin-add elixir https://github.com/asdf-vm/asdf-elixir.git
-$ asdf install erlang 20.2 # This takes a while
-$ asdf install elixir 1.5.2
-$ asdf global erlang 20.2
-$ asdf global elixir 1.5.2
+echo -e '\n. $HOME/.asdf/asdf.sh' >> ~/.bash_profile
+echo -e '\n. $HOME/.asdf/completions/asdf.bash' >> ~/.bash_profile # optional
+source ~/.bash_profile
+
+asdf plugin-add erlang https://github.com/asdf-vm/asdf-erlang.git
+asdf plugin-add elixir https://github.com/asdf-vm/asdf-elixir.git
+
+# If on Debian or Ubuntu, you'll want to install wx before running the next
+# line: sudo apt install libwxgtk-3.0-dev
+asdf install erlang 20.2 # This takes a while
+asdf install elixir 1.6.2 # or later version
+asdf global erlang 20.2
+asdf global elixir 1.6.2
 ```
 
 It is important to update the versions of `hex` and `rebar` used by Elixir,
 **even if you already had Elixir installed**.
 
 ```bash
-$ mix local.hex
-$ mix local.rebar
+mix local.hex
+mix local.rebar
 ```
 
 If you have your own version of `rebar` in your path, be sure that it is
@@ -117,11 +116,11 @@ is properly compiled using the right cross-compiler for the target. The
 to create new Nerves projects. To install the `nerves_bootstrap` archive:
 
 ```bash
-$ mix archive.install hex nerves_bootstrap
+mix archive.install hex nerves_bootstrap
 ```
 
 Once installed, you can upgrade `nerves_bootstrap` by running:
 
 ```bash
-$ mix local.nerves
+mix local.nerves
 ```

--- a/docs/Systems.md
+++ b/docs/Systems.md
@@ -110,6 +110,7 @@ end
 ```
 
 Nerves systems have a few requirements in the mix file:
+
 1. The `compilers` must include `:nerves_system` compiler after `Mix.compilers`.
 2. There must be a dependency for the toolchain and the build platform.
 3. The `package` must specify all the required `files` so they are present when
@@ -159,36 +160,36 @@ end
 
 The following keys are supported:
 
-1.  `type`: The type of Nerves Package.
+1. `type`: The type of Nerves Package.
 
     Options are: `system`, `system_compiler`, `system_platform`,
     `system_package`, `toolchain`, `toolchain_compiler`, `toolchain_platform`.
 
-2.  `artifact_url` (optional): The URL(s) of cached assets.
+2. `artifact_url` (optional): The URL(s) of cached assets.
 
     For official Nerves systems and toolchains, we upload the artifacts to
     GitHub Releases.
 
-3.  `platform`: The build platform to use for the system or toolchain.
+3. `platform`: The build platform to use for the system or toolchain.
 
-4.  `platform_config`: Configuration options for the build platform.
+4. `platform_config`: Configuration options for the build platform.
 
     In this example, the `defconfig` option for the `Nerves.System.BR`
     platform points to the Buildroot defconfig fragment file used to build the
     system.
 
-5.  `provider`: Optional - The provider that should be used to build the artifact.
-    
+5. `provider`: Optional - The provider that should be used to build the artifact.
+
     If this key is not defined, Nerves will choose a default provider
     that should be used to build the artifact based on information about the host
     computer that you are building on. For example, Mac OS will use
     `Nerves.Artifact.Providers.Docker` where as Linux will use
-    `Nerves.Artifact.Providers.Local`. Specifying a provider module in 
+    `Nerves.Artifact.Providers.Local`. Specifying a provider module in
     the package config could be used to force the provider.
 
-6.  `provider_opts`: Optional - A keyword list of options to pass to the provider module.
+6. `provider_opts`: Optional - A keyword list of options to pass to the provider module.
 
-6.  `checksum`: The list of files for which checksums are calculated and stored
+7. `checksum`: The list of files for which checksums are calculated and stored
     in the artifact cache.
 
     This checksum is used to match the cached Nerves artifact on disk with its
@@ -212,7 +213,7 @@ an existing one, renaming it to distinguish it from the official release. For
 example, if you're targeting a Raspberry Pi 3 board, do the following:
 
 ```bash
-$ git clone https://github.com/nerves-project/nerves_system_rpi3.git custom_rpi3
+git clone https://github.com/nerves-project/nerves_system_rpi3.git custom_rpi3
 ```
 
 The name of the system directory is up to you, but we will call it `custom_rpi3`
@@ -224,10 +225,10 @@ using GitHub:
 ```bash
 # After creating an empty custom_rpi3 repository in your GitHub account
 
-$ cd custom_rpi3
-$ git remote rename origin upstream
-$ git remote add origin git@github.com:YourGitHubUserName/custom_rpi3.git
-$ git push origin master
+cd custom_rpi3
+git remote rename origin upstream
+git remote add origin git@github.com:YourGitHubUserName/custom_rpi3.git
+git push origin master
 ```
 
 Next, tweak the metadata for your system so it won't conflict with the official
@@ -311,10 +312,10 @@ project directory, like so:
 Set your `MIX_TARGET` to refer to your custom system and build your firmware.
 
 ```bash
-$ cd ~/projects/your_project
-$ export MIX_TARGET=custom_rpi3
-$ mix deps.get
-$ mix firmware
+cd ~/projects/your_project
+export MIX_TARGET=custom_rpi3
+mix deps.get
+mix firmware
 ```
 
 This process will take quite a bit longer than a normal firmware build (15 to 30
@@ -393,15 +394,15 @@ When you quit from the `menuconfig` interface, the changes are stored
 temporarily. To save them back to your system source directory, follow the
 appropriate steps below:
 
-1.  After `make menuconfig`:
+1. After `make menuconfig`:
 
     Run `make savedefconfig` to update the `nerves_defconfig` in your System.
 
-2.  After `make linux-menuconfig`:
+2. After `make linux-menuconfig`:
 
     ```bash
-    $ make linux-savedefconfig
-    $ cp build/linux-x.y.z/defconfig <your system>/linux-x.y_defconfig
+    make linux-savedefconfig
+    cp build/linux-x.y.z/defconfig <your system>/linux-x.y_defconfig
     ```
 
     If your system doesn't contain a custom Linux configuration yet, you'll need
@@ -409,11 +410,11 @@ appropriate steps below:
     the new Linux defconfig in your system directory. The path is usually
     something like `$(NERVES_DEFCONFIG_DIR)/linux-x.y_defconfig`.
 
-3.  After `make busybox-menuconfig`:
+3. After `make busybox-menuconfig`:
 
     ```bash
-    $ make busybox-savedefconfig
-    $ cp build/busybox-x.y.z/defconfig <your system>/busybox-x.y_defconfig
+    make busybox-savedefconfig
+    cp build/busybox-x.y.z/defconfig <your system>/busybox-x.y_defconfig
     ```
 
     Like the Linux configuration, the Buildroot configuration will need to be

--- a/docs/Targets.md
+++ b/docs/Targets.md
@@ -25,9 +25,9 @@ If you're not familiar with [Buildroot](https://buildroot.org/), you should lear
 
 If you can find an existing Buildroot configuration for your intended hardware and you want to get it working with Nerves, you will need to make a custom System as follows:
 
-1.  Follow their procedure and confirm your target boots (independent of Nerves).
+1. Follow their procedure and confirm your target boots (independent of Nerves).
 
-2.  Figure out how to get everything working with the version of Buildroot Nerves uses.
+2. Figure out how to get everything working with the version of Buildroot Nerves uses.
     See [the `NERVES_BR_VERSION` variable in `create-build.sh`](https://github.com/nerves-project/nerves_system_br/blob/master/create-build.sh).
 
   * Look for packages and board configs can need to be copied into your System.
@@ -37,4 +37,3 @@ If you can find an existing Buildroot configuration for your intended hardware a
    See the section in the [System](systems.html) documentation about customizing Nerves Systems.
 
 > NOTE: You probably want to disable any userland packages that may be included by default to avoid distraction.
-

--- a/docs/User Interfaces.md
+++ b/docs/User Interfaces.md
@@ -13,9 +13,9 @@ Although Nerves supports umbrella projects, the preferred project structure is t
 First, generate the two new apps in a containing folder:
 
 ```bash
-$ mkdir nervy && cd nervy
-$ mix nerves.new fw
-$ mix phx.new ui --no-ecto --no-brunch
+mkdir nervy && cd nervy
+mix nerves.new fw
+mix phx.new ui --no-ecto --no-brunch
 ```
 
 Now, add the Phoenix `ui` app and the `nerves_network` library to the `fw` app as dependencies:
@@ -33,21 +33,20 @@ end
 
 Next: [Configure Networking](#configure-networking)
 
-
 #### Using an umbrella project structure
 
 First, generate a new umbrella app, called `nervy` in this case:
 
 ```bash
-$ mix new nervy --umbrella
+mix new nervy --umbrella
 ```
 
 Next, create your sub-applications for Nerves and for Phoenix:
 
 ```bash
-$ cd nervy/apps
-$ mix nerves.new fw
-$ mix phx.new ui --no-ecto --no-brunch
+cd nervy/apps
+mix nerves.new fw
+mix phx.new ui --no-ecto --no-brunch
 ```
 
 Now, add the Phoenix `ui` app and the `nerves_network` library to the `fw` app as dependencies:
@@ -81,7 +80,6 @@ use Mix.Config
 import_config "../apps/ui/config/config.exs"
 import_config "../apps/fw/config/config.exs"
 ```
-
 
 ### Configure networking
 
@@ -122,7 +120,6 @@ config :nerves_network, :default,
 
 For more network settings, see the [`nerves_network`](https://github.com/nerves-project/nerves_network) project.
 
-
 ### Configure Phoenix
 
 In order to build the `ui` Phoenix app into the Nerves `fw` app, you will need to make some changes to your `fw` application configuration:
@@ -145,7 +142,6 @@ config :logger, level: :debug
 # ...
 ```
 
-
 There you have it!
 A Phoenix web application ready to run on your Nerves device.
 By separating the Phoenix application from the Nerves application, you could easily distribute the development between team members and continue to leverage the features we have all come to love from Phoenix, like live code reloading.
@@ -153,16 +149,16 @@ By separating the Phoenix application from the Nerves application, you could eas
 When developing your UI, you can simply run the Phoenix server from the UI application:
 
 ```bash
-$ cd path/to/ui
-$ mix phoenix.server
+cd path/to/ui
+mix phoenix.server
 ```
 
 When it's time to create your firmware:
 
 ```bash
-$ cd path/to/fw
-$ export MIX_TARGET=rpi3
-$ mix deps.get
-$ mix firmware
-$ mix firmware.burn
+cd path/to/fw
+export MIX_TARGET=rpi3
+mix deps.get
+mix firmware
+mix firmware.burn
 ```


### PR DESCRIPTION
This contains a few Linux installation fixes based on findings from a
new Ubuntu install. It also adds some packages to make the asdf
installation of Erlang go more smoothly since we push asdf so
frequently.

Not all Markdown warnings were fixed, but a lot. The big change was the
removal of bash prompts which we had decided to do a long time ago, but
never got around to doing.