### PR TITLE
Require Elixir 1.9 or later (from Nerves v1.7.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ Craft and deploy bulletproof embedded software in Elixir
 
 * Mac OS 10.10+
 * 64-bit Linux (tested on Debian / Ubuntu / Redhat / CentOS / Arch)
-* Windows 10 with [Windows Subsystem for Linux](https://msdn.microsoft.com/en-us/commandline/wsl/install_guide) (experimental)
+* Windows 10 with [Windows Subsystem for Linux 2](https://msdn.microsoft.com/en-us/commandline/wsl/install_guide) (experimental)
 * Raspberry Pi 3 (experimental)
-* Elixir ~> 1.7
+* Elixir ~> 1.9
 
 See [Installation Docs](https://hexdocs.pm/nerves/installation.html) for
 software dependencies.


### PR DESCRIPTION
According to the release note, the minimum supported version of Elixir is now version 1.9.
And also, WSL "2" is recommended when we use Windows as the host.