### PR TITLE
Fix toolchain downloads for Apple M1/OTP 24

### DIFF
--- a/lib/nerves/artifact.ex
+++ b/lib/nerves/artifact.ex
@@ -315,8 +315,16 @@ defmodule Nerves.Artifact do
   end
 
   def host_tuple(_pkg) do
-    Nerves.Env.host_os() <> "_" <> Nerves.Env.host_arch()
+    (Nerves.Env.host_os() <> "_" <> Nerves.Env.host_arch())
+    |> normalize_osx()
   end
+
+  # Workaround for OTP 24 returning 'aarch64-apple-darwin20.4.0'
+  # and OTP 23 and earlier returning 'arm-apple-darwin20.4.0'.
+  #
+  # The current Nerves tooling naming uses "arm".
+  defp normalize_osx("darwin_aarch64"), do: "darwin_arm"
+  defp normalize_osx(other), do: other
 
   @doc """
   Determines the extension for an artifact based off its type.


### PR DESCRIPTION
OTP 24 returns 'aarch64-apple-darwin20.4.0' for the system architecture.
Previous OTP versions returned 'arm-apple-darwin20.4.0'. The toolchain
filename is constructed from the first word in the triple, so toolchains
started failing of M1 Macs.

This is a quick workaround that normalizes the name to the old way.
