### PR TITLE
Update Ubuntu installation instructions.

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -140,7 +140,10 @@ asdf plugin-add elixir
 
 # Note #1:
 # If on Debian or Ubuntu, you'll want to install wx before running the next line:
+# For Ubuntu versions before 20.04 run the next line:
 # sudo apt install libwxgtk3.0-dev
+# For Ubuntu 20.04 and up run the next line:
+# sudo apt install libwxgtk3.0-gtk3-dev
 # for arch based systems run the next line:
 # yay -S wxgtk2 fop jdk-openjdk unzip
 


### PR DESCRIPTION
Updated Ubuntu installation instruction for newer Ubuntu versions.

As per https://askubuntu.com/questions/1241217/package-libwxgtk3-0-dev-has-no-installation-candidate-on-ubuntu-20-04 - the package was renamed from libwxgtk3.0-dev to libwxgtk3.0-gtk3-dev.

Tested on Windows 10 + WSL2 with Ubuntu 20.04