### PR TITLE
Add WSL installation instructions

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -39,6 +39,20 @@ faster you can compile a custom Nerves system.
 
 Now skip to the instructions for all platforms below.
 
+## Windows Subsystem for Linux (WSL)
+Make sure that your `/etc/wsl.conf` file looks something like the following. If the file does not exist yet, create it.
+
+```
+[interop]
+enabled=true # enable launch of Windows binaries
+appendWindowsPath=true # append Windows path to $PATH variable
+```
+
+If you changed the WSL config don't forget to reboot the WSL by running  `wsl --shutdown` in PowerShell and starting the WSL shell again.
+
+Now follow the Linux instructions below.
+> Note that you must follow both the Linux and the Windows `fwup` installation instructions.
+
 ## Linux
 
 First, install a few packages using your package manager:


### PR DESCRIPTION
I've had a hard time getting nerves to build under WSL 2 as it kept showing the following error message when running `mix firmware`:
```
** (Mix) fwup.exe is required by the Nerves tooling.
Please see https://hexdocs.pm/nerves/installation.html for installation
instructions.
```

This PR adds a short section to the installation instructions that should help people with more recent WSL releases to figure out the right setup right away :)