### PR TITLE
Run 'make source all' to catch download issues first

### DIFF
--- a/scripts/docker/nerves_system_br/noninteractive-build.sh
+++ b/scripts/docker/nerves_system_br/noninteractive-build.sh
@@ -31,7 +31,7 @@ rm -rf $NERVES_PKG_PLATFORM/buildroot*
 $NERVES_PKG_PLATFORM/create-build.sh $NERVES_PKG_DEFCONFIG $NERVES_PKG_OUTPUT
 
 cd $NERVES_PKG_OUTPUT
-make
+make source all
 
 make system NERVES_ARTIFACT_NAME=$1
 # Uncomment when switching to Artifact Type


### PR DESCRIPTION
If a source code repository or the URL to it is broken, this change will
catch that error at the beginning of the build. This saves quite a bit
of time waiting for a build to complete only to find out that one of the
last packages to build fails due to a download issue.