### PR TITLE
Bump Erlang and Elixir versions

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -150,10 +150,10 @@ asdf plugin-add elixir
 # latest official Nerves systems are compatible with the versions below. In
 # general, differences in patch releases are harmless. Nerves detects
 # configurations that might not work at compile time.
-asdf install erlang 23.1.4
-asdf install elixir 1.11.2-otp-23
-asdf global erlang 23.1.4
-asdf global elixir 1.11.2-otp-23
+asdf install erlang 23.2.7
+asdf install elixir 1.11.4-otp-23
+asdf global erlang 23.2.7
+asdf global elixir 1.11.4-otp-23
 ```
 
 It is important to update the versions of `hex` and `rebar` used by Elixir,


### PR DESCRIPTION
These versions will match the 1.15.0-based official systems that were
just published.
