### PR TITLE
Update erlinit config path for system env var

### DIFF
--- a/lib/nerves/erlinit.ex
+++ b/lib/nerves/erlinit.ex
@@ -78,7 +78,8 @@ defmodule Nerves.Erlinit do
   """
   @spec system_config_file(Nerves.Package.t()) :: {:ok, Path.t()} | {:error, :no_config}
   def system_config_file(%Nerves.Package{path: path}) do
-    file = Path.join(path, "rootfs_overlay/etc/erlinit.config")
+    system_path = System.get_env("NERVES_SYSTEM") || path
+    file = Path.join(system_path, "rootfs_overlay/etc/erlinit.config")
 
     case File.exists?(file) do
       true ->

--- a/test/nerves/erlinit_test.exs
+++ b/test/nerves/erlinit_test.exs
@@ -198,4 +198,18 @@ defmodule Nerves.ErlinitTest do
            # with overrides from the application config
            """ == Mix.Tasks.Firmware.erlinit_config_header(foo: :bar)
   end
+
+  test "NERVES_SYSTEM env var overrides system erlinit path", context do
+    in_tmp(context.test, fn ->
+      path = "rootfs_overlay/etc" |> Path.expand()
+      File.mkdir_p!(path)
+
+      file = Path.join(path, "erlinit.config")
+      File.touch!(file)
+
+      System.put_env("NERVES_SYSTEM", File.cwd!())
+      assert {:ok, file} = Erlinit.system_config_file(%Nerves.Package{path: "foo"})
+      System.delete_env("NERVES_SYSTEM")
+    end)
+  end
 end


### PR DESCRIPTION
If NERVES_SYSTEM is set, look for the erlinit.config file in the system override location instead of the package path.