### PR TITLE
Add 9P path \\wsl$ for mix firmware.burn inside WSL on Windows 10 Version 1903

### DIFF
--- a/lib/nerves/utils/wsl.ex
+++ b/lib/nerves/utils/wsl.ex
@@ -26,7 +26,7 @@ defmodule Nerves.Utils.WSL do
   def running_on_wsl?(osrelease_path \\ "/proc/sys/kernel/osrelease") do
     with true <- File.exists?(osrelease_path),
          {content, _} <- System.cmd("cat", [osrelease_path]) do
-      Regex.match?(~r/Microsoft/, content)
+      Regex.match?(~r/[Mm]icrosoft/, content)
     else
       _ ->
         false

--- a/lib/nerves/utils/wsl.ex
+++ b/lib/nerves/utils/wsl.ex
@@ -101,7 +101,7 @@ defmodule Nerves.Utils.WSL do
   @spec valid_windows_path?(String.t()) :: boolean
   def valid_windows_path?(path) do
     # Match <drive_letter>: then \ or \\ and then one or more characters except line breaks
-    Regex.match?(~r/(^\w{1}:|^\\\\wsl\$)(\\\\|\\)(.+)/, path)
+    Regex.match?(~r/^(\w{1}:|\\\\[\w.$-]+)(\\\\|\\)(.+)/, path)
   end
 
   @doc """

--- a/lib/nerves/utils/wsl.ex
+++ b/lib/nerves/utils/wsl.ex
@@ -99,15 +99,15 @@ defmodule Nerves.Utils.WSL do
   Returns true when the path matches various kinds of Windows-specific paths, like:
 
   ```
-  C:\
-  C:\projects
-  \\myserver\sharename\
-  \\wsl$\Ubuntu-18.04\home\username\my_project\
+  C:\\
+  C:\\projects
+  \\\\myserver\\sharename\\
+  \\\\wsl$\\Ubuntu-18.04\\home\\username\\my_project\\
   ```
   """
   @spec valid_windows_path?(String.t()) :: boolean
   def valid_windows_path?(path) do
-    Regex.match?(~r/^(\w{1}:|\\\\[\w.$-]+)(\\\\|\\)(.+)/, path)
+    Regex.match?(~r/^(\w:|\\\\[\w.$-]+)\\/, path)
   end
 
   @doc """

--- a/lib/nerves/utils/wsl.ex
+++ b/lib/nerves/utils/wsl.ex
@@ -96,11 +96,17 @@ defmodule Nerves.Utils.WSL do
   end
 
   @doc """
-  Returns true when the path starts with a drive letter, colon and either single backslash or double backslash
+  Returns true when the path matches various kinds of Windows-specific paths, like:
+
+  ```
+  C:\
+  C:\projects
+  \\myserver\sharename\
+  \\wsl$\Ubuntu-18.04\home\username\my_project\
+  ```
   """
   @spec valid_windows_path?(String.t()) :: boolean
   def valid_windows_path?(path) do
-    # Match <drive_letter>: then \ or \\ and then one or more characters except line breaks
     Regex.match?(~r/^(\w{1}:|\\\\[\w.$-]+)(\\\\|\\)(.+)/, path)
   end
 

--- a/lib/nerves/utils/wsl.ex
+++ b/lib/nerves/utils/wsl.ex
@@ -101,7 +101,7 @@ defmodule Nerves.Utils.WSL do
   @spec valid_windows_path?(String.t()) :: boolean
   def valid_windows_path?(path) do
     # Match <drive_letter>: then \ or \\ and then one or more characters except line breaks
-    Regex.match?(~r/(^\w{1}:)(\\\\|\\)(.+)/, path)
+    Regex.match?(~r/(^\w{1}:|^\\\\wsl\$)(\\\\|\\)(.+)/, path)
   end
 
   @doc """

--- a/test/nerves/utils_wsl_test.exs
+++ b/test/nerves/utils_wsl_test.exs
@@ -3,6 +3,23 @@ defmodule Nerves.MixUtilsTest do
 
   alias Nerves.Utils.WSL
 
+  test "valid_windows_path?/1 handles various Windows-specific paths properly" do
+    paths = [
+      {"C:\\", true},
+      {"c:\\\\projects", true},
+      {"\\\\myserver\\sharename\\", true},
+      {"\\\\1.2.3.4\\sharename\\", true},
+      {"\\\\wsl$\\Ubuntu-18.04\\home\\username", true},
+      {"C\\missing_colon", false},
+      {"\\\\\\triple\\leading\\slash", false},
+      {"/unix/path", false}
+    ]
+
+    Enum.each(paths, fn {path, windows?} ->
+      assert WSL.valid_windows_path?(path) == windows?
+    end)
+  end
+
   test "without wslpath, get_wsl_paths correctly converts a Windows accessible path" do
     use_wslpath = false
     windows_accessible_path = "/mnt/c/project/firmware.fw"


### PR DESCRIPTION
This PR will also enable `mix firmware.burn` for 1903 users 😊

**Reproduction:** Run `mix firmware.burn` inside WSL on Windows 10 Version 1903.
```
$ mix firmware.burn
** (Mix) Could not auto detect your SD card
```

**Reason:** With the introduction of 9P server, each distro's files can be accessed from `\\wsl$\{distro name}\` path.
```sh
$ wslpath -w -a .     
\\wsl$\Ubuntu-18.04\home\nab\hello_nerves\  
```
Cf. https://devblogs.microsoft.com/commandline/whats-new-for-wsl-in-windows-10-version-1903/