### PR TITLE
Specify Elixir 1.8.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
     docker:
       - <<: *otp_21_image
     environment:
-      ELIXIR_VERSION: 1.8.0-otp-21
+      ELIXIR_VERSION: 1.8.1-otp-21
       LC_ALL: C.UTF-8
     <<: *defaults
     steps:

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -94,9 +94,9 @@ asdf plugin-add elixir
 # If on Debian or Ubuntu, you'll want to install wx before running the next
 # line: sudo apt install libwxgtk3.0-dev
 asdf install erlang 21.2.2 # Any OTP 21 version should work
-asdf install elixir 1.8.0-otp-21
+asdf install elixir 1.8.1-otp-21
 asdf global erlang 21.2.2
-asdf global elixir 1.8.0-otp-21
+asdf global elixir 1.8.1-otp-21
 ```
 
 It is important to update the versions of `hex` and `rebar` used by Elixir,


### PR DESCRIPTION
Elixir 1.8.0 has a bug that causes errors with optional dependencies.
The error message involves an optional dependency on the `jason` package
and isn't easy to understand. Specify 1.8.1 here in the installation to
fix the issue for people installing for the first time.