### PR TITLE
Build the firmware for mix firmware.image

### DIFF
--- a/lib/mix/tasks/firmware.image.ex
+++ b/lib/mix/tasks/firmware.image.ex
@@ -32,6 +32,9 @@ defmodule Mix.Tasks.Firmware.Image do
     Preflight.check!()
     debug_info("Nerves Firmware Image")
 
+    # Call "mix firmware" to ensure that the firmware bundle is up-to-date
+    Mix.Task.run("firmware", [])
+
     config = Mix.Project.config()
     otp_app = config[:app]
     target = mix_target()


### PR DESCRIPTION
Invocations of "mix firmware.image" call "mix firmware" implicitly with
this change to avoid situations where the image is made from stale
firmware.

This is analogous to "mix firmware.burn" also calling "mix firmware"
implicitly.