### PR TITLE
Fail immediately on mkdir error

### DIFF
--- a/lib/nerves/artifact/cache.ex
+++ b/lib/nerves/artifact/cache.ex
@@ -20,11 +20,11 @@ defmodule Nerves.Artifact.Cache do
     File.rm_rf(dest)
 
     if String.ends_with?(path, ext) do
-      File.mkdir_p(dest)
+      File.mkdir_p!(dest)
       :ok = Nerves.Utils.File.untar(path, dest)
     else
       Path.dirname(dest)
-      |> File.mkdir_p()
+      |> File.mkdir_p!()
 
       File.ln_s!(path, dest)
     end


### PR DESCRIPTION
Tar was failing due to a missing destination directory on my laptop.
This makes it fail sooner.