### PR TITLE
Add "mix firmware.unpack"

### DIFF
--- a/lib/mix/tasks/firmware.unpack.ex
+++ b/lib/mix/tasks/firmware.unpack.ex
@@ -1,0 +1,94 @@
+defmodule Mix.Tasks.Firmware.Unpack do
+  use Mix.Task
+  import Mix.Nerves.Utils
+  alias Mix.Nerves.Preflight
+
+  @shortdoc "Unpack a firmware bundle for inspection"
+
+  @moduledoc """
+  Unpack the firmware so that its contents can be inspected locally.
+
+  ## Usage
+
+      mix firmware.unpack [output directory]
+
+  If not supplied, the output directory will be based off the OTP application
+  name.
+
+  ## Examples
+
+  ```
+  # Create a firmware bundle. It will be under the _build directory
+  mix firmware
+
+  # Unpack it
+  mix firmware.unpack firmware_contents
+
+  # Inspect it
+  ls firmware_contents
+  ```
+  """
+
+  @impl true
+  def run([output_path]) do
+    Preflight.check!()
+    debug_info("Nerves Firmware Unpack")
+
+    config = Mix.Project.config()
+    otp_app = config[:app]
+    target = mix_target()
+
+    images_path =
+      (config[:images_path] || Path.join([Mix.Project.build_path(), "nerves", "images"]))
+      |> Path.expand()
+
+    _ = check_nerves_system_is_set!()
+
+    _ = check_nerves_toolchain_is_set!()
+
+    fw = "#{images_path}/#{otp_app}.fw"
+
+    unless File.exists?(fw) do
+      Mix.raise("Firmware for target #{target} not found at #{fw} run `mix firmware` to build")
+    end
+
+    unpack(fw, output_path)
+  end
+
+  def run([]) do
+    config = Mix.Project.config()
+    otp_app = config[:app]
+    target = mix_target()
+
+    file = "#{otp_app}-#{target}"
+    run([file])
+  end
+
+  def run(_args) do
+    Mix.raise("""
+    mix firmware.unpack [output path]
+
+    See mix help firmware.unpack for more info
+    """)
+
+    Mix.Task.run("help", ["firmware.unpack"])
+  end
+
+  defp unpack(fw, output_path) do
+    abs_output_path = Path.expand(output_path)
+    rootfs_output_path = Path.join(abs_output_path, "rootfs")
+    rootfs_image = Path.join([abs_output_path, "data", "rootfs.img"])
+
+    Mix.shell().info("Unpacking to #{output_path}...")
+
+    _ = File.rm_rf!(abs_output_path)
+
+    File.mkdir_p!(abs_output_path)
+
+    {_, 0} = shell("unzip", [fw, "-d", abs_output_path])
+
+    {_, 0} = shell("unsquashfs", ["-d", rootfs_output_path, rootfs_image])
+
+    :ok
+  end
+end


### PR DESCRIPTION
This command unpacks generated `.fw` files so that it's easy to inspect
the root filesystem and other .fw information on the host system.

Here's an example:

```sh
$ mix firmware.unpack

Nerves environment
  MIX_TARGET:   rpi0
  MIX_ENV:      dev

Unpacking to circuits_quickstart-rpi0...
Archive:  /Users/fhunleth/nerves/circuits/circuits_quickstart/_build/rpi0_dev/nerves/images/circuits_quickstart.fw
  inflating: /Users/fhunleth/nerves/circuits/circuits_quickstart/circuits_quickstart-rpi0/meta.conf
  inflating: /Users/fhunleth/nerves/circuits/circuits_quickstart/circuits_quickstart-rpi0/data/bootcode.bin
  inflating: /Users/fhunleth/nerves/circuits/circuits_quickstart/circuits_quickstart-rpi0/data/fixup.dat
  inflating: /Users/fhunleth/nerves/circuits/circuits_quickstart/circuits_quickstart-rpi0/data/start.elf
  inflating: /Users/fhunleth/nerves/circuits/circuits_quickstart/circuits_quickstart-rpi0/data/config.txt
  inflating: /Users/fhunleth/nerves/circuits/circuits_quickstart/circuits_quickstart-rpi0/data/cmdline.txt
  inflating: /Users/fhunleth/nerves/circuits/circuits_quickstart/circuits_quickstart-rpi0/data/zImage
  inflating: /Users/fhunleth/nerves/circuits/circuits_quickstart/circuits_quickstart-rpi0/data/bcm2708-rpi-zero-w.dtb
  inflating: /Users/fhunleth/nerves/circuits/circuits_quickstart/circuits_quickstart-rpi0/data/bcm2708-rpi-zero.dtb
  inflating: /Users/fhunleth/nerves/circuits/circuits_quickstart/circuits_quickstart-rpi0/data/w1-gpio-pullup.dtbo
  inflating: /Users/fhunleth/nerves/circuits/circuits_quickstart/circuits_quickstart-rpi0/data/dwc2.dtbo
  inflating: /Users/fhunleth/nerves/circuits/circuits_quickstart/circuits_quickstart-rpi0/data/pi3-miniuart-bt.dtbo
  inflating: /Users/fhunleth/nerves/circuits/circuits_quickstart/circuits_quickstart-rpi0/data/ramoops.dtbo
  inflating: /Users/fhunleth/nerves/circuits/circuits_quickstart/circuits_quickstart-rpi0/data/rootfs.img
Parallel unsquashfs: Using 4 processors
2456 inodes (2636 blocks) to write

[=============================================================|] 2636/2636 100%

created 2119 files
created 306 directories
created 337 symlinks
created 0 devices
created 0 fifos

$ ls circuits_quickstart-rpi0/rootfs
bin   dev   lib   media opt   root  sbin  sys   usr
boot  etc   lib32 mnt   proc  run   srv   tmp   var
$ ls circuits_quickstart-rpi0/rootfs/srv/erlang/lib
asn1-5.0.9                 inets-7.1.1                sasl-3.4.1
busybox-0.1.4              kernel-6.5                 shoehorn-0.6.0
circuits_gpio-0.4.3        logger-1.9.2               socket-0.3.13
circuits_i2c-0.3.5         logger-1.9.4               ssh-4.8
circuits_quickstart-0.3.0  mdns_lite-0.6.1            ssl-9.4
circuits_spi-0.1.4         muontrap-0.5.0             stdlib-3.10
circuits_uart-1.4.0        nerves_firmware_ssh2-0.4.4 system_registry-0.8.2
compiler-7.4.9             nerves_runtime-0.10.3      toolshed-0.2.11
crypto-4.6.2               nerves_time-0.3.2          uboot_env-0.1.1
dns-2.1.2                  one_dhcpd-0.2.4            vintage_net-0.7.0
elixir-1.9.2               power_control-0.2.0        vintage_net_direct-0.7.0
elixir-1.9.4               public_key-1.7             vintage_net_ethernet-0.7.0
gen_state_machine-2.0.5    ramoops_logger-0.3.0       vintage_net_wifi-0.7.0
iex-1.9.2                  ring_logger-0.8.0
iex-1.9.4                  runtime_tools-1.14
```