### PR TITLE
Do not fetch artifacts on deps.get that are set in the env

### DIFF
--- a/lib/mix/tasks/nerves.artifact.get.ex
+++ b/lib/mix/tasks/nerves.artifact.get.ex
@@ -32,12 +32,20 @@ defmodule Mix.Tasks.Nerves.Artifact.Get do
         :noop
 
       %Nerves.Package{} = pkg ->
-        case Artifact.Cache.get(pkg) do
-          nil ->
-            get_artifact(pkg)
+        # Check to see if the package path is set in the environment
+        if Nerves.Artifact.env_var?(pkg) do
+          path = System.get_env(Nerves.Artifact.env_var(pkg))
+          Nerves.Utils.Shell.success("  Env #{app}")
+          Nerves.Utils.Shell.success("      #{path}")
+        else
+          # Check the cache
+          case Artifact.Cache.get(pkg) do
+            nil ->
+              get_artifact(pkg)
 
-          _cache_path ->
-            Nerves.Utils.Shell.success("  Cached #{app}")
+            _cache_path ->
+              Nerves.Utils.Shell.success("  Cached #{app}")
+          end
         end
 
       _ ->

--- a/test/nerves/cache_test.exs
+++ b/test/nerves/cache_test.exs
@@ -80,4 +80,22 @@ defmodule Nerves.CacheTest do
       refute File.exists?(dl_path)
     end)
   end
+
+  test "skip fetching packages that have paths set in the env" do
+    in_fixture("system", fn ->
+      File.cwd!()
+      |> Path.join("mix.exs")
+      |> Code.require_file()
+
+      Nerves.Env.start()
+
+      File.mkdir_p(Nerves.Env.download_dir())
+
+      System.put_env("NERVES_SYSTEM", Nerves.Env.download_dir())
+      Mix.Tasks.Nerves.Artifact.Get.get(:system, [])
+      message = "\e[32m      " <> Nerves.Env.download_dir() <> "\e[0m"
+      assert_receive({:mix_shell, :info, [^message]}, 100)
+      System.delete_env("NERVES_SYSTEM")
+    end)
+  end
 end


### PR DESCRIPTION
When calling `mix deps.get` do not attempt to fetch the artifacts if the artifact path is being overridden by setting its env variable such as `NERVES_SYSTEM`