### PR TITLE
Improve error message reporting when missing tar

### DIFF
--- a/lib/nerves/utils/file.ex
+++ b/lib/nerves/utils/file.ex
@@ -32,6 +32,10 @@ defmodule Nerves.Utils.File do
   defp result({reason, _}), do: {:error, reason}
 
   defp cmd(cmd, args) do
-    System.cmd(cmd, args, stderr_to_stdout: true)
+    if System.find_executable(cmd) do
+      System.cmd(cmd, args, stderr_to_stdout: true)
+    else
+      raise "Could not find '#{cmd}'. See https://hexdocs.pm/nerves/installation.html for required packages."
+    end
   end
 end


### PR DESCRIPTION
@michaelkschmidt - I amended your PR (#332). Does this look ok?

Here's the error message now:

```
Resolving Nerves artifacts...
  Resolving nerves_system_rpi0
  => Trying /Users/fhunleth/.nerves/dl/nerves_system_rpi0-portable-1.4.0-5F0786C.tar.gz
** (RuntimeError) Could not find 'tar'. See https://hexdocs.pm/nerves/installation.html for required packages.
    lib/nerves/utils/file.ex:38: Nerves.Utils.File.cmd/2
    lib/nerves/utils/file.ex:5: Nerves.Utils.File.untar/2
    lib/nerves/artifact/cache.ex:24: Nerves.Artifact.Cache.put/2
    lib/mix/tasks/nerves.artifact.get.ex:88: Mix.Tasks.Nerves.Artifact.Get.put_cache/2
    (elixir) lib/enum.ex:765: Enum."-each/2-lists^foreach/1-0-"/2
    (elixir) lib/enum.ex:765: Enum.each/2
    (mix) lib/mix/task.ex:316: Mix.Task.run_task/3
    (nerves_bootstrap) lib/mix/tasks/nerves/deps.get.ex:15: Mix.Tasks.Nerves.Deps.Get.run/1
```