### PR TITLE
add Experimental Features to docs when publishing

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -58,6 +58,7 @@ defmodule Nerves.MixProject do
         "docs/Updating Projects.md",
         "docs/Internals.md",
         "docs/Customizing Systems.md",
+        "docs/Experimental Features.md",
         "CHANGELOG.md"
       ],
       source_ref: "v#{@version}",


### PR DESCRIPTION
We have this doc, but it doesn't show on hexdocs.pm

Is this on purpose? If not, here's the change. Once merged we can do `mix hex.publish docs` to just push this up for use