### PR TITLE
Extract ensure_available!/2 preflight helper

### DIFF
--- a/lib/mix/nerves/utils.ex
+++ b/lib/mix/nerves/utils.ex
@@ -26,30 +26,31 @@ defmodule Mix.Nerves.Utils do
 
   defp check_requirements("fwup") do
     ensure_available!("fwup")
-        with {vsn, 0} <- System.cmd("fwup", ["--version"]),
-             vsn = String.trim(vsn),
-             {:ok, req} = Version.parse_requirement(@fwup_semver),
-             true <- Version.match?(vsn, req) do
-          :ok
-        else
-          false ->
-            {vsn, 0} = System.cmd("fwup", ["--version"])
 
-            Mix.raise("""
-            fwup #{@fwup_semver} is required for Nerves.
+    with {vsn, 0} <- System.cmd("fwup", ["--version"]),
+         vsn = String.trim(vsn),
+         {:ok, req} = Version.parse_requirement(@fwup_semver),
+         true <- Version.match?(vsn, req) do
+      :ok
+    else
+      false ->
+        {vsn, 0} = System.cmd("fwup", ["--version"])
 
-            You are running #{vsn}.
-            Please see https://hexdocs.pm/nerves/installation.html#fwup
-            for installation instructions
-            """)
+        Mix.raise("""
+        fwup #{@fwup_semver} is required for Nerves.
 
-          error ->
-            Mix.raise("""
-            Nerves encountered an error while checking host requirements for fwup
-            #{inspect(error)}
-            Please open a bug report for this issue on github.com/nerves-project/nerves
-            """)
-        end
+        You are running #{vsn}.
+        Please see https://hexdocs.pm/nerves/installation.html#fwup
+        for installation instructions
+        """)
+
+      error ->
+        Mix.raise("""
+        Nerves encountered an error while checking host requirements for fwup
+        #{inspect(error)}
+        Please open a bug report for this issue on github.com/nerves-project/nerves
+        """)
+    end
   end
 
   defp check_host_requirements(:darwin) do

--- a/lib/mix/nerves/utils.ex
+++ b/lib/mix/nerves/utils.ex
@@ -19,27 +19,13 @@ defmodule Mix.Nerves.Utils do
   def preflight do
     {_, type} = :os.type()
     check_requirements("fwup")
-    check_requirements("mksquashfs")
+    ensure_available!("mksquashfs", package: "squashfs")
     check_host_requirements(type)
     Mix.Task.run("nerves.loadpaths")
   end
 
-  defp check_requirements("mksquashfs") do
-    case System.find_executable("mksquashfs") do
-      nil ->
-        Mix.raise(missing_package_message("squashfs"))
-
-      _ ->
-        :ok
-    end
-  end
-
   defp check_requirements("fwup") do
-    case System.find_executable("fwup") do
-      nil ->
-        Mix.raise(missing_package_message("fwup"))
-
-      _ ->
+    ensure_available!("fwup")
         with {vsn, 0} <- System.cmd("fwup", ["--version"]),
              vsn = String.trim(vsn),
              {:ok, req} = Version.parse_requirement(@fwup_semver),
@@ -64,20 +50,22 @@ defmodule Mix.Nerves.Utils do
             Please open a bug report for this issue on github.com/nerves-project/nerves
             """)
         end
-    end
   end
 
   defp check_host_requirements(:darwin) do
-    case System.find_executable("gstat") do
-      nil ->
-        Mix.raise(missing_package_message("gstat (coreutils)"))
-
-      _ ->
-        :ok
-    end
+    ensure_available!("gstat", package: "gstat (coreutils)")
   end
 
   defp check_host_requirements(_), do: nil
+
+  defp ensure_available!(executable, opts \\ []) do
+    if System.find_executable(executable) do
+      :ok
+    else
+      package = opts[:package] || executable
+      Mix.raise(missing_package_message(package))
+    end
+  end
 
   defp missing_package_message(package) do
     """


### PR DESCRIPTION
This simplifies checking for the availability of certain binaries and giving an appropriate error message saying which package to install if it's missing.

Broken out from #455 