### PR TITLE
Fix erlinit option parsing/formating issues

### DIFF
--- a/test/nerves/erlinit_test.exs
+++ b/test/nerves/erlinit_test.exs
@@ -12,8 +12,8 @@ defmodule Nerves.ErlinitTest do
   # Specify where erlinit should send the IEx prompt. Only one may be enabled at
   # a time.
 
-  # Nowhere - let nbtty send it to the gadget USB serial port
-  -c null
+  # TEST: Inline comment here to make sure that parser isn't tricked by that.
+  -c null # Nowhere - let nbtty send it to the gadget USB serial port
 
   # HDMI output
   # -c tty1
@@ -27,25 +27,27 @@ defmodule Nerves.ErlinitTest do
   -s "/usr/bin/nbtty --tty /dev/ttyGS0 --wait-input"
 
   # Specify the user and group IDs for the Erlang VM
-  #--uid 100
-  #--gid 200
+  # TEST: Numbers
+  --uid 100
+  --gid 200
 
   # Uncomment to ensure that the system clock is set to at least the Nerves
   # System's build date/time. If you enable this, you'll still need to use NTP or
   # another mechanism to set the clock, but it won't be decades off.
-  #--update-clock
+  --update-clock
 
   # Uncomment to hang the board rather than rebooting when Erlang exits
   # NOTE: Do not enable on production boards
-  #--hang-on-exit
+  --hang-on-exit
 
   # Change the graceful shutdown time. If 10 seconds isn't long enough between
   # calling "poweroff", "reboot", or "halt" and :init.stop/0 stopping all OTP
   # applications, enable this option with a new timeout in milliseconds.
-  #--graceful-shutdown-timeout 15000
+  # TEST: Lots of whitespace between option and value
+  --graceful-shutdown-timeout          15000
 
   # Optionally run a program if the Erlang VM exits
-  #--run-on-exit /bin/sh
+  --run-on-exit /bin/sh
 
   # Enable UTF-8 filename handling in Erlang and custom inet configuration
   -e LANG=en_US.UTF-8;LANGUAGE=en;ERL_INETRC=/etc/erl_inetrc;ERL_CRASH_DUMP=/root/crash.dump
@@ -66,7 +68,8 @@ defmodule Nerves.ErlinitTest do
   -m memory:/sys/fs/cgroup/memory:cgroup:nodev,noexec,nosuid:memory
 
   # Erlang release search path
-  -r /srv/erlang
+  # TEST: Spaces before option should be ignored
+     -r /srv/erlang
 
   # Assign a hostname of the form "nerves-<serial_number>".
   # See /etc/boardid.config for locating the serial number.
@@ -82,9 +85,31 @@ defmodule Nerves.ErlinitTest do
   test "parse example file", context do
     in_tmp(context.test, fn ->
       erlinit_opts = Erlinit.decode_config(@example)
-      assert erlinit_opts[:ctty] == "null"
-      refute erlinit_opts[:verbose]
-      assert erlinit_opts[:warn_unused_tty]
+
+      assert erlinit_opts == [
+               ctty: "null",
+               warn_unused_tty: true,
+               alternate_exec: "/usr/bin/nbtty --tty /dev/ttyGS0 --wait-input",
+               uid: 100,
+               gid: 200,
+               update_clock: true,
+               hang_on_exit: true,
+               graceful_shutdown_timeout: 15000,
+               run_on_exit: "/bin/sh",
+               env:
+                 "LANG=en_US.UTF-8;LANGUAGE=en;ERL_INETRC=/etc/erl_inetrc;ERL_CRASH_DUMP=/root/crash.dump",
+               mount: "/dev/mmcblk0p1:/boot:vfat:ro,nodev,noexec,nosuid:",
+               mount: "/dev/mmcblk0p3:/root:ext4:nodev:",
+               mount: "configfs:/sys/kernel/config:configfs:nodev,noexec,nosuid:",
+               mount: "pstore:/sys/fs/pstore:pstore:nodev,noexec,nosuid:",
+               mount: "tmpfs:/sys/fs/cgroup:tmpfs:nodev,noexec,nosuid:mode=755,size=1024k",
+               mount: "cpu:/sys/fs/cgroup/cpu:cgroup:nodev,noexec,nosuid:cpu",
+               mount: "memory:/sys/fs/cgroup/memory:cgroup:nodev,noexec,nosuid:memory",
+               release_path: "/srv/erlang",
+               uniqueid_exec: "/usr/bin/boardid",
+               hostname_pattern: "nerves-%s",
+               boot: "shoehorn"
+             ]
     end)
   end
 
@@ -115,6 +140,49 @@ defmodule Nerves.ErlinitTest do
     in_tmp(context.test, fn ->
       erlinit_opts = Erlinit.decode_config(@example)
       assert Erlinit.merge_opts(erlinit_opts, ctty: "1234")[:ctty] == "1234"
+    end)
+  end
+
+  test "strings are quoted", context do
+    in_tmp(context.test, fn ->
+      new_alternate_exec = "/usr/bin/nbtty --tty /dev/ttyAMA0 --wait-input"
+      erlinit_opts = Erlinit.decode_config(@example)
+      merged_opts = Erlinit.merge_opts(erlinit_opts, alternate_exec: new_alternate_exec)
+      assert merged_opts[:alternate_exec] == new_alternate_exec
+      assert Erlinit.encode_config(merged_opts) =~ "--alternate-exec \"#{new_alternate_exec}\""
+    end)
+  end
+
+  test "render example", context do
+    in_tmp(context.test, fn ->
+      result =
+        @example
+        |> Erlinit.decode_config()
+        |> Erlinit.encode_config()
+
+      assert result == """
+             --ctty null
+             --warn-unused-tty
+             --alternate-exec \"/usr/bin/nbtty --tty /dev/ttyGS0 --wait-input\"
+             --uid 100
+             --gid 200
+             --update-clock
+             --hang-on-exit
+             --graceful-shutdown-timeout 15000
+             --run-on-exit /bin/sh
+             --env LANG=en_US.UTF-8;LANGUAGE=en;ERL_INETRC=/etc/erl_inetrc;ERL_CRASH_DUMP=/root/crash.dump
+             --mount /dev/mmcblk0p1:/boot:vfat:ro,nodev,noexec,nosuid:
+             --mount /dev/mmcblk0p3:/root:ext4:nodev:
+             --mount configfs:/sys/kernel/config:configfs:nodev,noexec,nosuid:
+             --mount pstore:/sys/fs/pstore:pstore:nodev,noexec,nosuid:
+             --mount tmpfs:/sys/fs/cgroup:tmpfs:nodev,noexec,nosuid:mode=755,size=1024k
+             --mount cpu:/sys/fs/cgroup/cpu:cgroup:nodev,noexec,nosuid:cpu
+             --mount memory:/sys/fs/cgroup/memory:cgroup:nodev,noexec,nosuid:memory
+             --release-path /srv/erlang
+             --uniqueid-exec /usr/bin/boardid
+             --hostname-pattern nerves-%s
+             --boot shoehorn
+             """
     end)
   end
 end


### PR DESCRIPTION
This fixes and adds unit tests to the following erlinit.config override
support:

* Handle string values with spaces - previously they were split and
  appeared as separate options to erlinit when they were not. This
  affected `:alternate_exec` in particular.
* Handle trailing comments - previously an inline comment could be
  included in the value
* Trim whitespace - previously leading whitespace could cause parameters
  to be ignored. Whitespace in other places could also lead to weirdness
  with values.
* Quote strings with spaces when encodeding - previously, they weren't
  quoted and that would mess up erlinit (understandably)

This also converts the encoder to construct the result using iodata for
the intermediate work. The iodata is flattened at the end to a string to
avoid changing APIs.