### PR TITLE
Support the aarch64 architecture

### DIFF
--- a/lib/nerves/env.ex
+++ b/lib/nerves/env.ex
@@ -175,15 +175,11 @@ defmodule Nerves.Env do
     arch = List.first(arch)
 
     case arch do
-      <<"win", _tail::binary>> ->
-        "x86_64"
-
-      arch ->
-        if String.contains?(arch, "arm") do
-          "arm"
-        else
-          "x86_64"
-        end
+      <<"win", _rest::binary>> -> "x86_64"
+      <<"arm", _rest::binary>> -> "arm"
+      "aarch64" -> "aarch64"
+      "x86_64" -> "x86_64"
+      _anything_else -> "x86_64"
     end
   end
 

--- a/test/nerves/env_test.exs
+++ b/test/nerves/env_test.exs
@@ -23,6 +23,7 @@ defmodule Nerves.EnvTest do
     assert Env.parse_arch("win32") == "x86_64"
     assert Env.parse_arch("x86_64-apple-darwin14.1.0") == "x86_64"
     assert Env.parse_arch("armv7l-unknown-linux-gnueabihf") == "arm"
+    assert Env.parse_arch("aarch64-unknown-linux-gnu") == "aarch64"
     assert Env.parse_arch("unknown") == "x86_64"
   end
 
@@ -30,6 +31,8 @@ defmodule Nerves.EnvTest do
     assert Env.parse_platform("win32") == "win"
     assert Env.parse_platform("x86_64-apple-darwin14.1.0") == "darwin"
     assert Env.parse_platform("x86_64-unknown-linux-gnu") == "linux"
+    assert Env.parse_platform("armv7l-unknown-linux-gnueabihf") == "linux"
+    assert Env.parse_platform("aarch64-unknown-linux-gnu") == "linux"
 
     assert_raise Mix.Error, fn ->
       Env.parse_platform("unknown")


### PR DESCRIPTION
64-bit ARM machines previously were falling through the x86_64-catchall.
This adds an entry for them since they'll likely appear more often going
forward.