### PR TITLE
Allow for future docker versions to work with mix firmware

### DIFF
--- a/lib/nerves/artifact/providers/docker.ex
+++ b/lib/nerves/artifact/providers/docker.ex
@@ -62,7 +62,7 @@ defmodule Nerves.Artifact.Providers.Docker do
   alias Nerves.Artifact.Providers.Docker
   import Docker.Utils
 
-  @version "~> 1.12 or ~> 1.12.0-rc2 or ~> 17.0"
+  @version "~> 1.12 or ~> 1.12.0-rc2 or >= 17.0.0"
   @tag "nervesproject/nerves_system_br:latest"
 
   @dockerfile File.cwd!()


### PR DESCRIPTION
Currently, docker's edge channel is running version `18.03.00`, which I have installed locally. I was trying to be run `mix firmware` to build my company's firmware and was not able to. I was getting an error message telling me that I did not have docker installed locally, but I knew that was false and verified. After searching the repo I found: https://github.com/nerves-project/nerves/pull/85. Which suggests the possibility of just setting the version to `>= 0.0.0` or `>= 17.0.0`. So I updated the version to string to include `>= 17.0.0`. I am sure if we want more constraints on the versions that are allowed for docker or not, but I wanted to get the conversation started.

While most people are not on the edge channel, I would suspect that a version 18 release will happen at some point and this code will need to change anyway. Further, others who are on the edge channel (some co-workers of mine) will probably run into this error as well. After making this update the docker version error went away and I am able to run `mix firmware` successfully.