### PR TITLE
Update Elixir version requirements

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule Nerves.MixProject do
     [
       app: :nerves,
       version: @version,
-      elixir: "~> 1.7.3 or ~> 1.8",
+      elixir: "~> 1.9.4 or ~> 1.10.0 or ~> 1.11.2",
       elixirc_paths: elixirc_paths(Mix.env()),
       deps: deps(),
       description: description(),


### PR DESCRIPTION
The Elixir requirement string in the `mix.exs` was out of date and
allowed Elixir versions that don't work with Nerves. This updates the
check to require 1.9.4, 1.10.x, and ~> 1.11.2.

Reasoning:

1. Elixir versions prior to 1.9 don't work since mix releases are
   required. Distillery support was removed from Nerves 1.7.0
2. Elixir 1.9.4 is required since that's what we test with on CI. Anyone
   stuck on Elixir 1.9 hopefully can upgrade to 1.9.4.
3. All Elixir 1.10 versions seem to work, so they're all allowed.
4. Elixir 1.11.0 doesn't work due to a mix target issue.
5. Elixir 1.11.1 doesn't work due to an issue with recursive aliases
   that affects poncho projects
6. Elixir 1.11.2 and later versions work

This addresses #583. Note that Elixir only gives a warning when this check fails.