### PR TITLE
Move vm.args.eex check to `Nerves.Release.init/1`

### DIFF
--- a/lib/mix/tasks/firmware.ex
+++ b/lib/mix/tasks/firmware.ex
@@ -39,16 +39,6 @@ defmodule Mix.Tasks.Firmware do
 
     check_nerves_toolchain_is_set!()
 
-    vm_args =
-      File.cwd!()
-      |> Path.join("rel/vm.args.eex")
-
-    if !File.exists?(vm_args) do
-      Mix.raise("""
-        rel/vm.args needs to be moved to rel/vm.args.eex
-      """)
-    end
-
     # By this point, paths have already been loaded.
     # We just want to ensure any custom systems are compiled
     # via the precompile checks

--- a/lib/nerves/release.ex
+++ b/lib/nerves/release.ex
@@ -6,6 +6,14 @@ defmodule Nerves.Release do
   def init(%{options: options} = release) do
     opts = Keyword.merge(options, release_opts())
 
+    vm_args = Mix.Release.rel_templates_path(release, "vm.args.eex")
+
+    if !File.exists?(vm_args) do
+      Mix.raise("""
+        rel/vm.args needs to be moved to #{vm_args}
+      """)
+    end
+
     release = %{
       release
       | options: opts,


### PR DESCRIPTION
This should be all needed to allow for alternative `rel_templates_path`s.

Will try this out hopefully later today.

I'm wondering though if the error message could be a bit more generic. Seems like it was mostly added for the distillery -> releases change, but that's not the only reason the file might be missing.

Close #574 