### PR TITLE
update FAQ.md doc to reference correct rpi3 tty for USB serial console

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -25,7 +25,7 @@ For example, for the Raspberry Pi 3 target, you can find the [hardware descripti
 
     # Specify the UART port that the shell should use.
     #-c tty1
-    -c ttyS0
+    -c ttyAMA0
     ```
 
  4. Configure your project to replace this file in your firmware.


### PR DESCRIPTION
Really simple change. I just noticed that the FAQ doc in `Using a USB Serial Console` section references example rpi3 setting to use `ttyS0` while the linked hardware description README and default `erlinit.config` both state to use `ttyAMA0`

I'm assuming it needs to be the later one, so here you go.