### PR TITLE
Add new mix task for generating a gdb wrapper script

### DIFF
--- a/lib/mix/tasks/firmware.gen.gdb.ex
+++ b/lib/mix/tasks/firmware.gen.gdb.ex
@@ -1,0 +1,37 @@
+defmodule Mix.Tasks.Firmware.Gen.Gdb do
+  use Mix.Task
+  import Mix.Nerves.Utils
+  alias Mix.Nerves.Preflight
+
+  @script_name "gdb.sh"
+
+  @shortdoc "Generates a helper shell script for using gdb to analyze core dumps"
+
+  @moduledoc """
+  Generates a helper shell script for using gdb to analyze core dumps
+  
+  This script may be used on its own or used as a base for more complicated debugging.
+  It saves the script to #{@script_name}.
+  """
+  @spec run(keyword()) :: :ok
+  def run(_args) do
+    Preflight.check!()
+    system_path = check_nerves_system_is_set!()
+    check_nerves_toolchain_is_set!()
+
+    gdb_script_contents =
+      Application.app_dir(:nerves, "priv/templates/script.run-gdb.sh.eex")
+      |> EEx.eval_file(assigns: [nerves_system: system_path])
+
+    if File.exists?(@script_name) do
+      Mix.shell().yes?("OK to overwrite #{@script_name}?") || Mix.raise("Aborted")
+    end
+
+    Mix.shell().info("""
+    Writing #{@script_name}...
+    """)
+
+    File.write!(@script_name, gdb_script_contents)
+    File.chmod!(@script_name, 0o755)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -29,7 +29,7 @@ defmodule Nerves.MixProject do
   end
 
   def application do
-    [extra_applications: [:ssl, :inets]]
+    [extra_applications: [:ssl, :inets, :eex]]
   end
 
   defp elixirc_paths(:test), do: ["lib", "test/support"]

--- a/priv/templates/script.run-gdb.sh.eex
+++ b/priv/templates/script.run-gdb.sh.eex
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+#
+# Helper script to get GDB running against an executable and a core dump.
+# Feel free to modify this file to suit your needs
+#
+# Usage:
+#   run-gdb.sh <path to core dump> [path to executable]
+#
+
+set -e
+
+help() {
+    echo
+    echo "run-gdb.sh <path to core dump> [path to executable]"
+    echo
+    echo "MIX_TARGET=$MIX_TARGET"
+    echo "MIX_ENV=$MIX_ENV"
+    exit 1
+}
+
+CORE=$1
+[ -f "$CORE" ] || (echo "Error: no core dump provided."; help)
+
+NERVES_SYSTEM="${NERVES_SYSTEM:=<%= @nerves_system %>}"
+[ -n "$NERVES_SYSTEM" ] || (echo "Error: missing environment variable $NERVES_SYSTEM"; help)
+[ -f "$NERVES_SYSTEM/nerves-env.sh" ] || (echo "Error: $NERVES_SYSTEM/nerves-env.sh not found"; help)
+source $NERVES_SYSTEM/nerves-env.sh
+
+EXE=$2
+[ -f $EXE ] || EXE="$ERTS_INCLUDE_DIR/../bin/beam.smp"
+
+[ -n "$NERVES_SDK_SYSROOT" ] || (echo "Error: missing environment variable $NERVES_SDK_SYSROOT"; help)
+[ -n "$ERTS_INCLUDE_DIR" ] || (echo "Error: missing environment variable $ERTS_INCLUDE_DIR"; help)
+
+[ -n "$CROSSCOMPILE" ] || (echo "Warning: missing environment variable $CROSSCOMPILE")
+GDB=$CROSSCOMPILE-gdb
+[ -f "$GDB" ] || (echo "Error: gdb is not available in this toolchain"; help)
+
+$GDB --core="$CORE" \
+     --nx \
+     --init-eval-command="set sysroot $NERVES_SDK_SYSROOT" \
+     $EXE


### PR DESCRIPTION
This is required for programs like `gdb`, `debuginfod` and similar to automatacally locate debug symbols when present