### PR TITLE
Make the caller responsible for tracking MIX_TARGET changes

### DIFF
--- a/lib/nerves/env.ex
+++ b/lib/nerves/env.ex
@@ -72,12 +72,9 @@ defmodule Nerves.Env do
   """
   @spec change_target(String.t()) :: :no_return
   def change_target(target) do
-    unless System.get_env("NERVES_TARGET_CHANGE") do
-      System.put_env("MIX_TARGET", target)
-      System.put_env("NERVES_TARGET_CHANGE", "1")
-      :init.restart()
-      :timer.sleep(:infinity)
-    end
+    System.put_env("MIX_TARGET", target)
+    :init.restart()
+    :timer.sleep(:infinity)
   end
 
   @doc """


### PR DESCRIPTION
The purpose of this function is to allow for introspection of the mix environment under different targets. This is useful for situations where host tools need access to information from the `host` target as well as a desired target. In order to do this, the vm needs to be restarted which in the case of mix tasks means that the same code paths will be called. Wrapping this call in an environment variable prevents infinite recursion, but limits the caller to only change targets once. This PR makes it the responsibility of the caller to track the state so this function can be called more than once.