### PR TITLE
Make shebang consistent across Nerves

### DIFF
--- a/scripts/docker/nerves_system_br/noninteractive-build.sh
+++ b/scripts/docker/nerves_system_br/noninteractive-build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # noninteractive-build.sh \
 #  nerves_system_ev3-0.7.0.armv5tejl_unknown_linux_musleabi \
 #  /nerves/env/platform \


### PR DESCRIPTION
This standardizes on using `env` to find the shell executable and also
`bash`.
