### PR TITLE
Add NERVES_DATA_DIR to specify global nerves data location

### DIFF
--- a/lib/nerves/artifact.ex
+++ b/lib/nerves/artifact.ex
@@ -6,7 +6,7 @@ defmodule Nerves.Artifact do
   """
   alias Nerves.Artifact.{Cache, BuildRunners, Resolvers}
 
-  @base_dir Path.expand("~/.nerves/artifacts")
+  @path Path.expand("artifacts")
   @checksum_short 7
 
   @doc """
@@ -143,17 +143,14 @@ defmodule Nerves.Artifact do
   """
   @spec base_dir() :: String.t()
   def base_dir() do
-    System.get_env("NERVES_ARTIFACTS_DIR") || @base_dir
+    System.get_env("NERVES_ARTIFACTS_DIR") || Path.join(Nerves.Env.data_dir(), @path)
   end
 
   @doc """
   Get the path to where the artifact is built
   """
   def build_path(pkg) do
-    pkg.path
-    |> Path.join(".nerves")
-    |> Path.join("artifacts")
-    |> Path.join(name(pkg))
+    Path.join([pkg.path, ".nerves", "artifacts", name(pkg)])
   end
 
   @doc """

--- a/lib/nerves/env.ex
+++ b/lib/nerves/env.ex
@@ -61,15 +61,27 @@ defmodule Nerves.Env do
   end
 
   @doc """
-  The download location for artifacts.
+  The download location for artifact downloads.
 
   Placing an artifact tar in this location will bypass the need for it to
   be downloaded.
   """
   @spec download_dir() :: path :: String.t()
   def download_dir do
-    (System.get_env("NERVES_DL_DIR") || "~/.nerves/dl")
+    (System.get_env("NERVES_DL_DIR") || Path.join(data_dir(), "dl"))
     |> Path.expand()
+  end
+
+  @doc """
+  The location for storing global nerves data
+  """
+  @spec data_dir() :: path :: String.t()
+  def data_dir do
+    case {System.get_env("NERVES_DATA_DIR"), System.get_env("XDG_DATA_HOME")} do
+      {directory, _} when is_binary(directory) -> directory
+      {nil, directory} when is_binary(directory) -> :filename.basedir(:user_data, "nerves")
+      {nil, nil} -> Path.expand("~/.nerves")
+    end
   end
 
   @doc """
@@ -336,7 +348,7 @@ defmodule Nerves.Env do
       platform.bootstrap(pkg)
     end
 
-    # Bootstrap all other packahes who define a platform
+    # Bootstrap all other packages who define a platform
     Nerves.Env.packages()
     |> Enum.reject(&(&1 == Nerves.Env.toolchain()))
     |> Enum.reject(&(&1 == Nerves.Env.system()))

--- a/test/nerves/env_test.exs
+++ b/test/nerves/env_test.exs
@@ -59,4 +59,24 @@ defmodule Nerves.EnvTest do
       end
     end)
   end
+
+  describe "data_dir/0" do
+    test "prefers NERVES_DATA_DIR over XDG_DATA_HOME" do
+      System.put_env("NERVES_DATA_DIR", "nerves_data_dir")
+      System.put_env("XDG_DATA_HOME", "xdg_data_home")
+      assert "nerves_data_dir" = Nerves.Env.data_dir()
+    end
+
+    test "falls back to XDG_DATA_HOME/nerves" do
+      System.delete_env("NERVES_DATA_DIR")
+      System.put_env("XDG_DATA_HOME", "xdg_data_home")
+      assert :filename.basedir(:user_data, "nerves") == Nerves.Env.data_dir()
+    end
+
+    test "falls back to $HOME/.nerves" do
+      System.delete_env("NERVES_DATA_DIR")
+      System.delete_env("XDG_DATA_HOME")
+      assert Path.expand("~/.nerves") == Nerves.Env.data_dir()
+    end
+  end
 end

--- a/test/support/test_case.ex
+++ b/test/support/test_case.ex
@@ -40,11 +40,7 @@ defmodule NervesTest.Case do
 
     fixture_to_tmp(which, dest)
 
-    artifact_dir = Path.join(tmp_path(tmp), ".nerves/artifacts")
-    download_dir = Path.join(tmp_path(tmp), ".nerves/dl")
-
-    System.put_env("NERVES_ARTIFACTS_DIR", artifact_dir)
-    System.put_env("NERVES_DL_DIR", download_dir)
+    System.put_env("NERVES_DATA_DIR", tmp_path(tmp))
 
     try do
       File.cd!(dest, function)


### PR DESCRIPTION
This also adds support for XDG_DATA_HOME as described in  https://github.com/elixir-lang/elixir/pull/8933

This is going to require some documentation but I wanted to start the discussion on the variable name. Considering that the subcomponents of this could be set via `NERVES_DL_DIR` and `NERVES_ARTIFACTS_DIR` I chose to fix the existing but broken `data_dir/0` function and call it `NERVES_DATA_DIR`. 