### PR TITLE
Require fwup 1.8 or later

### DIFF
--- a/lib/mix/nerves/preflight.ex
+++ b/lib/mix/nerves/preflight.ex
@@ -1,7 +1,7 @@
 defmodule Mix.Nerves.Preflight do
   alias Nerves.Utils.WSL
 
-  @fwup_semver "~> 1.5"
+  @fwup_semver "~> 1.8"
 
   def check! do
     :os.type()


### PR DESCRIPTION
While most users won't need 1.8, updating to it brings in useful fixes for autodetecting SDCards and
verifying writes. It also brings in VCDIFF support which will be useful
as people start experimenting with binary diff firmware updates.

Fwup 1.8.1 was released July 15, 2020.