### PR TITLE
Add curl to the installation instructions

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -44,7 +44,7 @@ Now skip to the instructions for all platforms below.
 First, install a few packages using your package manager:
 
 ```bash
-sudo apt install build-essential automake autoconf git squashfs-tools ssh-askpass pkg-config
+sudo apt install build-essential automake autoconf git squashfs-tools ssh-askpass pkg-config curl
 ```
 
 If you're curious, `squashfs-tools` will be used by Nerves to create root


### PR DESCRIPTION
ASDF uses curl to download Kerl. It was found that on a fresh install of Ubuntu 19.10, curl was not installed by default.