### PR TITLE
Minor fix for HexDocs

### DIFF
--- a/lib/nerves/artifact/build_runners/docker.ex
+++ b/lib/nerves/artifact/build_runners/docker.ex
@@ -18,9 +18,9 @@ defmodule Nerves.Artifact.BuildRunners.Docker do
 
   Example:
 
-    build_runner_config: [
-      docker: {"Dockerfile", "my_system:0.1.0"}
-    ]
+      build_runner_config: [
+        docker: {"Dockerfile", "my_system:0.1.0"}
+      ]
 
   ## Volumes and Cache
 


### PR DESCRIPTION
I found the following page with unorganized format.
https://hexdocs.pm/nerves/Nerves.Artifact.BuildRunners.Docker.html#module-images

My PR makes this example code displayed as a block. (checked by `mix docs` locally)
![image](https://user-images.githubusercontent.com/23649012/101430885-3e90b980-3949-11eb-9339-04631535a2ab.png)
