### PR TITLE
Default strip_release: true in release config

### DIFF
--- a/priv/templates/release.eex
+++ b/priv/templates/release.eex
@@ -26,17 +26,19 @@ end
 # will be used by default<% end %>
 <%= for release <- releases do %><%= if Keyword.get(release, :is_umbrella) do %>
 release :<%= Keyword.get(release, :release_name) %> do
-  set version: "0.1.0"
-  set applications: [
+  set(version: "0.1.0")
+  set(strip_debug_info: true)
+  set(applications: [
 <%= Enum.map(Keyword.get(release, :release_applications), fn {app, start_type} ->
     "    #{app}: :#{start_type}"
     end) |> Enum.join(",\n") %>
-  ]
-  plugin Nerves
-  plugin Shoehorn
+  ])
+  plugin(Nerves)
+  plugin(Shoehorn)
 end<% else %>
 release :<%= Keyword.get(release, :release_name) %> do
   set(version: current_version(:<%= Keyword.get(release, :release_name)%>))
+  set(strip_debug_info: true)
   plugin(Nerves)
   plugin(Shoehorn)
 end<% end %><% end %>


### PR DESCRIPTION
This will enable the setting which will work once this PR lands https://github.com/bitwalker/distillery/pull/591

Stripping the release saves some significant space.
On `rpi0`, the size of firmware for a trivial app went from `29.91 Mb` to `21.12 Mb`