### PR TITLE
Set provisioning information during mix firmware and firmware burn

### DIFF
--- a/lib/mix/nerves/utils.ex
+++ b/lib/mix/nerves/utils.ex
@@ -208,6 +208,40 @@ defmodule Mix.Nerves.Utils do
     {win_path, wsl_path}
   end
 
+  def set_provisioning(nil), do: :ok
+
+  def set_provisioning(app) when is_atom(app) do
+    Application.load(app)
+
+    Application.get_env(app, :nerves_provisioning)
+    |> set_provisioning()
+  end
+
+  def set_provisioning(provisioning) when is_binary(provisioning) do
+    path = Path.expand(provisioning)
+    System.put_env("NERVES_PROVISIONING", path)
+  end
+
+  def set_provisioning(_) do
+    Mix.raise("""
+      Unexpected Mix config for :nerves, :firmware, :provisioning.
+      Provisioning should be a relative string path to a provisioning.conf
+      based off the root of the project or an atom of an application that 
+      provides a provisioning.conf.
+
+      For example:
+
+        config :nerves, :firmware,
+          provisioning: "config/provisioning.conf"
+
+      or
+
+        config :nerves, :firmware,
+          provisioning: :nerves_hub
+
+    """)
+  end
+
   defp raise_env_var_missing(name) do
     Mix.raise("""
     Environment variable $#{name} is not set.

--- a/lib/mix/tasks/firmware.burn.ex
+++ b/lib/mix/tasks/firmware.burn.ex
@@ -42,6 +42,7 @@ defmodule Mix.Tasks.Firmware.Burn do
     {opts, argv, _} = OptionParser.parse(argv, switches: @switches, aliases: @aliases)
 
     config = Mix.Project.config()
+    firmware_config = Application.get_env(:nerves, :firmware)
     otp_app = config[:app]
     target = config[:target]
 
@@ -75,6 +76,7 @@ defmodule Mix.Tasks.Firmware.Burn do
         dev -> dev
       end
 
+    set_provisioning(firmware_config[:provisioning])
     burn(fw, dev, opts, argv)
 
     # Remove the temporary .fw file
@@ -132,9 +134,8 @@ defmodule Mix.Tasks.Firmware.Burn do
   def provision_env() do
     System.get_env()
     |> Enum.filter(fn {k, _} ->
-      String.starts_with?(k, "NERVES_") or String.equivalent?("SERIAL_NUMBER")
+      String.starts_with?(k, "NERVES_") or String.equivalent?(k, "SERIAL_NUMBER")
     end)
     |> Enum.map(fn {k, v} -> k <> "=" <> v end)
-    |> IO.inspect()
   end
 end

--- a/lib/mix/tasks/firmware.ex
+++ b/lib/mix/tasks/firmware.ex
@@ -114,6 +114,8 @@ defmodule Mix.Tasks.Firmware do
     args = args ++ fwup_conf ++ rootfs_overlay ++ fw ++ output
     env = standard_fwup_variables(config)
 
+    set_provisioning(firmware_config[:provisioning])
+
     shell(cmd, args, env: env)
     |> result
   end


### PR DESCRIPTION
This makes it possible to have projects or dependencies of projects support configuring the provisioning.conf location. This can be set using the firmware config settings in mix config

```
config :nerves, :firmware,
  provisioning: "config/provisioning.conf"

# or delgate it to an app that sets nerves_provisioning: "path/to/file"
config :nerves, :firmware,
  provisioning: :nerves_hub
```