### PR TITLE
Fixes code block for `build_runner_opts`

### DIFF
--- a/docs/Systems.md
+++ b/docs/Systems.md
@@ -223,13 +223,14 @@ The following keys are supported:
     can use for execution. This is useful for situations where you may
     have a machine with a lot of CPUs but not enough ram.
 
-      # mix.exs
-      defp nerves_package do
-        [
-          # ...
-          build_runner_opts: [make_args: ["PARALLEL_JOBS=8"]],
-        ]
-      end
+    ```elixir
+    defp nerves_package do
+      [
+        # ...
+        build_runner_opts: [make_args: ["PARALLEL_JOBS=8"]],
+      ]
+    end
+    ```
 
 7. `checksum`: The list of files for which checksums are calculated and stored
     in the artifact cache.


### PR DESCRIPTION
The markdown for the code block on `build_runner_opts` wasn't correct, which resulted in a nasty headline when reading the docs.