### PR TITLE
Fix broken installation link

### DIFF
--- a/lib/mix/nerves/utils.ex
+++ b/lib/mix/nerves/utils.ex
@@ -81,8 +81,8 @@ defmodule Mix.Nerves.Utils do
     """
     #{package} is required by the Nerves tooling.
 
-    Please see https://hexdocs.pm/nerves/installation.html#host-specific-tools
-    for installation instructions.
+    Please see https://hexdocs.pm/nerves/installation.html for installation
+    instructions.
     """
   end
 


### PR DESCRIPTION
Broken out from #455 

The actual section of the page that this link was pointing to no longer exists.