### PR TITLE
Removes instructions related to init_gadget and replaces them with do…

### DIFF
--- a/docs/Getting Started.md
+++ b/docs/Getting Started.md
@@ -188,50 +188,11 @@ environment.
 To end your ssh connection type `exit`, or you can use the `ssh` command
 `<enter>~.`
 
-### RPi3B/B+ wired and wireless Ethernet connections
-
-With the RPi3B/B+, you will need to make a wired or wireless Ethernet
-connection. This can be done with just a few changes to the standard
-`config/config.exs` generated in a new Nerves project.
-
-To use wired Ethernet change the `ifname:` and `address_method` keys:
-
-```elixir
-config :nerves_init_gadget,
-  mdns_domain: "nerves.local",
-  node_name: node_name,
-  node_host: :mdns_domain,
-  ifname: "eth0",
-  address_method: :dhcp
-```
-
-To use wireless change the `ifname:` and `address_method:` keys, and configure
-the wireless settings:
-
-```elixir
-config :nerves_init_gadget,
-  mdns_domain: "nerves.local",
-  node_name: node_name,
-  node_host: :mdns_domain,
-  ifname: "wlan0",
-  address_method: :dhcp
-
-# Configure wireless settings
-
-key_mgmt = System.get_env("NERVES_NETWORK_KEY_MGMT") || "WPA-PSK"
-
-config :nerves_network, :default,
-  wlan0: [
-    ssid: System.get_env("NERVES_NETWORK_SSID"),
-    psk: System.get_env("NERVES_NETWORK_PSK"),
-    key_mgmt: String.to_atom(key_mgmt)
-  ]
-```
-
-You can find additional information on USB gadget mode, wired, and wireless
-network connections in the Nerves [Hello
-Network](https://github.com/nerves-project/nerves_examples/tree/master/hello_network)
-example.
+### Wireless and wired Ethernet connections
+The `config/config.exs` generated in a new Nerves project will setup connections
+for USB and Ethernet by default. Instructions on further configuring them, or to
+configure wireless connections, please refer to the [VintageNet](https://github.com/nerves-networking/vintage_net)
+documentation.
 
 ### Alternate connection methods
 

--- a/docs/Getting Started.md
+++ b/docs/Getting Started.md
@@ -191,7 +191,7 @@ To end your ssh connection type `exit`, or you can use the `ssh` command
 ### Wireless and wired Ethernet connections
 The `config/config.exs` generated in a new Nerves project will setup connections
 for USB and Ethernet by default. Instructions on further configuring them, or to
-configure wireless connections, please refer to the [VintageNet](https://github.com/nerves-networking/vintage_net)
+configure wireless connections, please refer to [Configure networking](https://hexdocs.pm/nerves/user-interfaces.html#configure-networking) or [VintageNet](https://hexdocs.pm/vintage_net)
 documentation.
 
 ### Alternate connection methods

--- a/docs/User Interfaces.md
+++ b/docs/User Interfaces.md
@@ -122,8 +122,11 @@ If you want to use some other network configuration, such as wired or wireless
 Ethernet, please refer to the [`nerves_pack` documentation] and the
 underlying [`vintage_net` documentation] as needed.
 
-[`nerves_pack` documentation]: https://hexdocs.pm/nerves_pack
-[`vintage_net` documentation]: https://hexdocs.pm/vintage_net
+[`nerves_pack`]: https://hexdocs.pm/nerves_pack
+[`VintageNetWifi`]: https://hexdocs.pm/vintage_net_wifi
+[`VintageNetEthernet`]: https://hexdocs.pm/vintage_net_ethernet
+[`VintageNetDirect`]: https://hexdocs.pm/vintage_net_direct
+[`VintageNetMobile`]: https://hexdocs.pm/vintage_net_mobile
 
 ### Configure Phoenix
 

--- a/docs/User Interfaces.md
+++ b/docs/User Interfaces.md
@@ -107,7 +107,7 @@ import_config "../apps/my_app_firmware/config/config.exs"
 
 ### Configure networking
 
-By default, the `my_app_firmware` project will include the `nerves_pack`
+By default, the `my_app_firmware` project will include the [`nerves_pack`]
 dependency, which simplifies the network setup and configuration process. At
 runtime, `nerves_pack` will detect all available interfaces that have not been
 configured and apply defaults for `usb*` and `eth*` interfaces.

--- a/docs/User Interfaces.md
+++ b/docs/User Interfaces.md
@@ -107,7 +107,7 @@ import_config "../apps/my_app_firmware/config/config.exs"
 
 ### Configure networking
 
-By default, the `my_app_firmware` project will include the `nerves_init_gadget`
+By default, the `my_app_firmware` project will include the `nerves_pack`
 dependency, which simplifies the network setup and configuration process. The
 default configuration assumes that we will be using a target device that
 supports USB gadget devices (such as the Raspberry Pi Zero and Raspberry Pi 3
@@ -115,22 +115,11 @@ A+). It configures the virtual Ethernet interface `usb0` to connect to the host
 computer over a USB cable by running a simple DHCP server on the device.
 
 If you want to use some other network configuration, such as wired or wireless
-Ethernet, please refer to the [`nerves_init_gadget` documentation] and the
-underlying [`nerves_network` documentation] as needed.
+Ethernet, please refer to the [`nerves_pack` documentation] and the
+underlying [`vintage_net` documentation] as needed.
 
-[`nerves_init_gadget` documentation]: https://hexdocs.pm/nerves_init_gadget
-[`nerves_network` documentation]: https://hexdocs.pm/nerves_network
-
-```elixir
-# my_app_firmware/config/config.exs
-
-config :nerves_init_gadget,
-  ifname: "usb0",
-  address_method: :dhcpd,
-  mdns_domain: "nerves.local",
-  node_name: node_name,
-  node_host: :mdns_domain
-```
+[`nerves_pack` documentation]: https://hexdocs.pm/nerves_pack
+[`vintage_net` documentation]: https://hexdocs.pm/vintage_net
 
 ### Configure Phoenix
 

--- a/docs/User Interfaces.md
+++ b/docs/User Interfaces.md
@@ -108,11 +108,15 @@ import_config "../apps/my_app_firmware/config/config.exs"
 ### Configure networking
 
 By default, the `my_app_firmware` project will include the `nerves_pack`
-dependency, which simplifies the network setup and configuration process. The
-default configuration assumes that we will be using a target device that
-supports USB gadget devices (such as the Raspberry Pi Zero and Raspberry Pi 3
-A+). It configures the virtual Ethernet interface `usb0` to connect to the host
-computer over a USB cable by running a simple DHCP server on the device.
+dependency, which simplifies the network setup and configuration process. At
+runtime, `nerves_pack` will detect all available interfaces that have not been
+configured and apply defaults for `usb*` and `eth*` interfaces.
+
+For `eth*` interfaces, the device attempts to connect to the network
+with DHCP using `ipv4` addressing.
+
+For `usb*` interfaces, it uses [`vintage_net_direct`] to run a simple DHCP server
+on the device and assign the host an IP address over a USB cable.
 
 If you want to use some other network configuration, such as wired or wireless
 Ethernet, please refer to the [`nerves_pack` documentation] and the


### PR DESCRIPTION
…cumentation for nerves_pack

This might be too simple. I opted to link to the documentation for nerves pack and vintage net instead of duplicating it here.
Also, there used to be examples in nerves_network. I am not sure if those are still useful or not. if not, perhaps it would be good to create some new examples.