### PR TITLE
Bug fix for double encoding of URL query parameters in OTP-23.2+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+* Bug fixes
+  * Fixes an issue where query parameters would be percent-encoded twice.
+    Packages that use `query_params` argument option to `artifact_sites` could
+    be impacted. For example, packages storing build artifacts in AWS S3
+    require the `X-Amz-Credential` query parameter key whose value
+    includes the reserved character `/`. This symbol is double encoded to
+    `%252F`. This failed on systems with Erlang OTP-23.2 and above.
+    See https://github.com/nerves-project/nerves/issues/604 for additional context.
+
 ## v1.7.4
 
 * Experimental features

--- a/lib/nerves/artifact/resolvers/github_api.ex
+++ b/lib/nerves/artifact/resolvers/github_api.ex
@@ -41,6 +41,8 @@ defmodule Nerves.Artifact.Resolvers.GithubAPI do
 
     Nerves.Utils.Shell.info("  Downloading artifacts from #{url}")
 
+    url = URI.encode(url)
+
     result =
       with {:ok, data} <- HTTPClient.get(http_pid, url, headers: [auth_header], progress?: false),
            %{"assets" => assets} <- Utils.json_decode(data),

--- a/lib/nerves/utils/http_client.ex
+++ b/lib/nerves/utils/http_client.ex
@@ -22,12 +22,7 @@ defmodule Nerves.Utils.HTTPClient do
   end
 
   def get(pid, %URI{} = uri, opts) do
-    url =
-      uri
-      |> URI.to_string()
-      |> URI.encode()
-      |> String.replace("+", "%2B")
-
+    url = URI.to_string(uri)
     get(pid, url, opts)
   end
 

--- a/test/nerves/artifact/resolver_test.exs
+++ b/test/nerves/artifact/resolver_test.exs
@@ -38,6 +38,22 @@ defmodule Nerves.Artifact.ResolverTest do
     end)
   end
 
+  test "artifact resolver can download using query param token auth with reserved chars" do
+    in_fixture("resolver", fn ->
+      set_artifact_path()
+
+      sites = [
+        {:prefix, "http://127.0.0.1:4000/token_auth/",
+         query_params: %{"id" => ":/?#[]@!$&'()&+,;="}}
+      ]
+
+      pkg = %{app: :example, version: "0.1.0", path: "./", config: [artifact_sites: sites]}
+
+      resolvers = Artifact.expand_sites(pkg)
+      assert {:ok, _path} = Artifact.Resolver.get(resolvers, pkg)
+    end)
+  end
+
   test "artifact resolver unauthorized using incorrect token auth" do
     in_fixture("resolver", fn ->
       set_artifact_path()

--- a/test/support/test_server/router.ex
+++ b/test/support/test_server/router.ex
@@ -19,12 +19,17 @@ defmodule Nerves.TestServer.Router do
       |> fetch_query_params()
       |> Map.get(:query_params)
 
-    if Map.get(query_params, "id", "") == "1234" do
-      send_file(conn, 200, System.get_env("TEST_ARTIFACT_TAR"))
-    else
-      conn
-      |> send_resp(401, "Unauthorized")
-      |> Plug.Conn.halt()
+    case Map.get(query_params, "id", "") do
+      "1234" ->
+        send_file(conn, 200, System.get_env("TEST_ARTIFACT_TAR"))
+
+      ":/?#[]@!$&'()&+,;=" ->
+        send_file(conn, 200, System.get_env("TEST_ARTIFACT_TAR"))
+
+      _ ->
+        conn
+        |> send_resp(401, "Unauthorized")
+        |> Plug.Conn.halt()
     end
   end
 


### PR DESCRIPTION
Resolves #604 