### PR TITLE
Elixir 1.10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
 otp_22_image: &otp_22_image
-  image: erlang:22.0.4
+  image: erlang:22.2.8
 
 otp_21_image: &otp_21_image
-  image: erlang:21.2.2
+  image: erlang:21.3.8
 
 otp_20_image: &otp_20_image
   image: erlang:20.3.8
@@ -27,11 +27,11 @@ defaults: &defaults
 
 version: 2
 jobs:
-  build_elixir_1_9_otp_22:
+  build_elixir_1_10_otp_22:
     docker:
       - <<: *otp_22_image
     environment:
-      ELIXIR_VERSION: 1.9.0-otp-22
+      ELIXIR_VERSION: 1.10.2-otp-22
       LC_ALL: C.UTF-8
     <<: *defaults
     steps:
@@ -43,6 +43,20 @@ jobs:
       - run: mix format --check-formatted
       - run: mix docs
       - run: mix hex.build
+
+  build_elixir_1_9_otp_22:
+    docker:
+      - <<: *otp_22_image
+    environment:
+      ELIXIR_VERSION: 1.9.4-otp-22
+      LC_ALL: C.UTF-8
+    <<: *defaults
+    steps:
+      - checkout
+      - <<: *install_elixir
+      - <<: *install_hex_rebar
+      - run: mix deps.get --only test
+      - run: mix test
 
   build_elixir_1_8_otp_21:
     docker:
@@ -104,6 +118,8 @@ workflows:
   version: 2
   build_test:
     jobs:
+      - build_elixir_1_10_otp_22:
+          context: org-global
       - build_elixir_1_9_otp_22:
           context: org-global
       - build_elixir_1_8_otp_21:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,9 +4,6 @@ otp_22_image: &otp_22_image
 otp_21_image: &otp_21_image
   image: erlang:21.3.8
 
-otp_20_image: &otp_20_image
-  image: erlang:20.3.8
-
 install_elixir: &install_elixir
   run:
     name: Install Elixir
@@ -86,34 +83,6 @@ jobs:
       - run: mix deps.get --only test
       - run: mix test
 
-  build_elixir_1_6_otp_21:
-    docker:
-      - <<: *otp_21_image
-    environment:
-      ELIXIR_VERSION: 1.6.6-otp-21
-      LC_ALL: C.UTF-8
-    <<: *defaults
-    steps:
-      - checkout
-      - <<: *install_elixir
-      - <<: *install_hex_rebar
-      - run: mix deps.get --only test
-      - run: mix test
-
-  build_elixir_1_6_otp_20:
-    docker:
-      - <<: *otp_20_image
-    environment:
-      ELIXIR_VERSION: 1.6.6
-      LC_ALL: C.UTF-8
-    <<: *defaults
-    steps:
-      - checkout
-      - <<: *install_elixir
-      - <<: *install_hex_rebar
-      - run: mix deps.get --only test
-      - run: mix test
-
 workflows:
   version: 2
   build_test:
@@ -125,8 +94,4 @@ workflows:
       - build_elixir_1_8_otp_21:
           context: org-global
       - build_elixir_1_7_otp_21:
-          context: org-global
-      - build_elixir_1_6_otp_21:
-          context: org-global
-      - build_elixir_1_6_otp_20:
           context: org-global

--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ Craft and deploy bulletproof embedded software in Elixir
 ## Host Requirements
 
 * Mac OS 10.10+
-* 64-bit Linux (tested on Debian / Ubuntu / Redhat / CentOS)
+* 64-bit Linux (tested on Debian / Ubuntu / Redhat / CentOS / Arch)
 * Windows 10 with [Windows Subsystem for Linux](https://msdn.microsoft.com/en-us/commandline/wsl/install_guide) (experimental)
 * Raspberry Pi 3 (experimental)
-* Elixir ~> 1.4
+* Elixir ~> 1.7
 
 See [Installation Docs](https://hexdocs.pm/nerves/installation.html) for
 software dependencies.

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -101,10 +101,10 @@ asdf plugin-add elixir
 # latest official Nerves systems are compatible with the versions below. In
 # general, differences in patch releases are harmless. Nerves detects
 # configurations that might not work at compile time.
-asdf install erlang 22.0.7
-asdf install elixir 1.9.1-otp-22
-asdf global erlang 22.0.7
-asdf global elixir 1.9.1-otp-22
+asdf install erlang 22.2.8
+asdf install elixir 1.10.2-otp-22
+asdf global erlang 22.2.8
+asdf global elixir 1.10.2-otp-22
 ```
 
 It is important to update the versions of `hex` and `rebar` used by Elixir,

--- a/lib/nerves.ex
+++ b/lib/nerves.ex
@@ -17,19 +17,18 @@ defmodule Nerves do
     else
       _ ->
         Nerves.Utils.Shell.warn("""
-        Nerves #{version()} requires
-        Elixir:      #{@elixir_version_req}
-        OTP release: #{@otp_version_req}
+        Nerves #{version()} requires at least Elixir #{@elixir_version_req} and Erlang/OTP #{
+          @otp_version_req
+        }.
 
-        Your system has
-        Elixir:      #{elixir_version}
-        OTP release: #{otp_release}
+        Your system has Elixir #{elixir_version} and Erlang/OTP #{otp_release}.
 
-        Please resolve the issue by
-        * Installing a version of Elixir / OTP that is compatible with the
-          Minimal requirements.
-        * Pin your nerves and nerves_bootstrap dependencies to an older
-          version that supports your version of Elixir / OTP.
+        Please resolve this by either:
+
+        1. Installing a compatible version of Elixir and Erlang/OTP
+
+        2. Pinning your nerves and nerves_bootstrap dependencies to
+           older versions.
         """)
 
         :error

--- a/lib/nerves.ex
+++ b/lib/nerves.ex
@@ -1,6 +1,40 @@
 defmodule Nerves do
+  @elixir_version_req ">= 1.7.0"
+  @otp_version_req ">= 21.0.0"
+
   def version, do: unquote(Mix.Project.config()[:version])
   def elixir_version, do: unquote(System.version())
+  def otp_release, do: unquote(System.otp_release())
+
+  def system_requirements(elixir_version \\ nil, otp_release \\ nil) do
+    elixir_version = elixir_version || elixir_version()
+    otp_release = otp_release || otp_release()
+
+    with {:ok, otp_rel_version} <- Version.parse(otp_release <> ".0.0"),
+         true <- Version.match?(elixir_version, @elixir_version_req),
+         true <- Version.match?(otp_rel_version, @otp_version_req) do
+      :ok
+    else
+      _ ->
+        Nerves.Utils.Shell.warn("""
+        Nerves #{version()} requires
+        Elixir:      #{@elixir_version_req}
+        OTP release: #{@otp_version_req}
+
+        Your system has
+        Elixir:      #{elixir_version}
+        OTP release: #{otp_release}
+
+        Please resolve the issue by
+        * Installing a version of Elixir / OTP that is compatible with the
+          Minimal requirements.
+        * Pin your nerves and nerves_bootstrap dependencies to an older
+          version that supports your version of Elixir / OTP.
+        """)
+
+        :error
+    end
+  end
 
   # If distillery is present, load the plugin code
   if Code.ensure_loaded?(Distillery.Releases.Plugin) do

--- a/lib/nerves/env.ex
+++ b/lib/nerves/env.ex
@@ -17,6 +17,7 @@ defmodule Nerves.Env do
   """
   @spec start() :: Agent.on_start()
   def start do
+    Nerves.system_requirements()
     set_source_date_epoch()
     Agent.start_link(fn -> load_packages() end, name: __MODULE__)
   end

--- a/lib/nerves/package/utils/squashfs.ex
+++ b/lib/nerves/package/utils/squashfs.ex
@@ -145,6 +145,7 @@ defmodule Nerves.Package.Utils.Squashfs do
     ])
 
     File.rm_rf!(tmp_dir)
+
     # File.rm!(pseudofile_path)
 
     {:reply, {:ok, path}, s}

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule Nerves.Mixfile do
       source_url: "https://github.com/nerves-project/nerves",
       homepage_url: "http://nerves-project.org/",
       version: "1.5.4",
-      elixir: "~> 1.6.0 or ~> 1.7.3 or ~> 1.8",
+      elixir: "~> 1.7.3 or ~> 1.8",
       elixirc_paths: elixirc_paths(Mix.env()),
       deps: deps(),
       description: description(),

--- a/test/nerves/env_test.exs
+++ b/test/nerves/env_test.exs
@@ -2,6 +2,14 @@ defmodule Nerves.EnvTest do
   use NervesTest.Case, async: false
   alias Nerves.Env
 
+  test "system requirements" do
+    assert :error = Nerves.system_requirements(Version.parse!("1.6.0"), "20")
+    assert :error = Nerves.system_requirements(Version.parse!("1.7.0"), "20")
+    assert :error = Nerves.system_requirements(Version.parse!("1.7.0"), "ABC")
+    assert :ok = Nerves.system_requirements(Version.parse!("1.7.0"), "21")
+    assert :ok = Nerves.system_requirements(Version.parse!("1.10.2"), "22")
+  end
+
   test "populate Nerves env" do
     in_fixture("simple_app", fn ->
       packages =

--- a/test/nerves/mix_test.exs
+++ b/test/nerves/mix_test.exs
@@ -2,18 +2,11 @@ defmodule Nerves.MixTest do
   use NervesTest.Case, async: false
 
   describe "mix burn" do
-    test "raise when passing firmware file that does not exist" do
-      in_fixture("simple_app", fn ->
-        System.put_env("MIX_TARGET", "target")
-
-        ~w(system toolchain system_platform toolchain_platform)
-        |> load_env()
-
+    test "raise when passing firmware file that does not exist", context do
+      in_tmp(context.test, fn ->
         assert_raise Mix.Error, fn ->
-          Mix.Tasks.Burn.run(["--firmware", "/tmp/does_not_exist"])
+          Mix.Tasks.Burn.firmware_file(firmware: "/tmp/does_not_exist")
         end
-
-        System.delete_env("MIX_TARGET")
       end)
     end
 

--- a/test/nerves/utils_test.exs
+++ b/test/nerves/utils_test.exs
@@ -1,5 +1,6 @@
 defmodule Nerves.UtilsTest do
   use NervesTest.Case, async: false
+
   # Special thanks to Hex
 
   alias Nerves.Utils

--- a/test/support/test_case.ex
+++ b/test/support/test_case.ex
@@ -1,6 +1,10 @@
 defmodule NervesTest.Case do
   use ExUnit.CaseTemplate
 
+  @compile {:no_warn_undefined, {Mix, :target, 0}}
+  @compile {:no_warn_undefined, {Mix.State, :clear_cache, 0}}
+  @compile {:no_warn_undefined, {Mix.ProjectStack, :clear_cache, 0}}
+
   using do
     quote do
       import unquote(__MODULE__)
@@ -12,12 +16,27 @@ defmodule NervesTest.Case do
     Application.stop(:nerves_bootstrap)
 
     on_exit(fn ->
+      Application.start(:logger)
       Mix.env(:dev)
+
+      if elixir_minor() > 8 do
+        Mix.target(:host)
+      end
+
       Mix.Task.clear()
       Mix.Shell.Process.flush()
-      Mix.ProjectStack.clear_cache()
+
+      # < Elixir 1.10.0
+      if elixir_minor() < 10 do
+        Mix.ProjectStack.clear_cache()
+      else
+        Mix.State.clear_cache()
+      end
+
       Mix.ProjectStack.clear_stack()
       delete_tmp_paths()
+
+      :ok
     end)
 
     :ok
@@ -34,19 +53,42 @@ defmodule NervesTest.Case do
   end
 
   def in_fixture(which, tmp, function) do
-    dest =
-      tmp_path(tmp)
-      |> Path.join(which)
+    src = fixture_path(which)
+    dest = tmp_path(String.replace(tmp, ":", "_"))
+    flag = String.to_charlist(tmp_path())
 
-    fixture_to_tmp(which, dest)
+    System.put_env("XDG_DATA_HOME", Path.join(dest, ".nerves"))
 
-    System.put_env("XDG_DATA_HOME", tmp_path(tmp))
+    File.rm_rf!(dest)
+    File.mkdir_p!(dest)
+    File.cp_r!(src, dest)
+
+    get_path = :code.get_path()
+    previous = :code.all_loaded()
 
     try do
       File.cd!(dest, function)
     after
-      unload_env()
+      :code.set_path(get_path)
+
+      for {mod, file} <- :code.all_loaded() -- previous,
+          file == [] or (is_list(file) and List.starts_with?(file, flag)) do
+        purge([mod])
+      end
+
+      System.delete_env("XDG_DATA_HOME")
+
+      if elixir_minor() < 10 do
+        unload_env()
+      end
     end
+  end
+
+  def purge(modules) do
+    Enum.each(modules, fn m ->
+      :code.purge(m)
+      :code.delete(m)
+    end)
   end
 
   def in_tmp(which, function) do
@@ -120,5 +162,9 @@ defmodule NervesTest.Case do
   defp delete_tmp_paths do
     tmp = String.to_charlist(tmp_path())
     for path <- :code.get_path(), :string.str(path, tmp) != 0, do: :code.del_path(path)
+  end
+
+  defp elixir_minor() do
+    System.version() |> Version.parse!() |> Map.get(:minor)
   end
 end

--- a/test/support/test_case.ex
+++ b/test/support/test_case.ex
@@ -20,7 +20,7 @@ defmodule NervesTest.Case do
       Mix.env(:dev)
 
       if elixir_minor() > 8 do
-        Mix.target(:host)
+        apply(Mix, :target, [:host])
       end
 
       Mix.Task.clear()


### PR DESCRIPTION
Add support for Elixir 1.10.

This mainly updates the test suite to accommodate for upstream changes in the Mix test suite. This was tested on a rpi0.

This also bumps the "official" versions in the docs to elixir 1.10.2 and OTP 22.2.8