### PR TITLE
Update upgrade doc to mention shoehorn for Elixir 1.9

### DIFF
--- a/docs/Updating Projects.md
+++ b/docs/Updating Projects.md
@@ -621,12 +621,13 @@ In your project's `mix.exs`, make the following edits:
     end
     ```
 
-3. Update the nerves dependency
+3. Update the nerves and shoehorn dependencies
 
     ```elixir
     def deps
       [
         {:nerves, "~> 1.5.0", runtime: false},
+        {:shoehorn, "~> 0.6"},
         # ...
       ]
     end


### PR DESCRIPTION
Without this you will run into an error compiling shoehorn that looks like:
```
==> shoehorn
Compiling 7 files (.ex)

== Compilation error in file lib/shoehorn/plugin.ex ==
** (CompileError) lib/shoehorn/plugin.ex:2: module Mix.Releases.Plugin is not loaded and could not be found
    (elixir) expanding macro: Kernel.use/1
    lib/shoehorn/plugin.ex:2: Shoehorn.Plugin (module)
could not compile dependency :shoehorn, "mix compile" failed. You can recompile this dependency with "mix deps.compile shoehorn", update it with "mix deps.update shoehorn" or clean it with "mix deps.clean shoehorn"
```