### PR TITLE
Don't set xattrs when unpacking archives

### DIFF
--- a/lib/mix/tasks/firmware.unpack.ex
+++ b/lib/mix/tasks/firmware.unpack.ex
@@ -80,7 +80,7 @@ defmodule Mix.Tasks.Firmware.Unpack do
 
     {_, 0} = shell("unzip", [fw, "-d", abs_output_path])
 
-    {_, 0} = shell("unsquashfs", ["-d", rootfs_output_path, rootfs_image])
+    {_, 0} = shell("unsquashfs", ["-d", rootfs_output_path, "-no-xattrs", rootfs_image])
 
     :ok
   end


### PR DESCRIPTION
On some systems (Arch Linux) xattrs needs additional permissions. Since
`mix firmware.unpack` is intended as a debug tool, having accurate
xattrs hardly seems important so this disables them.
