### PR TITLE
Clean env before running tests

### DIFF
--- a/test/nerves/cache_test.exs
+++ b/test/nerves/cache_test.exs
@@ -55,6 +55,8 @@ defmodule Nerves.CacheTest do
 
       Nerves.Utils.File.tar(working_path, dl_path)
 
+      System.delete_env("NERVES_SYSTEM")
+
       Mix.Tasks.Nerves.Artifact.Get.get(:system, [])
       output = "  => Trying #{dl_path}"
       assert_receive {:mix_shell, :info, [^output]}

--- a/test/nerves/env_test.exs
+++ b/test/nerves/env_test.exs
@@ -164,7 +164,7 @@ defmodule Nerves.EnvTest do
         ~w(system toolchain system_platform toolchain_platform)
         |> load_env
 
-        assert System.get_env("FOO") == nil
+        System.delete_env("FOO")
 
         Nerves.Env.packages()
         |> Enum.each(&Nerves.Env.export_package_env/1)


### PR DESCRIPTION
Fixes up tests running on CI by unsetting environment variables prior to assert. 