### PR TITLE
Add xz as a host package requirement in OSX

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -25,7 +25,7 @@ Just run the following:
 
 ```bash
 brew update
-brew install fwup squashfs coreutils
+brew install fwup squashfs coreutils xz
 ```
 
 Optionally, if you want to build custom Nerves Systems, you'll also need to


### PR DESCRIPTION
I noticed while getting my new OSX machine set up that `mix deps.get` was failing to download toolchains until I had `xz` installed.

```
Resolving Nerves artifacts...
  Resolving nerves_system_rpi0
  => Trying https://github.com/nerves-project/nerves_system_rpi0/releases/download/v1.2.2-dev/nerves_system_rpi0-portable-1.2.2-dev-DCDDC11.tar.gz
  => Trying https://github.com/nerves-project/nerves_system_rpi0/releases/download/v1.2.2-dev/nerves_system_rpi0-portable-1.2.2-dev-DCDDC11D4EB73C5545F16E6B56B23835950B8F66E6A044B77B0231318E2C365B.tar.gz
  => no_result
  Resolving nerves_toolchain_armv6_rpi_linux_gnueabi
** (ErlangError) Erlang error: :enoent
    (elixir) lib/system.ex:622: System.cmd("xz", ["-t", "/Users/gmefford/.nerves/dl/nerves_toolchain_armv6_rpi_linux_gnueabi-darwin_x86_64-1.0.0-D5EC22E.tar.xz"], [stderr_to_stdout: true])
    (nerves) lib/nerves/utils/file.ex:23: Nerves.Utils.File.validate/1
    (nerves) lib/mix/tasks/nerves.artifact.get.ex:61: Mix.Tasks.Nerves.Artifact.Get.get_artifact/1
    (elixir) lib/enum.ex:737: Enum."-each/2-lists^foreach/1-0-"/2
    (elixir) lib/enum.ex:737: Enum.each/2
    (mix) lib/mix/task.ex:314: Mix.Task.run_task/3
    (nerves_bootstrap) lib/mix/tasks/nerves/deps.get.ex:15: Mix.Tasks.Nerves.Deps.Get.run/1
    (mix) lib/mix/task.ex:314: Mix.Task.run_task/3
```