### PR TITLE
Simplify template

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,14 +1,13 @@
 ### Environment
 
-* Erlang version (`erl -eval 'erlang:display(erlang:system_info(otp_release)), halt().'  -noshell`):
 * Elixir version (`elixir -v`):
-* Operating system:
-* Nerves Environment Info:
-  (`mix nerves.env --info`) or
-  General info about target / system / toolchain
+* Nerves environment: (`mix nerves.env --info`)
+* Additional information about your host, target hardware or environment that
+  may help
 
 ### Current behavior
 
-Include code samples, errors and stacktraces if appropriate.
+Include errors, stacktraces, screenshots or code that may help us reproduce the
+issue.
 
 ### Expected behavior


### PR DESCRIPTION
I simplified the template some since `elixir -v` prints out the Erlang version and the host OS can be derived from `mix nerves.env --info`.