### PR TITLE
erlang/otp: bump to v22.3.2 in install  doc

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,5 @@
 otp_22_image: &otp_22_image
-  image: erlang:22.2.8
+  image: erlang:22.3.2
 
 otp_21_image: &otp_21_image
   image: erlang:21.3.8

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -135,9 +135,9 @@ asdf plugin-add elixir
 # latest official Nerves systems are compatible with the versions below. In
 # general, differences in patch releases are harmless. Nerves detects
 # configurations that might not work at compile time.
-asdf install erlang 22.2.8
+asdf install erlang 22.3.2
 asdf install elixir 1.10.2-otp-22
-asdf global erlang 22.2.8
+asdf global erlang 22.3.2
 asdf global elixir 1.10.2-otp-22
 ```
 


### PR DESCRIPTION
Fixes https://github.com/nerves-project/nerves/issues/516