### PR TITLE
inconsistent use of MIX_TARGET=rpi3 in docs

### DIFF
--- a/docs/Systems.md
+++ b/docs/Systems.md
@@ -391,8 +391,7 @@ run the `mix nerves.system.shell` task, either from your project directory or
 from the custom system source directory.
 
 ```bash
-$ export MIX_TARGET=rpi3
-$ mix deps.get
+$ MIX_TARGET=rpi3 mix deps.get
 Mix environment
  MIX_TARGET:   rpi3
  MIX_ENV:      dev

--- a/docs/Systems.md
+++ b/docs/Systems.md
@@ -387,8 +387,7 @@ Because Buildroot can only be used from Linux, Nerves provides an abstraction
 layer called the Nerves system configuration shell that allows the same
 procedure to be used on Linux and non-Linux development hosts by using a
 Linux-based Docker container on non-Linux platforms. To access this environment,
-run the `mix nerves.system.shell` task, either from your project directory or
-from the custom system source directory.
+run the `mix nerves.system.shell` task from the custom system source directory.
 
 ```bash
 $ MIX_TARGET=rpi3 mix deps.get


### PR DESCRIPTION
I noticed this while following this tutorial (which is great btw). But the env does not change to the next command but that runs again in `custom_rpi3` so I thought that not exporting it maybe is the right thing?

I was wondering why doing a `mix deps.get` at this point anyways. Maybe expanding the docs about that would help too.