### PR TITLE
distillery: update requirement to ~> 2.0.12

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -28,7 +28,7 @@ defmodule Nerves.Mixfile do
 
   defp deps do
     [
-      {:distillery, "2.0.12", runtime: false},
+      {:distillery, "~> 2.0.12", runtime: false},
       {:jason, "~> 1.0", optional: true},
       {:ex_doc, "~> 0.19", only: [:test, :dev], runtime: false},
       {:dialyxir, "~> 1.0.0-rc.3", only: [:test, :dev], runtime: false},


### PR DESCRIPTION
`nerves` and `shoehorn` both depend on `distillery`.`nerves`  locked distillery to 2.0.12 to work around a critical bug in previous 2.0.x versions. `shoehorn` specified its requirement as ~> 2.0 since it was not affected by the same issues. The difference between these two requirement specifications has started to cause the `nerves` dependency to downgrade itself.