### PR TITLE
Update user interface docs for phoenix 1.4

### DIFF
--- a/docs/User Interfaces.md
+++ b/docs/User Interfaces.md
@@ -15,7 +15,7 @@ First, generate the two new apps in a containing folder:
 ```bash
 mkdir nervy && cd nervy
 mix nerves.new fw
-mix phx.new ui --no-ecto --no-brunch
+mix phx.new ui --no-ecto --no-webpack
 ```
 
 Now, add the Phoenix `ui` app and the `nerves_network` library to the `fw` app as dependencies:
@@ -46,7 +46,7 @@ Next, create your sub-applications for Nerves and for Phoenix:
 ```bash
 cd nervy/apps
 mix nerves.new fw
-mix phx.new ui --no-ecto --no-brunch
+mix phx.new ui --no-ecto --no-webpack
 ```
 
 Now, add the Phoenix `ui` app and the `nerves_network` library to the `fw` app as dependencies:
@@ -137,6 +137,8 @@ config :ui, UiWeb.Endpoint,
   render_errors: [view: UiWeb.ErrorView, accepts: ~w(html json)],
   pubsub: [name: Nerves.PubSub, adapter: Phoenix.PubSub.PG2],
   code_reloader: false
+
+config :phoenix, :json_library, Jason
 
 config :logger, level: :debug
 # ...


### PR DESCRIPTION
👋 

Was working on some UI on a nerves side project last week, and noticed that I since I have upgraded to Phoenix 1.4 locally some of the docs were a little out of date.

Not sure if you want to add comments to the effect of, "If you are using Phoenix < 1.4 use `no-bunch`, otherwise `no-webpack`." However, I just assume the user will be using Phoenix 1.4 in my updates, but I can change that if you want.

Also configuring the JSON library is now needed for Phoenix apps. I used `Jason` in the example because Phoenix 1.4 had that installed already and fixed my issue. The issue is [Phoenix defaults to Poison](https://github.com/phoenixframework/phoenix/blob/master/lib/phoenix.ex#L71), which if that is not in the deps of the fw directory then warning/errors happen on `mix firmware`. I did not add `jason` to the deps in this example to try to minimize the changes, but if you prefer that be explicitly be added and explained I can update.