### PR TITLE
Cleanup System.md doc

### DIFF
--- a/docs/Systems.md
+++ b/docs/Systems.md
@@ -177,17 +177,22 @@ The following keys are supported:
     For official Nerves systems and toolchains, we upload the artifacts to
     GitHub Releases.
 
-    For an artifact site that uses `:github_api` be sure to have `username`, `token`, and `tag`
-    fields are set as they are required. Otherwise, you will get an exception when trying to
-    download the artifact.
-
-    Artifact sites can pass options as a third parameter for adding headers
-    or query string parameters. For example, if you are trying to resolve
-    artifacts hosted using `:github_releases` in a private repo,
-    you can pass a personal access token into the sites helper.
+    For an artifact site that uses GitHub Releases in a private repo, [create a
+    personal access token](https://help.github.com/en/articles/creating-a-personal-access-token-for-the-command-line)
+    and use `:github_api` with `username`, `token`, and `tag` options:
 
     ```elixir
-    {:github_releases, "my-organization/my_repository", query_params: %{"access_token" => System.get_env("GITHUB_ACCESS_TOKEN")}}
+    {:github_api, "owner/repo", username: "skroob", token: "1234567", tag: "v0.1.0"}
+    ```
+
+    Artifact sites can pass options as a third parameter for adding headers
+    or query string parameters.
+
+    ```elixir
+    {:prefix, "https://my-organization.com",
+      query_params: %{"id" => "1234567", "token" => "abcd"},
+      headers: [{"Content-Type", "application/octet-stream"}]
+    }
     ```
 
     You can also use this to add an authorization header for files behind basic auth.

--- a/lib/nerves/artifact.ex
+++ b/lib/nerves/artifact.ex
@@ -249,11 +249,17 @@ defmodule Nerves.Artifact do
 
   Artifact sites can pass options as a third parameter for adding headers
   or query string parameters. For example, if you are trying to resolve
-  artifacts hosted using `:github_releases` in a private repo,
-  you can pass a personal access token into the sites helper.
+  artifacts hosted in a private Github repo, use `:github_api` and
+  pass a user, tag, and personal access token into the sites helper:
 
   ```elixir
-  {:github_releases, "my-organization/my_repository", query_params: %{"access_token" => System.get_env("GITHUB_ACCESS_TOKEN")}}
+  {:github_api, "owner/repo", username: "skroob", token: "1234567", tag: "v0.1.0"}
+  ```
+
+  Or pass query parameters for the URL:
+
+  ```elixir
+  {:prefix, "https://my-organization.com", query_params: %{"id" => "1234567", "token" => "abcd"}}
   ```
 
   You can also use this to add an authorization header for files behind basic auth.


### PR DESCRIPTION
`System.md` and `lib/nerves/artifact.ex` reference using `:github_releases` with an access_token query param. However, that does not seem to be supported anymore in github.

So this removes that and updates the docs a bit.

As a bonus, I've also tested using `:github_api` for artifacts in a private repo and works like a charm 👌 :tada: