### PR TITLE
Do not depend on base dir

### DIFF
--- a/lib/nerves/env.ex
+++ b/lib/nerves/env.ex
@@ -79,7 +79,7 @@ defmodule Nerves.Env do
   @spec data_dir() :: path :: String.t()
   def data_dir do
     case System.get_env("XDG_DATA_HOME") do
-      directory when is_binary(directory) -> :filename.basedir(:user_data, "nerves")
+      directory when is_binary(directory) -> Path.join(directory, "nerves")
       nil -> Path.expand("~/.nerves")
     end
   end


### PR DESCRIPTION
Depending on base dir does not allow the `XDG_DATA_HOME` env variable to override the location of the data directory.