### PR TITLE
Update /CONTRIBUTING.md to /.github/CONTRIBUTING.md on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ binary.  On Arch Linux systems, this is in `/usr/lib/ssh/ssh-askpass`
 This project exists thanks to all the people who contribute.
 <a href="https://github.com/nerves-project/nerves/graphs/contributors"><img src="https://opencollective.com/nerves-project/contributors.svg?width=890" /></a>
 
-Please see our [Contributing Guide](/CONTRIBUTING.md) for details on how you can
+Please see our [Contributing Guide](/.github/CONTRIBUTING.md) for details on how you can
 contribute in various ways.
 
 ## Gold Sponsors


### PR DESCRIPTION
70065de93b4159b9926000bce2587643305e2072 moves CONTRIBUTING.md .
But the link of 'Contributing Guide' keeps old.