### PR TITLE
Add firmware build success message

### DIFF
--- a/lib/mix/tasks/firmware.ex
+++ b/lib/mix/tasks/firmware.ex
@@ -55,13 +55,20 @@ defmodule Mix.Tasks.Firmware do
   end
 
   @doc false
-  def result({_, 0}), do: nil
+  def result({_, 0}) do
+    Mix.shell().info("""
+    Firmware built successfully! 🎉
 
-  def result({result, _}),
-    do:
-      Mix.raise("""
-      Nerves encountered an error. #{inspect(result)}
-      """)
+    Now you may install it to a MicroSD card using `mix burn` or upload it
+    to a device with `mix upload` or `mix firmware.gen.script`+`./upload.sh`.
+    """)
+  end
+
+  def result({result, _}) do
+    Mix.raise("""
+    Nerves encountered an error. #{inspect(result)}
+    """)
+  end
 
   defp build_release() do
     Mix.Task.run("release", [])


### PR DESCRIPTION
This adds a short message for what to do next after running `mix
firmware`. The goal is to have a simple reminder for what to do next.

It looks like this:

```sh
...
Building /Users/fhunleth/git/nerves-project/nerves_examples/blinky/_build/rpi0_dev/nerves/images/blinky.fw...
Firmware built successfully! 🎉

Now you may install the firmware on a MicroSD card using `mix burn` or upload
the firmware to a device with `mix upload` or `mix firmware.gen.script`/`./upload.sh`.
```
