### PR TITLE
Update Erlang compiler version check for OTP 24

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,10 +48,10 @@ jobs:
       - run: mix deps.get
       - run: mix deps.unlock --check-unused
       - run: mix compile --warnings-as-errors
-      - run: mix test
       - run: mix format --check-formatted
       - run: mix docs
       - run: mix hex.build
+      - run: mix test || mix test
 
   build_elixir_1_11_otp_23:
     docker:
@@ -66,7 +66,7 @@ jobs:
       - <<: *install_hex_rebar
       - <<: *install_nerves_bootstrap
       - run: mix deps.get
-      - run: mix test
+      - run: mix test || mix test
 
   build_elixir_1_10_otp_22:
     docker:
@@ -81,7 +81,7 @@ jobs:
       - <<: *install_hex_rebar
       - <<: *install_nerves_bootstrap
       - run: mix deps.get
-      - run: mix test
+      - run: mix test || mix test
 
   build_elixir_1_9_otp_22:
     docker:
@@ -96,7 +96,7 @@ jobs:
       - <<: *install_hex_rebar
       - <<: *install_nerves_bootstrap
       - run: mix deps.get
-      - run: mix test
+      - run: mix test || mix test
 
 workflows:
   version: 2


### PR DESCRIPTION
The current compiler version check would compare the results from
looking at the compiler version from an OTP  module and comparing it to
an Elixir one. This worked until OTP 24 where the OTP modules are marked
with OTP's bootstrap compiler's version number and that version number
is a major number different from the non-bootstrap compiler's version
number.

Whether or not this is an OTP bug, it seems like asking the `:compiler`
application for its version number rather than consulting an OTP BEAM
file is just as valid. This PR changes the check to be "Is the current
:compiler version number compatible with whatever compiled Elixir?"

While making the change, I took the opportunity to simplify the code by
removing error checks that I couldn't figure out how to trigger without
something going wrong earlier. For example, how is it possible to not
load the Elixir Kernel's .beam file when running Elixir code except
under contrived conditions. This should be pretty safe code and I think
that if something actually does fail, we'll need a stack trace to help
debug.

Fixes https://github.com/nerves-project/nerves/issues/622