### PR TITLE
Do not clear out the existing bootscripts

### DIFF
--- a/lib/nerves/release.ex
+++ b/lib/nerves/release.ex
@@ -9,7 +9,6 @@ defmodule Nerves.Release do
     release = %{
       release
       | options: opts,
-        boot_scripts: %{},
         steps: release.steps ++ [&Nerves.Release.finalize/1]
     }
 


### PR DESCRIPTION
The existing bootscripts may be helpful to other functions in the release steps, lets not remove them.