### PR TITLE
fix broken contribute guide link

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ binary.  On Arch Linux systems, this is in `/usr/lib/ssh/ssh-askpass`
 This project exists thanks to all the people who contribute.
 <a href="https://github.com/nerves-project/nerves/graphs/contributors"><img src="https://opencollective.com/nerves-project/contributors.svg?width=890" /></a>
 
-Please see our [Contributing Guide](CONTRIBUTING.md) for details on how you can
+Please see our [Contributing Guide](/docs/CONTRIBUTING.md) for details on how you can
 contribute in various ways.
 
 ## Platinum Sponsors


### PR DESCRIPTION
When I clicked on the link for the contributing guide in the readme I was taken to a 404 GitHub page. This fix should navigate people to the contributing guide correctly from the readme.