### PR TITLE
Refactor images_path to centralize in Nerves.Env

### DIFF
--- a/lib/mix/tasks/burn.ex
+++ b/lib/mix/tasks/burn.ex
@@ -154,14 +154,7 @@ defmodule Mix.Tasks.Burn do
         Mix.raise("The firmware file #{fw} does not exist")
 
       _ ->
-        config = Mix.Project.config()
-        otp_app = config[:app]
-
-        images_path =
-          (config[:images_path] || Path.join([Mix.Project.build_path(), "nerves", "images"]))
-          |> Path.expand()
-
-        "#{images_path}/#{otp_app}.fw"
+        Nerves.Env.firmware_path()
     end
   end
 end

--- a/lib/nerves/env.ex
+++ b/lib/nerves/env.ex
@@ -260,6 +260,30 @@ defmodule Nerves.Env do
   end
 
   @doc """
+  The path to where firmware build files are stored
+  This can be overridden in a Mix project by setting the `:images_path` key.
+
+    images_path: "/some/other/location"
+
+  Defaults to (build_path)/nerves/images
+  """
+  @spec images_path(keyword) :: String.t()
+  def images_path(config \\ mix_config()) do
+    (config[:images_path] || Path.join([Mix.Project.build_path(), "nerves", "images"]))
+    |> Path.expand()
+  end
+
+  @doc """
+  The path to the firmware file
+  """
+  @spec firmware_path(keyword) :: String.t()
+  def firmware_path(config \\ mix_config()) do
+    config
+    |> images_path()
+    |> Path.join("#{config[:app]}.fw")
+  end
+
+  @doc """
   Helper function for returning the system type package
   """
   @spec system() :: Nerves.Package.t()
@@ -458,5 +482,9 @@ defmodule Nerves.Env do
       _e ->
         File.exists?(Package.config_path(path))
     end
+  end
+
+  defp mix_config() do
+    Mix.Project.config()
   end
 end

--- a/test/nerves/env_test.exs
+++ b/test/nerves/env_test.exs
@@ -128,4 +128,22 @@ defmodule Nerves.EnvTest do
       end)
     end
   end
+
+  describe "images_path" do
+    test "without overrides" do
+      in_fixture("simple_app", fn ->
+        assert Env.images_path() == Path.join([Mix.Project.build_path(), "nerves", "images"])
+      end)
+    end
+
+    test "override in mix config" do
+      in_fixture("simple_app", fn ->
+        config =
+          Mix.Project.config()
+          |> Keyword.put(:images_path, "/tmp")
+
+        assert Env.images_path(config) == "/tmp"
+      end)
+    end
+  end
 end


### PR DESCRIPTION
This cleans up some code duplication, adds a couple tests, and exposes a place for 3rd party tools to locate firmware build files.