### PR TITLE
Clarify artifact mix tasks 

### DIFF
--- a/lib/mix/tasks/nerves.artifact.ex
+++ b/lib/mix/tasks/nerves.artifact.ex
@@ -6,7 +6,11 @@ defmodule Mix.Tasks.Nerves.Artifact do
   require Logger
 
   @moduledoc """
-  Create an artifact for a specified Nerves package.
+  Creates a Nerves artifact for a Nerves system or toolchain
+
+  This compiles the system or toolchain and creates the tar ball containing the
+  result. One would normally post this to GitHub releases or another website so
+  that it can be downloaded when someone uses the system or toolchain.
 
   ## Command line options
 
@@ -24,7 +28,7 @@ defmodule Mix.Tasks.Nerves.Artifact do
 
   """
 
-  @shortdoc "Nerves create artifact"
+  @shortdoc "Creates system and toolchain artifacts for Nerves"
   @recursive true
 
   @switches [path: :string]

--- a/lib/mix/tasks/nerves.artifact.get.ex
+++ b/lib/mix/tasks/nerves.artifact.get.ex
@@ -4,21 +4,7 @@ defmodule Mix.Tasks.Nerves.Artifact.Get do
   alias Nerves.Artifact
   alias Nerves.Artifact.{Cache, Resolver}
 
-  @moduledoc """
-  Fetch the artifacts from one of the artifact_sites
-  This task is typically called as part of the
-  Nerves.Bootstrap aliases during `mix deps.get`
-
-  You can also call into this task by calling
-  `mix nerves.deps.get`
-
-  ## Examples
-
-      $ mix nerves.artifact.get
-
-  """
-
-  @shortdoc "Nerves get artifacts"
+  @moduledoc false
 
   @impl true
   def run(opts) do


### PR DESCRIPTION
This also turns off the docs for `nerves.artifact.get` since this is
better called via `mix deps.get`.