### PR TITLE
Bump erlang version

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -150,9 +150,9 @@ asdf plugin-add elixir
 # latest official Nerves systems are compatible with the versions below. In
 # general, differences in patch releases are harmless. Nerves detects
 # configurations that might not work at compile time.
-asdf install erlang 23.2.7
+asdf install erlang 23.3.1
 asdf install elixir 1.11.4-otp-23
-asdf global erlang 23.2.7
+asdf global erlang 23.3.1
 asdf global elixir 1.11.4-otp-23
 ```
 


### PR DESCRIPTION
Following the 1.7.5 release documentation for [Customizing Your Own Nerves System](https://hexdocs.pm/nerves/customizing-systems.html#getting-setup-to-build-a-system) and had errors ( warnings ) about SSL in erlang 23.1.*.

[Conversation available in slack.](https://elixir-lang.slack.com/archives/C0AB4A879/p1619304867115500)

This doesn't fix the autogenerated hexdocs for v1.7.5, but I noticed the installation.md on main was out of date from my experience and I couldn't build earlier than 23.3.* successfully. So I'm tossing this PR anyways.

Thanks.