### PR TITLE
Fix issue with artifact base_dir expansion.

### DIFF
--- a/lib/nerves/artifact.ex
+++ b/lib/nerves/artifact.ex
@@ -6,7 +6,6 @@ defmodule Nerves.Artifact do
   """
   alias Nerves.Artifact.{Cache, BuildRunners, Resolvers}
 
-  @path Path.expand("artifacts")
   @checksum_short 7
 
   @doc """
@@ -143,7 +142,7 @@ defmodule Nerves.Artifact do
   """
   @spec base_dir() :: String.t()
   def base_dir() do
-    System.get_env("NERVES_ARTIFACTS_DIR") || Path.join(Nerves.Env.data_dir(), @path)
+    System.get_env("NERVES_ARTIFACTS_DIR") || Path.join(Nerves.Env.data_dir(), "artifacts")
   end
 
   @doc """

--- a/test/nerves/artifact_test.exs
+++ b/test/nerves/artifact_test.exs
@@ -145,4 +145,16 @@ defmodule Nerves.ArtifactTest do
       assert :ok = Mix.Tasks.Nerves.Precompile.run([])
     end)
   end
+
+  describe "artifact base_path" do
+    test "XDG_DATA_HOME" do
+      System.put_env("XDG_DATA_HOME", "xdg_data_home")
+      assert "xdg_data_home/nerves/artifacts" = Nerves.Artifact.base_dir()
+    end
+
+    test "falls back to $HOME/.nerves" do
+      System.delete_env("XDG_DATA_HOME")
+      assert Path.expand("~/.nerves/artifacts") == Nerves.Artifact.base_dir()
+    end
+  end
 end


### PR DESCRIPTION
This fixes the issue where mix deps.get would try to fetch the artifact even though it has already been downloaded.