### PR TITLE
Make firmware.burn work with fwup from a Nix shell

### DIFF
--- a/lib/mix/tasks/firmware.burn.ex
+++ b/lib/mix/tasks/firmware.burn.ex
@@ -112,7 +112,7 @@ defmodule Mix.Tasks.Firmware.Burn do
                 {"fwup", args}
 
               _ ->
-                fwup = "which" |> System.cmd(["fwup"]) |> elem(0) |> String.trim()
+                fwup = System.find_executable("fwup")
                 ask_pass = System.get_env("SUDO_ASKPASS") || "/usr/bin/ssh-askpass"
                 System.put_env("SUDO_ASKPASS", ask_pass)
                 {"sudo", provision_env() ++ [fwup] ++ args}

--- a/lib/mix/tasks/firmware.burn.ex
+++ b/lib/mix/tasks/firmware.burn.ex
@@ -112,9 +112,10 @@ defmodule Mix.Tasks.Firmware.Burn do
                 {"fwup", args}
 
               _ ->
+                fwup = "which" |> System.cmd(["fwup"]) |> elem(0) |> String.trim()
                 ask_pass = System.get_env("SUDO_ASKPASS") || "/usr/bin/ssh-askpass"
                 System.put_env("SUDO_ASKPASS", ask_pass)
-                {"sudo", provision_env() ++ ["fwup"] ++ args}
+                {"sudo", provision_env() ++ [fwup] ++ args}
             end
           end
 


### PR DESCRIPTION
Following #324, I’ve made a tiny patch that enables to use `mix firmware.burn` in a Nix shell where `fwup` is available while not installed system-wide. It uses `which` to find its path before calling `sudo`.