### PR TITLE
Change error advice around compilation issues, especially from an Umbrella project

### DIFF
--- a/lib/mix/tasks/compile.nerves_package.ex
+++ b/lib/mix/tasks/compile.nerves_package.ex
@@ -47,32 +47,24 @@ defmodule Mix.Tasks.Compile.NervesPackage do
 
   def bootstrap_check(false) do
     error =
-      cond do
-        in_umbrella?(File.cwd!()) ->
-          """
-          Compiling Nerves packages from the top of umbrella projects isn't supported.
-          Please cd into the application directory and try again.
+      """
+      Compiling Nerves packages requires nerves_bootstrap to be started, which ought to
+      happen in your generated `config.exs`. Please ensure that MIX_TARGET is set in your environment.
+      """ <>
+        if in_umbrella?(File.cwd!()) do
           """
 
-        true ->
-          """
-          Compiling Nerves packages requires nerves_bootstrap to be started.
-          Please ensure that MIX_TARGET is set in your environment and that you have added
-          the proper aliases to your mix.exs file:
+          When compiling from an Umbrella project you must also ensure:
 
-            def project do
-              [
-                # ...
-                aliases: [loadconfig: [&bootstrap/1]],
-              ]
-            end
+          * You are compiling from an application directory, not the root of the Umbrella
 
-            defp bootstrap(args) do
-              Application.start(:nerves_bootstrap)
-              Mix.Task.run("loadconfig", args)
-            end
+          * The Umbrella config (/config/config.exs) imports the generated Nerves config from your
+          Nerves application (import_config "../apps/your_nerves_app/config/config.exs")
+
           """
-      end
+        else
+          ""
+        end
 
     Mix.raise(error)
   end


### PR DESCRIPTION
I haven't done any Nerves in long time, and the updates are awesome. I did get a bit confused by this messaging when trying to debug creating firmware in an Umbrella project though. The problem was that I was not importing the generated `config.exs` file. (Umbrella projects no longer import the application configs by default.)

I thought this might help someone else.

The wording of the  current advice implies that the code has detected that `mix firmware` (or `compile`) is taking place in the base of the umbrella project, and that the fix is to cd into an application and try from there.

In fact `in_umbrella/1` will return true in an umbrella project even if  `mix firmware` is being invoked in application directory. When I checked, the working directory (`File.cwd!`) at this point is in the dependencies: (in  my case `deps/nerves_toolchain_armv6_rpi_linux_gnueabi`).

Also I don't think the advice around aliases is relevant any longer. It looks like this is taken care of in `nerves_bootstrap` which now gets started by the generated `config.exs`.




