### PR TITLE
Make preflight helper functions private

### DIFF
--- a/lib/mix/nerves/utils.ex
+++ b/lib/mix/nerves/utils.ex
@@ -1,4 +1,6 @@
 defmodule Mix.Nerves.Utils do
+  alias Nerves.Utils.WSL
+
   @fwup_semver "~> 1.2.5 or ~> 1.3"
 
   def shell(cmd, args, opts \\ []) do
@@ -104,8 +106,8 @@ defmodule Mix.Nerves.Utils do
 
   def get_devs do
     {result, 0} =
-      if Nerves.Utils.WSL.running_on_wsl?() do
-        Nerves.Utils.WSL.get_fwup_devices()
+      if WSL.running_on_wsl?() do
+        WSL.get_fwup_devices()
       else
         System.cmd("fwup", ["--detect"])
       end

--- a/lib/mix/nerves/utils.ex
+++ b/lib/mix/nerves/utils.ex
@@ -22,7 +22,7 @@ defmodule Mix.Nerves.Utils do
     Mix.Task.run("nerves.loadpaths")
   end
 
-  def check_requirements("mksquashfs") do
+  defp check_requirements("mksquashfs") do
     case System.find_executable("mksquashfs") do
       nil ->
         Mix.raise(missing_package_message("squashfs"))
@@ -32,7 +32,7 @@ defmodule Mix.Nerves.Utils do
     end
   end
 
-  def check_requirements("fwup") do
+  defp check_requirements("fwup") do
     case System.find_executable("fwup") do
       nil ->
         Mix.raise(missing_package_message("fwup"))
@@ -65,7 +65,7 @@ defmodule Mix.Nerves.Utils do
     end
   end
 
-  def check_host_requirements(:darwin) do
+  defp check_host_requirements(:darwin) do
     case System.find_executable("gstat") do
       nil ->
         Mix.raise(missing_package_message("gstat (coreutils)"))
@@ -75,7 +75,7 @@ defmodule Mix.Nerves.Utils do
     end
   end
 
-  def check_host_requirements(_), do: nil
+  defp check_host_requirements(_), do: nil
 
   defp missing_package_message(package) do
     """


### PR DESCRIPTION
Broken out from #455

Prepping to move these out to a separate module by proving that they're only used from here.