### PR TITLE
Add build runner option for passing args to make

### DIFF
--- a/docs/Systems.md
+++ b/docs/Systems.md
@@ -221,6 +221,22 @@ The following keys are supported:
 
 6. `build_runner_opts`: Optional - A keyword list of options to pass to the build_runner module.
 
+    `make_args:` - Extra arguments to be passed to make. 
+    
+    For example:
+    
+    You can configure the number of parallel jobs that buildroot
+    can use for execution. This is useful for situations where you may
+    have a machine with a lot of CPUs but not enough ram.
+
+      # mix.exs
+      defp nerves_package do
+        [
+          # ...
+          build_runner_opts: [make_args: ["PARALLEL_JOBS=8"]],
+        ]
+      end
+
 7. `checksum`: The list of files for which checksums are calculated and stored
     in the artifact cache.
 

--- a/lib/nerves/artifact/build_runners/local.ex
+++ b/lib/nerves/artifact/build_runners/local.ex
@@ -12,6 +12,23 @@ defmodule Nerves.Artifact.BuildRunners.Local do
 
   @doc """
   Builds an artifact locally.
+
+  Opts:
+    `make_args:` - Extra arguments to be passed to make. 
+    
+    For example:
+    
+    You can configure the number of parallel jobs that buildroot
+    can use for execution. This is useful for situations where you may
+    have a machine with a lot of CPUs but not enough ram.
+
+      # mix.exs
+      defp nerves_package do
+        [
+          # ...
+          build_runner_opts: [make_args: ["PARALLEL_JOBS=8"]],
+        ]
+      end
   """
   @spec build(Nerves.Package.t(), Nerves.Package.t(), term) :: BuildRunner.build_result()
   def build(pkg, toolchain, opts) do

--- a/lib/nerves/system/br.ex
+++ b/lib/nerves/system/br.ex
@@ -53,7 +53,7 @@ defmodule Nerves.System.BR do
     make_archive(type, pkg, toolchain, opts)
   end
 
-  defp make(:linux, pkg, _toolchain, _opts) do
+  defp make(:linux, pkg, _toolchain, opts) do
     System.delete_env("BINDIR")
     dest = Artifact.build_path(pkg)
 
@@ -65,7 +65,9 @@ defmodule Nerves.System.BR do
     {:ok, pid} = Nerves.Utils.Stream.start_link(file: "build.log")
     stream = IO.stream(pid, :line)
 
-    case shell("make", [], cd: dest, stream: stream) do
+    make_args = Keyword.get(opts, :make_args, [])
+
+    case shell("make", make_args, cd: dest, stream: stream) do
       {_, 0} -> {:ok, dest}
       {_error, _} -> {:error, Nerves.Utils.Stream.history(pid)}
     end


### PR DESCRIPTION
This PR allows `build_runner_opts` to be used to pass additional arguments to the call to make.

For example:

The `kiosk_system_*`  Nerves packages build QtWebEngine which consume a lot of memory and cause the build to fail in an obscure way. To address the problem we need to reduce the number of `PARALLEL_JOBS` to 8.

Here is how we would pass the args through the mix.exs file
```
# mix.exs
defp nerves_package do
  [
    # ...
    build_runner_opts: [make_args: ["PARALLEL_JOBS=8"]],
  ]
end
```