### PR TITLE
Add docs for configuring kernel parameters

### DIFF
--- a/docs/Advanced Configuration.md
+++ b/docs/Advanced Configuration.md
@@ -450,3 +450,11 @@ The following is a list of all options that can be specified:
 ```
 
 See [erlinit](https://github.com/nerves-project/erlinit) for more information.
+
+## Configuring Kernel Parameters
+
+`sysctl` is used to modify kernel parameters at runtime. [`nerves_sytem_br`](https://github.com/nerves-project/nerves_system_br)
+provides a default `/etc/sysctl.conf` file that is loaded on application
+startup. You can modify the kernel parameters for your application or custom
+Nerves system by copying this default `sysctl.conf` file to your
+`rootfs_overlay/etc` directory and making the desired changes.


### PR DESCRIPTION
Related to nerves-project/nerves_system_br#570

This PR adds documentation for how to use `sysctl` to configure kernel parameters, which was introduced in nerves-project/nerves_system_br#570.