### PR TITLE
Sanitize path when opening any shell

### DIFF
--- a/lib/mix/nerves/shell.ex
+++ b/lib/mix/nerves/shell.ex
@@ -25,7 +25,7 @@ defmodule Mix.Nerves.Shell do
         :eof,
         :stream,
         :stderr_to_stdout,
-        {:env, [{'PATH', sanitize_path()}]}
+        {:env, [{'PATH', Mix.Nerves.Utils.sanitize_path() |> to_charlist()}]}
       ])
 
     # Tell the script command about the terminal dimensions
@@ -67,12 +67,6 @@ defmodule Mix.Nerves.Shell do
       _message ->
         shell_loop(stdin_port, stdout_port, cmd_port)
     end
-  end
-
-  defp sanitize_path() do
-    System.get_env("PATH")
-    |> String.replace("::", ":")
-    |> to_charlist()
   end
 
   # Starting in OTP 21.3.0, the CTRL_OP_GET_WINSIZE changes to be

--- a/lib/mix/nerves/utils.ex
+++ b/lib/mix/nerves/utils.ex
@@ -4,7 +4,13 @@ defmodule Mix.Nerves.Utils do
   def shell(cmd, args, opts \\ []) do
     stream = opts[:stream] || IO.binstream(:standard_io, :line)
     std_err = opts[:stderr_to_stdout] || true
-    opts = Keyword.drop(opts, [:into, :stderr_to_stdout, :stream])
+    env = Keyword.get(opts, :env, []) ++ [{"PATH", sanitize_path()}]
+
+    opts =
+      opts
+      |> Keyword.drop([:into, :stderr_to_stdout, :stream])
+      |> Keyword.put(:env, env)
+
     System.cmd(cmd, args, [into: stream, stderr_to_stdout: std_err] ++ opts)
   end
 
@@ -207,6 +213,11 @@ defmodule Mix.Nerves.Utils do
       (System.get_env("MIX_TARGET") || "host")
       |> String.to_atom()
     end
+  end
+
+  def sanitize_path() do
+    System.get_env("PATH")
+    |> String.replace("::", ":")
   end
 
   defp raise_env_var_missing(name) do


### PR DESCRIPTION
Sanitizing the path for `mix nerves.system.shell` fixed the issue with `asdf` >= 0.7.0 but didn't cover other times where a shell is opened. This PR covers the local build runner in the same fashion. 

Fixes https://github.com/nerves-project/nerves/issues/389