### PR TITLE
Do not include empty priv directories in sort list

### DIFF
--- a/lib/nerves.ex
+++ b/lib/nerves.ex
@@ -167,7 +167,7 @@ defmodule Nerves do
       app_name = to_string(name)
       host_priv_dir = Path.join(path, "priv")
 
-      if File.dir?(host_priv_dir) do
+      if File.dir?(host_priv_dir) and not_empty_dir(host_priv_dir) do
         priv_dir =
           Path.join([target_release_path, "lib", app_name <> "-" <> to_string(vsn), "priv"])
 
@@ -201,4 +201,8 @@ defmodule Nerves do
 
   defp nerves_plugin({Nerves, _}), do: true
   defp nerves_plugin({_, _}), do: false
+
+  defp not_empty_dir(dir) do
+    File.ls(dir) == {:ok, []}
+  end
 end


### PR DESCRIPTION
Empty directories are pruned by the release script when constructing firmware. If the sort list contains a priv dir that had no files in it during compile time, the directory will not exist on the target and will throw a warning. An example of this can be seen with the package `mint`. The following warning will appear in the output of the call to `mix firmware`

```
Cannot stat sortlist entry "srv/erlang/lib/mint-0.2.1/priv"
This is probably because you're using the wrong file
path relative to the source directories.  Ignoring
```

This PR excludes empty directories from being included in the sort list.