### PR TITLE
Reduce Makefile/gcc prints to clean build output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,9 +43,11 @@ install: $(PREFIX) $(BUILD) $(PORT)
 $(OBJ): Makefile
 
 $(BUILD)/%.o: src/%.c
+	@echo "HOST_CC $(notdir $@)"
 	$(CC_FOR_BUILD) -c $(CFLAGS_FOR_BUILD) -o $@ $<
 
 $(PORT): $(OBJ)
+	@echo "HOST_LD $(notdir $@)"
 	$(CC_FOR_BUILD) $^ $(LDFLAGS_FOR_BUILD) -o $@
 
 $(PREFIX) $(BUILD):
@@ -56,3 +58,6 @@ clean:
 	if [ -f test/fixtures/port/Makefile ]; then $(MAKE) -C test/fixtures/port clean; fi
 
 .PHONY: all clean calling_from_make install
+
+# Don't echo commands unless the caller exports "V=1"
+${V}.SILENT:


### PR DESCRIPTION
The gcc commandlines and other prints can be useful, but most of the
time they are overwhelming especially for non-C programmers. This
simplifies the prints.

To re-enable, set `V=1` like is common with many Makefile/C projects.
For example `V=1 make`, `V=1 mix compile`, etc.
