### PR TITLE
Revert "Update erlinit config path for system env var"

### DIFF
--- a/lib/nerves/erlinit.ex
+++ b/lib/nerves/erlinit.ex
@@ -78,8 +78,7 @@ defmodule Nerves.Erlinit do
   """
   @spec system_config_file(Nerves.Package.t()) :: {:ok, Path.t()} | {:error, :no_config}
   def system_config_file(%Nerves.Package{path: path}) do
-    system_path = System.get_env("NERVES_SYSTEM") || path
-    file = Path.join(system_path, "rootfs_overlay/etc/erlinit.config")
+    file = Path.join(path, "rootfs_overlay/etc/erlinit.config")
 
     case File.exists?(file) do
       true ->

--- a/test/nerves/erlinit_test.exs
+++ b/test/nerves/erlinit_test.exs
@@ -198,18 +198,4 @@ defmodule Nerves.ErlinitTest do
            # with overrides from the application config
            """ == Mix.Tasks.Firmware.erlinit_config_header(foo: :bar)
   end
-
-  test "NERVES_SYSTEM env var overrides system erlinit path", context do
-    in_tmp(context.test, fn ->
-      path = "rootfs_overlay/etc" |> Path.expand()
-      File.mkdir_p!(path)
-
-      file = Path.join(path, "erlinit.config")
-      File.touch!(file)
-
-      System.put_env("NERVES_SYSTEM", File.cwd!())
-      assert {:ok, file} = Erlinit.system_config_file(%Nerves.Package{path: "foo"})
-      System.delete_env("NERVES_SYSTEM")
-    end)
-  end
 end


### PR DESCRIPTION
This reverts commit 5ef228de51f18f85fa38797ceef0bd17d7729d2b.

Turns out this doesn't work. The `rootfs_overlay` is unavailable in the system artifact and this commit causes the erlinit.config Mix override to break.