### PR TITLE
Clean the release directory

### DIFF
--- a/lib/nerves/release.ex
+++ b/lib/nerves/release.ex
@@ -12,6 +12,8 @@ defmodule Nerves.Release do
         steps: release.steps ++ [&Nerves.Release.finalize/1]
     }
 
+    File.rm_rf!(release.path)
+
     if Code.ensure_loaded?(Shoehorn.Release) do
       apply(Shoehorn.Release, :init, [release])
     else


### PR DESCRIPTION
This will clear out the release directory and prevent it from accumulating upgraded libraries / unnecessary OTP applications over time.