### PR TITLE
Resolve strange link behavior in documentation

### DIFF
--- a/docs/Targets.md
+++ b/docs/Targets.md
@@ -31,7 +31,7 @@ If you can find an existing Buildroot configuration for your intended hardware a
 1. Follow their procedure and confirm your target boots (independent of Nerves).
 
 2. Figure out how to get everything working with the version of Buildroot Nerves uses.
-    See [the `NERVES_BR_VERSION` variable in `create-build.sh`](https://github.com/nerves-project/nerves_system_br/blob/main/create-build.sh).
+    See the [`NERVES_BR_VERSION` variable in `create-build.sh`](https://github.com/nerves-project/nerves_system_br/blob/main/create-build.sh).
 
   * Look for packages and board configs can need to be copied into your System.
   * Look for patches to existing packages that are needed.


### PR DESCRIPTION
Hey y'all,

I was reading through the Nerves pages on HexDocs, and came across this weird link in the [Targets](https://hexdocs.pm/nerves/targets.html#content) page under the [Supporting New Target Hardware](https://hexdocs.pm/nerves/targets.html#supporting-new-target-hardware) header:

> See [create-build.sh variable in NERVES_BR_VERSIONthe](https://github.com/nerves-project/nerves_system_br/blob/master/create-build.sh).

I took a peek at the `docs/Target.md` file to see what's up and everything looks fine there:

> See [the NERVES_BR_VERSION variable in create-build.sh](https://github.com/nerves-project/nerves_system_br/blob/master/create-build.sh).

I generated the docs locally to see what would happen, and ended up with the same weird link as above.  Maybe an ExDoc bug? In the meantime, I just took `the` out of the hyperlink, and the html renders without this odd behavior. 

Are we ok with this fix?