### PR TITLE
Move Mix task preflight checks to a module

### DIFF
--- a/lib/mix/nerves/preflight.ex
+++ b/lib/mix/nerves/preflight.ex
@@ -1,0 +1,64 @@
+defmodule Mix.Nerves.Preflight do
+  @fwup_semver "~> 1.2.5 or ~> 1.3"
+
+  def check! do
+    {_, type} = :os.type()
+    check_requirements("fwup")
+    ensure_available!("mksquashfs", package: "squashfs")
+    check_host_requirements(type)
+    Mix.Task.run("nerves.loadpaths")
+  end
+
+  defp check_requirements("fwup") do
+    ensure_available!("fwup")
+
+    with {vsn, 0} <- System.cmd("fwup", ["--version"]),
+         vsn = String.trim(vsn),
+         {:ok, req} = Version.parse_requirement(@fwup_semver),
+         true <- Version.match?(vsn, req) do
+      :ok
+    else
+      false ->
+        {vsn, 0} = System.cmd("fwup", ["--version"])
+
+        Mix.raise("""
+        fwup #{@fwup_semver} is required for Nerves.
+
+        You are running #{vsn}.
+        Please see https://hexdocs.pm/nerves/installation.html#fwup
+        for installation instructions
+        """)
+
+      error ->
+        Mix.raise("""
+        Nerves encountered an error while checking host requirements for fwup
+        #{inspect(error)}
+        Please open a bug report for this issue on github.com/nerves-project/nerves
+        """)
+    end
+  end
+
+  defp check_host_requirements(:darwin) do
+    ensure_available!("gstat", package: "gstat (coreutils)")
+  end
+
+  defp check_host_requirements(_), do: nil
+
+  defp ensure_available!(executable, opts \\ []) do
+    if System.find_executable(executable) do
+      :ok
+    else
+      package = opts[:package] || executable
+      Mix.raise(missing_package_message(package))
+    end
+  end
+
+  defp missing_package_message(package) do
+    """
+    #{package} is required by the Nerves tooling.
+
+    Please see https://hexdocs.pm/nerves/installation.html for installation
+    instructions.
+    """
+  end
+end

--- a/lib/mix/nerves/utils.ex
+++ b/lib/mix/nerves/utils.ex
@@ -1,8 +1,6 @@
 defmodule Mix.Nerves.Utils do
   alias Nerves.Utils.WSL
 
-  @fwup_semver "~> 1.2.5 or ~> 1.3"
-
   def shell(cmd, args, opts \\ []) do
     stream = opts[:stream] || IO.binstream(:standard_io, :line)
     std_err = opts[:stderr_to_stdout] || true
@@ -14,67 +12,6 @@ defmodule Mix.Nerves.Utils do
       |> Keyword.put(:env, env)
 
     System.cmd(cmd, args, [into: stream, stderr_to_stdout: std_err] ++ opts)
-  end
-
-  def preflight do
-    {_, type} = :os.type()
-    check_requirements("fwup")
-    ensure_available!("mksquashfs", package: "squashfs")
-    check_host_requirements(type)
-    Mix.Task.run("nerves.loadpaths")
-  end
-
-  defp check_requirements("fwup") do
-    ensure_available!("fwup")
-
-    with {vsn, 0} <- System.cmd("fwup", ["--version"]),
-         vsn = String.trim(vsn),
-         {:ok, req} = Version.parse_requirement(@fwup_semver),
-         true <- Version.match?(vsn, req) do
-      :ok
-    else
-      false ->
-        {vsn, 0} = System.cmd("fwup", ["--version"])
-
-        Mix.raise("""
-        fwup #{@fwup_semver} is required for Nerves.
-
-        You are running #{vsn}.
-        Please see https://hexdocs.pm/nerves/installation.html#fwup
-        for installation instructions
-        """)
-
-      error ->
-        Mix.raise("""
-        Nerves encountered an error while checking host requirements for fwup
-        #{inspect(error)}
-        Please open a bug report for this issue on github.com/nerves-project/nerves
-        """)
-    end
-  end
-
-  defp check_host_requirements(:darwin) do
-    ensure_available!("gstat", package: "gstat (coreutils)")
-  end
-
-  defp check_host_requirements(_), do: nil
-
-  defp ensure_available!(executable, opts \\ []) do
-    if System.find_executable(executable) do
-      :ok
-    else
-      package = opts[:package] || executable
-      Mix.raise(missing_package_message(package))
-    end
-  end
-
-  defp missing_package_message(package) do
-    """
-    #{package} is required by the Nerves tooling.
-
-    Please see https://hexdocs.pm/nerves/installation.html for installation
-    instructions.
-    """
   end
 
   def debug_info(msg) do

--- a/lib/mix/tasks/burn.ex
+++ b/lib/mix/tasks/burn.ex
@@ -1,6 +1,7 @@
 defmodule Mix.Tasks.Burn do
   use Mix.Task
   import Mix.Nerves.Utils
+  alias Mix.Nerves.Preflight
   alias Nerves.Utils.WSL
 
   @switches [device: :string, task: :string]
@@ -39,7 +40,7 @@ defmodule Mix.Tasks.Burn do
 
   @impl true
   def run(argv) do
-    preflight()
+    Preflight.check!()
     debug_info("Nerves Burn")
 
     {opts, argv, _} = OptionParser.parse(argv, switches: @switches, aliases: @aliases)

--- a/lib/mix/tasks/firmware.ex
+++ b/lib/mix/tasks/firmware.ex
@@ -1,6 +1,7 @@
 defmodule Mix.Tasks.Firmware do
   use Mix.Task
   import Mix.Nerves.Utils
+  alias Mix.Nerves.Preflight
 
   @shortdoc "Build a firmware bundle"
 
@@ -28,7 +29,7 @@ defmodule Mix.Tasks.Firmware do
 
   @impl true
   def run(args) do
-    preflight()
+    Preflight.check!()
     debug_info("Nerves Firmware Assembler")
 
     {opts, _, _} = OptionParser.parse(args, switches: @switches)

--- a/lib/mix/tasks/firmware.image.ex
+++ b/lib/mix/tasks/firmware.image.ex
@@ -1,6 +1,7 @@
 defmodule Mix.Tasks.Firmware.Image do
   use Mix.Task
   import Mix.Nerves.Utils
+  alias Mix.Nerves.Preflight
 
   @shortdoc "Create a firmware image file"
 
@@ -28,7 +29,7 @@ defmodule Mix.Tasks.Firmware.Image do
 
   @impl true
   def run([file]) do
-    preflight()
+    Preflight.check!()
     debug_info("Nerves Firmware Image")
 
     config = Mix.Project.config()


### PR DESCRIPTION
Note that the function name was change from `Mix.Nerves.Utils.preflight/0` to `Mix.Nerves.Preflight.check!/0`. This was technically a public function but I'm assuming that this isn't an API anyone is using, so I didn't leave a deprecated stub in the `Utils` module. Let me know if you prefer for it to stay there.

Split out from #455 