### PR TITLE
Don't silently drop unknown erlinit options

### DIFF
--- a/lib/nerves/erlinit.ex
+++ b/lib/nerves/erlinit.ex
@@ -105,7 +105,14 @@ defmodule Nerves.Erlinit do
       |> Enum.map(&String.trim/1)
       |> Enum.map(&trim_quoted_string/1)
 
-    {opts, _, _} = OptionParser.parse(argv, switches: @switches, aliases: @aliases)
+    # `allow_nonexistent_atoms: true` allows unknown erlinit options to pass through.
+    {opts, _, _} =
+      OptionParser.parse(argv,
+        switches: @switches,
+        aliases: @aliases,
+        allow_nonexistent_atoms: true
+      )
+
     opts
   end
 

--- a/test/nerves/erlinit_test.exs
+++ b/test/nerves/erlinit_test.exs
@@ -80,6 +80,9 @@ defmodule Nerves.ErlinitTest do
   # shoehorn OTP release up first. If shoehorn isn't around, erlinit fails back
   # to the main OTP release.
   --boot shoehorn
+
+  # Test that unknown erlinit options are passed through unharmed
+  --unknown-erlinit-option 1234
   """
 
   test "parse example file", context do
@@ -108,7 +111,8 @@ defmodule Nerves.ErlinitTest do
                release_path: "/srv/erlang",
                uniqueid_exec: "/usr/bin/boardid",
                hostname_pattern: "nerves-%s",
-               boot: "shoehorn"
+               boot: "shoehorn",
+               unknown_erlinit_option: "1234"
              ]
     end)
   end
@@ -182,6 +186,7 @@ defmodule Nerves.ErlinitTest do
              --uniqueid-exec /usr/bin/boardid
              --hostname-pattern nerves-%s
              --boot shoehorn
+             --unknown-erlinit-option 1234
              """
     end)
   end


### PR DESCRIPTION
OptionParser silently drops options that it doesn't know. This is a
"feature" since options are turned into atoms and the Erlang VM doesn't
GC atoms. However, this is not a feature for `erlinit` since it prevents
possibly valid options from making their way to the target. Exhausting
the atom pool is not an issue, since this is a compilation tool and not
a long-lived server.