### PR TITLE
Add env to package and export during bootstrap

### DIFF
--- a/docs/Experimental Features.md
+++ b/docs/Experimental Features.md
@@ -214,3 +214,25 @@ such as the Linux kernel and other files that do not change frequently.
 We anticipate that all other files will offer similar support, but we started
 with the first most impactful file, the SquashFS root filesystem, so we can begin
 testing this workflow using devices.
+
+## Nerves package environment variables
+
+Packages can provide custom system environment variables to be exported when
+`Nerves.Env.bootstrap/0` is called. The initial use case for this feature is to
+export system specific information for llvm-based tools. Here is an example from
+`nerves_system_rpi0`
+
+```elixir
+  defp nerves_package do
+    [
+      # ...
+      env: [
+        {"TARGET_ARCH", "arm"},
+        {"TARGET_CPU", "arm1176jzf_s"},
+        {"TARGET_OS", "linux"},
+        {"TARGET_ABI", "gnueabi"}
+      ]
+      # ...
+    ]
+  end
+```

--- a/lib/nerves/env.ex
+++ b/lib/nerves/env.ex
@@ -335,6 +335,7 @@ defmodule Nerves.Env do
   def bootstrap do
     nerves_system_path = system_path()
     nerves_toolchain_path = toolchain_path()
+    packages = Nerves.Env.packages()
 
     [
       {"NERVES_SYSTEM", nerves_system_path},
@@ -392,8 +393,11 @@ defmodule Nerves.Env do
       platform.bootstrap(pkg)
     end
 
+    # Export nerves package env variables
+    Enum.map(packages, &export_package_env/1)
+
     # Bootstrap all other packages who define a platform
-    Nerves.Env.packages()
+    packages
     |> Enum.reject(&(&1 == Nerves.Env.toolchain()))
     |> Enum.reject(&(&1 == Nerves.Env.system()))
     |> Enum.reject(&(&1.platform == nil))
@@ -433,6 +437,10 @@ defmodule Nerves.Env do
   def source_date_epoch() do
     (System.get_env("SOURCE_DATE_EPOCH") || Application.get_env(:nerves, :source_date_epoch))
     |> validate_source_date_epoch()
+  end
+
+  def export_package_env(%Package{env: env}) do
+    System.put_env(env)
   end
 
   defp set_source_date_epoch() do

--- a/lib/nerves/package.ex
+++ b/lib/nerves/package.ex
@@ -10,6 +10,7 @@ defmodule Nerves.Package do
   defstruct app: nil,
             path: nil,
             dep: nil,
+            env: [],
             type: nil,
             version: nil,
             platform: nil,
@@ -24,6 +25,7 @@ defmodule Nerves.Package do
   @type t :: %__MODULE__{
           app: atom,
           path: binary,
+          env: Keyword.t(),
           type:
             :system
             | :package
@@ -53,6 +55,7 @@ defmodule Nerves.Package do
     version = config[:version]
     type = config[:nerves_package][:type]
     compilers = config[:compilers] || Mix.compilers()
+    env = config[:nerves_package][:env] || %{}
 
     unless type do
       Mix.shell().error(
@@ -76,6 +79,7 @@ defmodule Nerves.Package do
     %Package{
       app: app,
       type: type,
+      env: env,
       platform: platform,
       build_runner: build_runner,
       compilers: compilers,

--- a/test/fixtures/system/mix.exs
+++ b/test/fixtures/system/mix.exs
@@ -23,6 +23,9 @@ defmodule System.Mixfile do
       platform_config: [
         defconfig: "nerves_defconfig"
       ],
+      env: [
+        {"FOO", "BAR"}
+      ],
       checksum: package_files()
     ]
   end

--- a/test/nerves/env_test.exs
+++ b/test/nerves/env_test.exs
@@ -157,4 +157,21 @@ defmodule Nerves.EnvTest do
       end)
     end
   end
+
+  describe "package env vars" do
+    test "exported at bootstrap" do
+      in_fixture("simple_app", fn ->
+        ~w(system toolchain system_platform toolchain_platform)
+        |> load_env
+
+        assert System.get_env("FOO") == nil
+
+        Nerves.Env.packages()
+        |> Enum.each(&Nerves.Env.export_package_env/1)
+
+        assert System.get_env("FOO") == "BAR"
+        System.delete_env("FOO")
+      end)
+    end
+  end
 end


### PR DESCRIPTION
Packages can provide custom system environment variables to be exported when
`Nerves.Env.bootstrap/0` is called. The initial use case for this feature is to
export system specific information for llvm-based tools. Here is an example from
`nerves_system_rpi0`

```elixir
  defp nerves_package do
    [
      # ...
      env: [
        {"TARGET_ARCH", "arm"},
        {"TARGET_CPU", "arm1176jzf_s"},
        {"TARGET_OS", "linux"},
        {"TARGET_ABI", "gnueabi"}
      ]
      # ...
    ]
  end
```