### PR TITLE
Require fwup 1.5 or later

### DIFF
--- a/lib/mix/nerves/preflight.ex
+++ b/lib/mix/nerves/preflight.ex
@@ -1,7 +1,7 @@
 defmodule Mix.Nerves.Preflight do
   alias Nerves.Utils.WSL
 
-  @fwup_semver "~> 1.2.5 or ~> 1.3"
+  @fwup_semver "~> 1.5"
 
   def check! do
     :os.type()


### PR DESCRIPTION
While most users won't need 1.5, updating to it brings in fixes and
includes GPT and SOURCE_DATA_EPOCH support which will be nice to expect.

Fwup 1.5 was released November 16, 2019.