### PR TITLE
Fix rootfs_priorities file creation and add test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,12 @@ install_hex_rebar: &install_hex_rebar
       mix local.hex --force
       mix local.rebar --force
 
+install_nerves_bootstrap: &install_nerves_bootstrap
+  run:
+    name: Install nerves_bootstrap
+    command: |
+      mix archive.install hex nerves_bootstrap
+
 defaults: &defaults
   working_directory: ~/repo
 
@@ -38,6 +44,7 @@ jobs:
       - checkout
       - <<: *install_elixir
       - <<: *install_hex_rebar
+      - <<: *install_nerves_bootstrap
       - run: mix deps.get --only test
       - run: mix test
       - run: mix format --check-formatted
@@ -55,6 +62,7 @@ jobs:
       - checkout
       - <<: *install_elixir
       - <<: *install_hex_rebar
+      - <<: *install_nerves_bootstrap
       - run: mix deps.get --only test
       - run: mix test
 
@@ -69,34 +77,7 @@ jobs:
       - checkout
       - <<: *install_elixir
       - <<: *install_hex_rebar
-      - run: mix deps.get --only test
-      - run: mix test
-
-  build_elixir_1_8_otp_21:
-    docker:
-      - <<: *otp_21_image
-    environment:
-      ELIXIR_VERSION: 1.8.2-otp-21
-      LC_ALL: C.UTF-8
-    <<: *defaults
-    steps:
-      - checkout
-      - <<: *install_elixir
-      - <<: *install_hex_rebar
-      - run: mix deps.get --only test
-      - run: mix test
-
-  build_elixir_1_7_otp_21:
-    docker:
-      - <<: *otp_21_image
-    environment:
-      ELIXIR_VERSION: 1.7.4-otp-21
-      LC_ALL: C.UTF-8
-    <<: *defaults
-    steps:
-      - checkout
-      - <<: *install_elixir
-      - <<: *install_hex_rebar
+      - <<: *install_nerves_bootstrap
       - run: mix deps.get --only test
       - run: mix test
 
@@ -109,8 +90,4 @@ workflows:
       - build_elixir_1_10_otp_22:
           context: org-global
       - build_elixir_1_9_otp_22:
-          context: org-global
-      - build_elixir_1_8_otp_21:
-          context: org-global
-      - build_elixir_1_7_otp_21:
           context: org-global

--- a/lib/nerves/release.ex
+++ b/lib/nerves/release.ex
@@ -53,6 +53,8 @@ defmodule Nerves.Release do
   def write_rootfs_priorities(applications, host_release_path, bootfile) do
     target_release_path = @target_release_path
 
+    applications = normalize_applications(applications)
+
     {:script, _, boot_script} = :erlang.binary_to_term(bootfile)
 
     target_beam_files = target_beam_files(boot_script, host_release_path, target_release_path)
@@ -175,5 +177,12 @@ defmodule Nerves.Release do
     Path.join(["/", target_release_path, path])
     |> Path.expand(target_release_path)
     |> String.trim_leading("/")
+  end
+
+  defp normalize_applications(applications) do
+    Enum.map(applications, fn
+      {app, opts} ->
+        {to_string(app), to_string(opts[:vsn]), Path.expand(to_string(opts[:path]))}
+    end)
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Nerves.MixProject do
   use Mix.Project
 
-  @version "1.6.5"
+  @version "1.7.0"
   @source_url "https://github.com/nerves-project/nerves"
 
   def project do

--- a/test/fixtures/release_app/config/config.exs
+++ b/test/fixtures/release_app/config/config.exs
@@ -1,0 +1,2 @@
+import Config
+Application.start(:nerves_bootstrap)

--- a/test/fixtures/release_app/mix.exs
+++ b/test/fixtures/release_app/mix.exs
@@ -1,0 +1,32 @@
+defmodule ReleaseApp.Fixture do
+  use Mix.Project
+
+  def project do
+    [
+      app: :release_app,
+      version: "0.1.0",
+      deps: deps(),
+      releases: [{:release_app, release()}],
+    ]
+  end
+
+  def application do
+    [applications: []]
+  end
+
+  defp deps do
+    [
+      {:nerves, path: System.get_env("NERVES_PATH") || "../../../"},
+      {:shoehorn, "~> 0.6"},
+      {:system, path: "../system", targets: :target}
+    ]
+  end
+
+  def release do
+    [
+      overwrite: true,
+      steps: [&Nerves.Release.init/1, :assemble],
+      strip_beams: true
+    ]
+  end
+end

--- a/test/nerves/mix_test.exs
+++ b/test/nerves/mix_test.exs
@@ -1,5 +1,5 @@
 defmodule Nerves.MixTest do
-  use NervesTest.Case
+  use NervesTest.Case, async: false
 
   describe "mix burn" do
     test "raise when passing firmware file that does not exist", context do
@@ -15,6 +15,19 @@ defmodule Nerves.MixTest do
         fw = "tmp.fw"
         File.touch(fw)
         assert Path.expand(fw) == Mix.Tasks.Burn.firmware_file(firmware: fw)
+      end)
+    end
+  end
+
+  describe "mix firmware" do
+    test "can create a release", _context do
+      in_fixture("release_app", fn ->
+        packages = ~w(system toolchain system_platform toolchain_platform)
+
+        _ = load_env(packages)
+
+        Mix.Tasks.Deps.Get.run([])
+       assert {_, 0} = Nerves.Port.cmd("mix", ["release"], [env: [{"MIX_TARGET", "target"}]])
       end)
     end
   end


### PR DESCRIPTION
This fixes rootfs priority file creation logic that was broken when removing distillery, adds a end to end test. 