### PR TITLE
Allow erlinit options to be merged from mix config

### DIFF
--- a/docs/Advanced Configuration.md
+++ b/docs/Advanced Configuration.md
@@ -395,3 +395,54 @@ attempt to mount the partition. You may want to see [how `nerves_runtime` does
 this for the default application data
 partition](https://github.com/nerves-project/nerves_runtime/blob/master/lib/nerves_runtime/init.ex),
 extending it to meet your specific needs.
+
+### Overriding erlinit.config from Mix Config
+
+Options specified in the `erlinit.config` file can be overridden through the
+project's Mix config. This can be helpful when you want to alter a couple
+options without having to maintain a copy of the entire `erlinit.config`
+from the system. Here is an example of how you can change the `ctty` option
+from the `config/target.exs` file.
+
+```elixir
+config :nerves, :erlinig,
+  ctty: "ttyAMA0"
+```
+
+Options that can only be specified once will overwrite the values specified in
+the `erlinig.config` provided by the system. Options that can be specified
+multiple times, such as `mount` and `env` will append to the original ones.
+If an `erlinit.config` file is provided in the project's `rootfs_overlay` it
+will override everything else.
+
+The following is a list of all options that can be specified:
+
+```elixir
+[
+  boot: Path.t(),
+  ctty: String.t(),
+  uniqueid_exec: String.t(),
+  env: String.t(),
+  gid: non_neg_integer(),
+  graceful_shutdown_timeout: non_neg_integer(),
+  hang_on_exit: boolean(),
+  hang_on_fatal: boolean(),
+  mount: String.t(),
+  hostname_pattern: String.t(),
+  pre_run_exec: String.t(),
+  poweroff_on_exit: boolean(),
+  poweroff_on_fatal: boolean(),
+  reboot_on_fatal: boolean(),
+  release_path: String.t(),
+  run_on_exit: String.t(),
+  alternate_exec: binary(),
+  print_timing: boolean(),
+  uid: non_neg_integer(),
+  update_clock: boolean(),
+  verbose: boolean(),
+  warn_unused_tty: boolean(),
+  working_directory: Path.t()
+]
+```
+
+See [erlinit](https://github.com/nerves-project/erlinit) for more information.

--- a/lib/nerves/erlinit.ex
+++ b/lib/nerves/erlinit.ex
@@ -1,0 +1,99 @@
+defmodule Nerves.Erlinit do
+  @switches [
+    boot: :string,
+    ctty: :string,
+    uniqueid_exec: :string,
+    env: :keep,
+    gid: :integer,
+    graceful_shutdown_timeout: :integer,
+    hang_on_exit: :boolean,
+    reboot_on_exit: :boolean,
+    hang_on_fatal: :boolean,
+    mount: :keep,
+    hostname_pattern: :string,
+    pre_run_exec: :string,
+    poweroff_on_exit: :boolean,
+    poweroff_on_fatal: :boolean,
+    reboot_on_fatal: :boolean,
+    release_path: :string,
+    run_on_exit: :string,
+    alternate_exec: :string,
+    print_timing: :boolean,
+    uid: :integer,
+    update_clock: :boolean,
+    verbose: :boolean,
+    warn_unused_tty: :boolean,
+    working_directory: :string
+  ]
+
+  @aliases [
+    b: :boot,
+    c: :ctty,
+    d: :uniqueid_exec,
+    e: :env,
+    h: :hang_on_exit,
+    m: :mount,
+    n: :hostname_pattern,
+    r: :release_path,
+    s: :alternate_exec,
+    t: :print_timing,
+    v: :verbose
+  ]
+
+  def system_config_file(%Nerves.Package{path: path}) do
+    file = Path.join(path, "rootfs_overlay/etc/erlinit.config")
+
+    case File.exists?(file) do
+      true ->
+        {:ok, file}
+
+      false ->
+        {:error, :no_config}
+    end
+  end
+
+  def decode_config(config) do
+    argv =
+      config
+      |> String.split("\n")
+      |> Enum.filter(&String.starts_with?(&1, "-"))
+      |> Enum.map(&String.split(&1, " ", parts: 2))
+      |> List.flatten()
+
+    {opts, _, _} = OptionParser.parse(argv, switches: @switches, aliases: @aliases)
+    opts
+  end
+
+  def merge_opts(old, new) do
+    Enum.reduce(new, old, fn
+      {k, nil}, acc ->
+        Keyword.delete(acc, k)
+
+      {k, v}, acc ->
+        case Keyword.get(@switches, k) do
+          :keep ->
+            [{k, v} | acc]
+
+          _ ->
+            Keyword.put(acc, k, v)
+        end
+    end)
+  end
+
+  def encode_config(config) do
+    config
+    |> Enum.map(&encode_line/1)
+    |> Enum.join("\n")
+  end
+
+  def encode_line({k, v}) do
+    Keyword.get(@switches, k)
+    |> encode_type(k, v)
+  end
+
+  def encode_type(:boolean, _k, false), do: ""
+  def encode_type(:boolean, k, true), do: encode_key(k)
+  def encode_type(_, k, v), do: "#{encode_key(k)} #{v}"
+
+  def encode_key(key), do: "--" <> String.replace(to_string(key), "_", "-")
+end

--- a/test/nerves/erlinit_test.exs
+++ b/test/nerves/erlinit_test.exs
@@ -1,0 +1,113 @@
+defmodule Nerves.ErlinitTest do
+  use NervesTest.Case, async: false
+
+  alias Nerves.Erlinit
+
+  @example """
+  # Additional configuration for erlinit
+
+  # Turn on the debug prints
+  #-v
+
+  # Specify where erlinit should send the IEx prompt. Only one may be enabled at
+  # a time.
+
+  # Nowhere - let nbtty send it to the gadget USB serial port
+  -c null
+
+  # HDMI output
+  # -c tty1
+
+  # If more than one tty are available, always warn if the user is looking at the
+  # wrong one.
+  --warn-unused-tty
+
+  # Use nbtty to improve terminal handling on serial ports.
+  # Change this to ttyAMA0 to use the UART pins and remove for HDMI
+  -s "/usr/bin/nbtty --tty /dev/ttyGS0 --wait-input"
+
+  # Specify the user and group IDs for the Erlang VM
+  #--uid 100
+  #--gid 200
+
+  # Uncomment to ensure that the system clock is set to at least the Nerves
+  # System's build date/time. If you enable this, you'll still need to use NTP or
+  # another mechanism to set the clock, but it won't be decades off.
+  #--update-clock
+
+  # Uncomment to hang the board rather than rebooting when Erlang exits
+  # NOTE: Do not enable on production boards
+  #--hang-on-exit
+
+  # Change the graceful shutdown time. If 10 seconds isn't long enough between
+  # calling "poweroff", "reboot", or "halt" and :init.stop/0 stopping all OTP
+  # applications, enable this option with a new timeout in milliseconds.
+  #--graceful-shutdown-timeout 15000
+
+  # Optionally run a program if the Erlang VM exits
+  #--run-on-exit /bin/sh
+
+  # Enable UTF-8 filename handling in Erlang and custom inet configuration
+  -e LANG=en_US.UTF-8;LANGUAGE=en;ERL_INETRC=/etc/erl_inetrc;ERL_CRASH_DUMP=/root/crash.dump
+
+  # Mount the application partition (run "man fstab" for field names)
+  # NOTE: This must match the location in the fwup.conf. If it doesn't the system
+  #       will probably still work fine, but you won't get shell history since
+  #       shoehorn/nerves_runtime can't mount the application filesystem before
+  #       the history is loaded. If this mount fails due to corruption, etc.,
+  #       nerves_runtime will auto-format it. Your applications will need to handle
+  #       initializing any expected files and folders.
+  -m /dev/mmcblk0p1:/boot:vfat:ro,nodev,noexec,nosuid:
+  -m /dev/mmcblk0p3:/root:ext4:nodev:
+  -m configfs:/sys/kernel/config:configfs:nodev,noexec,nosuid:
+  -m pstore:/sys/fs/pstore:pstore:nodev,noexec,nosuid:
+  -m tmpfs:/sys/fs/cgroup:tmpfs:nodev,noexec,nosuid:mode=755,size=1024k
+  -m cpu:/sys/fs/cgroup/cpu:cgroup:nodev,noexec,nosuid:cpu
+  -m memory:/sys/fs/cgroup/memory:cgroup:nodev,noexec,nosuid:memory
+
+  # Erlang release search path
+  -r /srv/erlang
+
+  # Assign a hostname of the form "nerves-<serial_number>".
+  # See /etc/boardid.config for locating the serial number.
+  -d /usr/bin/boardid
+  -n nerves-%s
+
+  # If using shoehorn (https://github.com/nerves-project/shoehorn), start the
+  # shoehorn OTP release up first. If shoehorn isn't around, erlinit fails back
+  # to the main OTP release.
+  --boot shoehorn
+  """
+
+  test "parse example file", context do
+    in_tmp(context.test, fn ->
+      erlinit_opts = Erlinit.decode_config(@example)
+      assert erlinit_opts[:ctty] == "null"
+      refute erlinit_opts[:verbose]
+      assert erlinit_opts[:warn_unused_tty]
+    end)
+  end
+
+  test "merge options", context do
+    in_tmp(context.test, fn ->
+      erlinit_opts = Erlinit.decode_config(@example)
+      assert Erlinit.merge_opts(erlinit_opts, verbose: true)[:verbose] == true
+    end)
+  end
+
+  test "remove option", context do
+    in_tmp(context.test, fn ->
+      erlinit_opts = Erlinit.decode_config(@example)
+      merged_opts = Erlinit.merge_opts(erlinit_opts, alternate_exec: nil)
+      refute Erlinit.encode_config(merged_opts) =~ "--alternate_exec"
+    end)
+  end
+
+  test "merge keep options", context do
+    in_tmp(context.test, fn ->
+      erlinit_opts = Erlinit.decode_config(@example)
+      merged_opts = Erlinit.merge_opts(erlinit_opts, mount: "1234")
+      assert Erlinit.encode_config(merged_opts) =~ "--mount 1234"
+    end)
+  end
+end

--- a/test/nerves/erlinit_test.exs
+++ b/test/nerves/erlinit_test.exs
@@ -110,4 +110,11 @@ defmodule Nerves.ErlinitTest do
       assert Erlinit.encode_config(merged_opts) =~ "--mount 1234"
     end)
   end
+
+  test "override ctty", context do
+    in_tmp(context.test, fn ->
+      erlinit_opts = Erlinit.decode_config(@example)
+      assert Erlinit.merge_opts(erlinit_opts, ctty: "1234")[:ctty] == "1234"
+    end)
+  end
 end


### PR DESCRIPTION
The options from the system are merged with the options specified in `Application.get_env(:nerves, :erlinit)`. If there are overrides, a new erlinit.config file is generated and placed in a new _build  rootfs_overlay directory. This path is passed to rel2fw and will be overridden by the project level rootfs_overlay files.

Here is an example:
If we have a Raspberry PI 3 and in our `config/target.exs` put 

```elixir
config :nerves, :erlinit,
  ctty: "ttyAMA0"
```
The generated config will send the terminal output to the serial port.

There are a few caveats with this approach.

  * Options that accumulate can not be overridden, they can only be appended. For example, multiple `--mount`.
  * Other options can be removed if a value is already specified by setting the value to `nil` or `false` in the case of `boolean` values. For example, disabling the `--alternate_exec` `alternate_exec: nil` or disabling `--verbose` `verbose: false`.