### PR TITLE
Fix style guide inconsistency

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,10 +1,10 @@
 ### Environment
 
-* Erlang version (erl -eval 'erlang:display(erlang:system_info(otp_release)), halt().'  -noshell):
-* Elixir version (elixir -v):
+* Erlang version (`erl -eval 'erlang:display(erlang:system_info(otp_release)), halt().'  -noshell`):
+* Elixir version (`elixir -v`):
 * Operating system:
 * Nerves Environment Info:
-  (mix nerves.env --info) or
+  (`mix nerves.env --info`) or
   General info about target / system / toolchain
 
 ### Current behavior

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -176,12 +176,11 @@ details!
 
 We want our instructions to be clear and user-friendly, even for people who are
 not familiar with using a command-line interface. We also want to be consistent
-within the Nerves documentation and with documentation in the broader community.
-Therefore, we will show an appropriate prompt (e.g. `$`, `#`, or `iex(1)>`)
-before the commands to be entered. This makes it slightly harder to
-copy-and-paste several commands from the browser to the terminal, but allows the
-reader to more easily differentiate what they need to type from what they should
-expect to see as output. For example:
+within the Nerves documentation and with documentation in the broader
+community.  Therefore, we will not show a prompt (e.g. `$`, `#`, or `iex(1)>`)
+before the commands to be entered. This makes it easier to copy-and-paste
+several commands from the browser to the terminal without the reader having to
+understand that they should not type the prompt itself.
 
 ```bash
 export MIX_TARGET=rpi3


### PR DESCRIPTION
I noticed while reviewing #280 that the paragraph says that we _will_ use prompts and the examples and actual documentation _don't_ use prompts. I hope this is the last time we switch back and forth. 😿 