### PR TITLE
Handle local system compilation via mix.firmware

### DIFF
--- a/docs/Customizing Systems.md
+++ b/docs/Customizing Systems.md
@@ -130,10 +130,14 @@ mix nerves.new your_project --target rpi3
 
       # Dependencies for specific targets
       {:nerves_system_rpi3, "~> 1.6", runtime: false, targets: :rpi},
-      {:custom_rpi3, path: "../custom_rpi3", runtime: false, targets: :custom_rpi3}, # <===
+      {:custom_rpi3, path: "../custom_rpi3", runtime: false, targets: :custom_rpi3, nerves: [compile: true]}, # <===
     ]
   end
 ```
+
+> NOTE: Including the `nerves: [compile: true]` option in your dependency will cause the system to be compiled
+> automatically. If you don't want this behavior, remove this option and you will need to manually compile the
+> system via the `mix compile` task before building firmware with it
 
 Set your `MIX_TARGET` to refer to your custom system and build your firmware.
 

--- a/lib/mix/tasks/firmware.ex
+++ b/lib/mix/tasks/firmware.ex
@@ -61,6 +61,10 @@ defmodule Mix.Tasks.Firmware do
       end
     end
 
+    # By this point, paths have already been loaded.
+    # We just want to ensure any custom systems are compiled
+    # via the precompile checks
+    Mix.Task.run("nerves.precompile", ["--no-loadpaths"])
     Mix.Task.run("compile", [])
 
     Mix.Nerves.IO.shell_info("Building OTP Release...")


### PR DESCRIPTION
For https://github.com/nerves-project/nerves/issues/395
See https://github.com/nerves-project/nerves/issues/395#issuecomment-607398618 for more info.

This allows a local, uncompiled system to pass the Env check so that it can be run through the precompile check later on. This will give a better warning if the system has not be compiled, or will trigger compilation if the `nerves: [compile: true]` option is enabled in the dependency