### PR TITLE
Add :shutdown_report to erlinit options

### DIFF
--- a/docs/Advanced Configuration.md
+++ b/docs/Advanced Configuration.md
@@ -444,7 +444,8 @@ The following is a list of all options that can be specified:
   update_clock: boolean(),
   verbose: boolean(),
   warn_unused_tty: boolean(),
-  working_directory: Path.t()
+  working_directory: Path.t(),
+  shutdown_report: Path.t()
 ]
 ```
 

--- a/lib/nerves/erlinit.ex
+++ b/lib/nerves/erlinit.ex
@@ -30,7 +30,8 @@ defmodule Nerves.Erlinit do
     update_clock: :boolean,
     verbose: :boolean,
     warn_unused_tty: :boolean,
-    working_directory: :string
+    working_directory: :string,
+    shutdown_report: :string
   ]
 
   @aliases [
@@ -70,7 +71,8 @@ defmodule Nerves.Erlinit do
           update_clock: boolean(),
           verbose: boolean(),
           warn_unused_tty: boolean(),
-          working_directory: Path.t()
+          working_directory: Path.t(),
+          shutdown_report: Path.t()
         ]
 
   @doc """


### PR DESCRIPTION
The `:shutdown_report` option lets you specify a path that `erlinit` can
use to write a report on why the system powered off or rebooted. This
report can be useful when debugging unexpected exits from the Erlang VM.