### PR TITLE
check whether the env is Docker or WSL 2 shell

### DIFF
--- a/lib/nerves/utils/wsl.ex
+++ b/lib/nerves/utils/wsl.ex
@@ -22,19 +22,17 @@ defmodule Nerves.Utils.WSL do
   @doc """
   Returns true if inside a WSL shell environment
   """
-  @spec running_on_wsl?(String.t()) :: boolean
-  def running_on_wsl?(osrelease_path \\ "/proc/sys/kernel/osrelease") do
-    with true <- File.exists?(osrelease_path),
-         {content, _} <- Nerves.Port.cmd("cat", [osrelease_path]) do
-      # Docker Desktop for Windows uses WSL 2 kernel as the back-end
-      # This line checks whether the env is Docker or WSL 2 shell
-      case !File.exists?("/.dockerenv") do
-        true -> Regex.match?(~r/[Mm]icrosoft/, content)
-        false -> false
-      end
-    else
-      _ ->
-        false
+  @spec running_on_wsl?() :: boolean
+  def running_on_wsl?() do
+    # Docker Desktop for Windows uses WSL 2 kernel as the back-end
+    # so also check whether the env is Docker
+    Regex.match?(~r/[Mm]icrosoft/, osrelease()) and not File.exists?("/.dockerenv")
+  end
+
+  defp osrelease() do
+    case File.read("/proc/sys/kernel/osrelease") do
+      {:ok, text} -> text
+      _ -> "unknown"
     end
   end
 

--- a/lib/nerves/utils/wsl.ex
+++ b/lib/nerves/utils/wsl.ex
@@ -26,7 +26,12 @@ defmodule Nerves.Utils.WSL do
   def running_on_wsl?(osrelease_path \\ "/proc/sys/kernel/osrelease") do
     with true <- File.exists?(osrelease_path),
          {content, _} <- Nerves.Port.cmd("cat", [osrelease_path]) do
-      Regex.match?(~r/[Mm]icrosoft/, content)
+      # Docker Desktop for Windows uses WSL 2 kernel as the back-end
+      # This line checks whether the env is Docker or WSL 2 shell
+      case !File.exists?("/.dockerenv") do
+        true -> Regex.match?(~r/[Mm]icrosoft/, content)
+        false -> false
+      end
     else
       _ ->
         false


### PR DESCRIPTION
Docker Desktop for Windows uses WSL 2 kernel as the back-end. 

`/.Dockerenv` exists in the environment where Docker container is running.
We can use this file to check whether the environment is Docker or WSL 2 shell before checking the kernel name from `/proc/sys/kernel/osrelease`. 

This PR will fix #568