### PR TITLE
Update installation doc Elixir/OTP versions

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -150,10 +150,10 @@ asdf plugin-add elixir
 # latest official Nerves systems are compatible with the versions below. In
 # general, differences in patch releases are harmless. Nerves detects
 # configurations that might not work at compile time.
-asdf install erlang 23.3.1
-asdf install elixir 1.11.4-otp-23
-asdf global erlang 23.3.1
-asdf global elixir 1.11.4-otp-23
+asdf install erlang 24.0.2
+asdf install elixir 1.12.1-otp-24
+asdf global erlang 24.0.2
+asdf global elixir 1.12.1-otp-24
 ```
 
 It is important to update the versions of `hex` and `rebar` used by Elixir,


### PR DESCRIPTION
The current nerves versions and systems require OTP 24 to avoid the host and target have different OTP versions error, so the installation guide should be updated as well.

Reported on slack