### PR TITLE
Update compiler check recommendation.

### DIFF
--- a/lib/mix/tasks/firmware.ex
+++ b/lib/mix/tasks/firmware.ex
@@ -223,8 +223,8 @@ defmodule Mix.Tasks.Firmware do
 
         If you're using asdf to manage Elixir versions, run:
 
-        asdf install elixir #{System.version()}-otp-#{otpc.major}
-        asdf global elixir #{System.version()}-otp-#{otpc.major}
+        asdf install elixir #{System.version()}-otp-#{system_otp_release()}
+        asdf global elixir #{System.version()}-otp-#{system_otp_release()}
         """)
       end
     else
@@ -243,5 +243,10 @@ defmodule Mix.Tasks.Firmware do
          vsn <- to_string(vsn) do
       parse_version(vsn)
     end
+  end
+
+  def system_otp_release do
+    :erlang.system_info(:otp_release)
+    |> to_string()
   end
 end


### PR DESCRIPTION
There is no linkage that we know of between the kernel compiler version, and the OTP version number. Removing this prevents the text from providing recommendations to install versions of OTP that do not exist.