### PR TITLE
System shell updates

### DIFF
--- a/lib/mix/nerves/shell.ex
+++ b/lib/mix/nerves/shell.ex
@@ -24,7 +24,8 @@ defmodule Mix.Nerves.Shell do
         :binary,
         :eof,
         :stream,
-        :stderr_to_stdout
+        :stderr_to_stdout,
+        {:env, [{'PATH', sanitize_path()}]}
       ])
 
     # Tell the script command about the terminal dimensions


### PR DESCRIPTION
This PR addresses two issues.

1. Starting with OTP 21.3.0, requesting the geometry of the window through `:erlang.port_control/3` results in an argument error:
```
** (ArgumentError) argument error
:erlang.port_control(#Port<0.14>, 100, [])
lib/mix/nerves/shell.ex:75: Mix.Nerves.Shell.get_tty_geometry/1
lib/mix/nerves/shell.ex:31: Mix.Nerves.Shell.open/2
(mix) lib/mix/cli.ex:79: Mix.CLI.run_task/2
```

~This will comment this out until the issue is fixed.~
This fixes the issue by first trying the original control number and then attempting the number for OTP >= 21.3.0. Thanks @fhunleth ❤️ 

2. Starting with asdf >= 0.7.0, the `PATH` contained `::`. I was unable to identify where in the code this was happening. This PR sanitizes `::` for the system shell.

Resolves
https://github.com/nerves-project/nerves/issues/411
https://github.com/nerves-project/nerves/issues/389 