### PR TITLE
If using Elixir 1.7 then require 1.7.3

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule Nerves.Mixfile do
       source_url: "https://github.com/nerves-project/nerves",
       homepage_url: "http://nerves-project.org/",
       version: "1.3.0",
-      elixir: "~> 1.4",
+      elixir: "~> 1.6.0 or ~> 1.7.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       deps: deps(),
       description: description(),


### PR DESCRIPTION
This will hopefully catch people who still have 1.7.2 installed and
prevent them from hitting the runtime: false issue. Elixir 1.6 is still
supported.