### PR TITLE
Allow http_opts to be overwritten

### DIFF
--- a/lib/nerves/utils/http_client.ex
+++ b/lib/nerves/utils/http_client.ex
@@ -69,8 +69,9 @@ defmodule Nerves.Utils.HTTPClient do
     ]
 
     http_opts =
-      [timeout: :infinity, autoredirect: false] ++
-        Nerves.Utils.Proxy.config(url) ++ Keyword.get(opts, :http_opts, [])
+      [timeout: :infinity, autoredirect: false]
+      |> Keyword.merge(Nerves.Utils.Proxy.config(url))
+      |> Keyword.merge(Keyword.get(opts, :http_opts, []))
 
     opts = [stream: :self, receiver: self(), sync: false]
     :httpc.request(:get, {String.to_charlist(url), headers}, http_opts, opts, :nerves)


### PR DESCRIPTION
Github Enterprise seems to need `autoredirect: true` to download
large-ish packages