### PR TITLE
Docs: clarify location of artifacts directory

### DIFF
--- a/lib/nerves/artifact.ex
+++ b/lib/nerves/artifact.ex
@@ -137,8 +137,9 @@ defmodule Nerves.Artifact do
   @doc """
   Get the base dir for where an artifact for a package should be stored.
 
-  The base dir for an artifact will point
-  to the NERVES_ARTIFACTS_DIR or if undefined, `~/.nerves/artifacts`
+  The directory for artifacts will be found in the directory returned
+  by `Nerves.Env.data_dir/0` (i.e. `"#{Nerves.Env.data_dir()}/artifacts/"`).
+  This location can be overriden by the environment variable `NERVES_ARTIFACTS_DIR`.
   """
   @spec base_dir() :: String.t()
   def base_dir() do

--- a/lib/nerves/env.ex
+++ b/lib/nerves/env.ex
@@ -79,7 +79,12 @@ defmodule Nerves.Env do
   end
 
   @doc """
-  The location for storing global nerves data
+  The location for storing global nerves data.
+
+  The base directory is normally set by the `XDG_DATA_HOME`
+  environment variable (i.e. `$XDG_DATA_HOME/nerves/`).
+  If `XDG_DATA_HOME` is unset, the user's home directory
+  is used (i.e. `$HOME/.nerves`).
   """
   @spec data_dir() :: path :: String.t()
   def data_dir do


### PR DESCRIPTION
The directory used by `Nerves.Env.data_dir` is not $HOME, but $XDG_DATA_HOME which is different on some Linux distributions. Updated the artifacts directory docs to note this as well.