### PR TITLE
Add help if an artifact directory is missing

### DIFF
--- a/lib/nerves/env.ex
+++ b/lib/nerves/env.ex
@@ -305,6 +305,9 @@ defmodule Nerves.Env do
           Mix.shell().error("""
           #{k} is set to a path which does not exist:
           #{v}
+
+          Try running `mix deps.get` to see if this resolves the issue by
+          downloading the missing artifact.
           """)
 
           exit({:shutdown, 1})


### PR DESCRIPTION
This seems to happen if you run `mix deps.update --all` and then `mix
firmware`. The artifact doesn't seem to be downloaded. Running `mix
deps.get` fixes the problem.