### PR TITLE
Always call mkdir_p! to catch errors

### DIFF
--- a/lib/mix/tasks/firmware.ex
+++ b/lib/mix/tasks/firmware.ex
@@ -99,7 +99,7 @@ defmodule Mix.Tasks.Firmware do
     end
 
     build_rootfs_overlay = Path.join([Mix.Project.build_path(), "nerves", "rootfs_overlay"])
-    File.mkdir_p(build_rootfs_overlay)
+    File.mkdir_p!(build_rootfs_overlay)
 
     write_erlinit_config(build_rootfs_overlay)
 
@@ -136,7 +136,7 @@ defmodule Mix.Tasks.Firmware do
 
     config
     |> Nerves.Env.images_path()
-    |> File.mkdir_p()
+    |> File.mkdir_p!()
 
     shell(cmd, args, env: env)
     |> result
@@ -234,7 +234,7 @@ defmodule Mix.Tasks.Firmware do
       erlinit_config_file = Path.join(build_overlay, "etc/erlinit.config")
 
       Path.dirname(erlinit_config_file)
-      |> File.mkdir_p()
+      |> File.mkdir_p!()
 
       header = erlinit_config_header(user_opts)
 

--- a/lib/mix/tasks/firmware.patch.ex
+++ b/lib/mix/tasks/firmware.patch.ex
@@ -61,9 +61,9 @@ defmodule Mix.Tasks.Firmware.Patch do
     target_work_dir = Path.join(work_dir, "target")
     output_work_dir = Path.join(work_dir, "output")
 
-    File.mkdir_p(source_work_dir)
-    File.mkdir_p(target_work_dir)
-    File.mkdir_p(Path.join(output_work_dir, "data"))
+    File.mkdir_p!(source_work_dir)
+    File.mkdir_p!(target_work_dir)
+    File.mkdir_p!(Path.join(output_work_dir, "data"))
 
     {_, 0} = shell("unzip", ["-qq", source, "-d", source_work_dir])
     {_, 0} = shell("unzip", ["-qq", target, "-d", target_work_dir])

--- a/lib/nerves/artifact/cache.ex
+++ b/lib/nerves/artifact/cache.ex
@@ -86,7 +86,7 @@ defmodule Nerves.Artifact.Cache do
 
     if valid_checksum?(pkg, checksum) do
       dest = path(pkg)
-      File.mkdir_p(Artifact.base_dir())
+      File.mkdir_p!(Artifact.base_dir())
       File.rm_rf!(dest)
       File.ln_s!(build_path_link, dest)
       true

--- a/lib/nerves/artifact/resolver.ex
+++ b/lib/nerves/artifact/resolver.ex
@@ -18,7 +18,7 @@ defmodule Nerves.Artifact.Resolver do
     case resolver.get(opts) do
       {:ok, data} ->
         file = Nerves.Artifact.download_path(pkg)
-        File.mkdir_p(Nerves.Env.download_dir())
+        File.mkdir_p!(Nerves.Env.download_dir())
         File.write(file, data)
 
         case Nerves.Utils.File.validate(file) do

--- a/test/fixtures/host_tool/lib/host_tool/platform.ex
+++ b/test/fixtures/host_tool/lib/host_tool/platform.ex
@@ -20,9 +20,9 @@ defmodule HostTool.Platform do
 
     build_path
     |> Path.dirname()
-    |> File.mkdir_p()
+    |> File.mkdir_p!()
 
-    File.mkdir_p(priv_dir)
+    File.mkdir_p!(priv_dir)
 
     File.ln_s!(priv_dir, build_path)
 

--- a/test/nerves/cache_test.exs
+++ b/test/nerves/cache_test.exs
@@ -44,10 +44,10 @@ defmodule Nerves.CacheTest do
 
       dl_name = Nerves.Artifact.download_name(package) <> Nerves.Artifact.ext(package)
       dl_path = Path.join(Nerves.Env.download_dir(), dl_name)
-      File.mkdir_p(Nerves.Env.download_dir())
+      File.mkdir_p!(Nerves.Env.download_dir())
 
       working_path = Path.join(File.cwd!(), "archive")
-      File.mkdir_p(working_path)
+      File.mkdir_p!(working_path)
 
       working_path
       |> Path.join("CHECKSUM")
@@ -72,7 +72,7 @@ defmodule Nerves.CacheTest do
 
       dl_name = Nerves.Artifact.download_name(package) <> Nerves.Artifact.ext(package)
       dl_path = Path.join(Nerves.Env.download_dir(), dl_name)
-      File.mkdir_p(Nerves.Env.download_dir())
+      File.mkdir_p!(Nerves.Env.download_dir())
 
       File.touch(dl_path)
       assert File.exists?(dl_path)
@@ -89,7 +89,7 @@ defmodule Nerves.CacheTest do
 
       Nerves.Env.start()
 
-      File.mkdir_p(Nerves.Env.download_dir())
+      File.mkdir_p!(Nerves.Env.download_dir())
 
       System.put_env("NERVES_SYSTEM", Nerves.Env.download_dir())
       Mix.Tasks.Nerves.Artifact.Get.get(:system, [])


### PR DESCRIPTION
This updates all of the unchecked calls to `File.mkdir_p` so that
they raise on error. This is ok, since `mkdir_p!` doesn't raise if the
directory already exists. If the directory can't be created, though,
this now fails immediately rather than at some other place where you
have to infer what the problem was.