### PR TITLE
Add pkg-config to installation instructions

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -25,7 +25,7 @@ Just run the following:
 
 ```bash
 brew update
-brew install fwup squashfs coreutils xz
+brew install fwup squashfs coreutils xz pkg-config
 ```
 
 Optionally, if you want to build custom Nerves Systems, you'll also need to
@@ -44,7 +44,7 @@ Now skip to the instructions for all platforms below.
 First, install a few packages using your package manager:
 
 ```bash
-sudo apt install build-essential automake autoconf git squashfs-tools ssh-askpass
+sudo apt install build-essential automake autoconf git squashfs-tools ssh-askpass pkg-config
 ```
 
 If you're curious, `squashfs-tools` will be used by Nerves to create root


### PR DESCRIPTION
Since switching to `nerves_pack`,`vintage_net_wifi` is included by default and requires pkg-config to be installed on the host system.

Fixes:
```
==> vintage_net_wifi
Makefile:53: *** pkg-config required to build. Install by running "brew install pkg-config".  Stop.
could not compile dependency :vintage_net_wifi, "mix compile" failed. You can recompile this dependency with "mix deps.compile vintage_net_wifi", update it with "mix deps.update vintage_net_wifi" or clean it with "mix deps.clean vintage_net_wifi"
```