### PR TITLE
enable ssh-agent forwarding for docker containers

### DIFF
--- a/mix.lock
+++ b/mix.lock
@@ -2,5 +2,5 @@
   "distillery": {:hex, :distillery, "1.5.2", "eec18b2d37b55b0bcb670cf2bcf64228ed38ce8b046bb30a9b636a6f5a4c0080", [:mix], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.2.4", "99b637c62a4d65a20a9fb674b8cffb8baa771c04605a80c911c4418c69b75439", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.18.3", "f4b0e4a2ec6f333dccf761838a4b253d75e11f714b85ae271c9ae361367897b7", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
-  "nerves_bootstrap": {:hex, :nerves_bootstrap, "1.0.0-rc.0", "38fc74d585fea1973dcca1235ddeecf3a94696bfb84974134adf6fcc13312057", [:mix], [], "hexpm"},
+  "nerves_bootstrap": {:hex, :nerves_bootstrap, "1.0.0-rc.0", "b279c74035a612c40ee4acb34c21e5082bd604410e30ea9d030fec8cede4a027", [:mix], [], "hexpm"},
 }


### PR DESCRIPTION
This will configure `ssh-agent` forwarding for docker containers to allow assets to be downloaded from ssh connections.

Note: `openssh-client` was not included in the `nerves-project/nerves_system_br` docker image but has recently been added. You will need to update the image before running any new containers.

```
docker pull nervesproject/nerves_system_br
```

Fixes: https://github.com/nerves-project/nerves/issues/260