### PR TITLE
Update phoenix config in the User Interfaces doc

### DIFF
--- a/docs/User Interfaces.md
+++ b/docs/User Interfaces.md
@@ -1,29 +1,48 @@
 # User Interfaces
 
-## Phoenix web interfaces
+## Phoenix web interface
 
-The Phoenix web framework makes an excellent companion to Nerves-based devices
+The [Phoenix] web framework makes an excellent companion to [Nerves]-based devices
 that need to serve content over HTTP directly from the device. For example, a
 device with no display might provide administration and configuration
 interfaces intended to be accessed from a computer or mobile device.
 
+[Nerves]: https://www.nerves-project.org/
+[Phoenix]: http://www.phoenixframework.org/
+
 ### Choosing a project structure
 
-Although Nerves supports umbrella projects, the preferred project structure is
-to simply use separate Mix projects, side-by-side with path dependencies
-between them, in the same source code repository. We call this a "poncho
-project" structure. For the reasoning behind this, please see the original
-[blog post describing poncho projects].
+There are two commonly used project structures for Nerves-based devices that uses
+Phoenix web interface:
+
+- [poncho project structure]
+- [umbrella project structure]
+
+Although Nerves supports both, the preferred project structure is what we call
+poncho project structure. For the reasoning behind this, please see the original
+[blog post describing poncho projects]. The following steps assume that we use
+the poncho project structure.
+
+Using the poncho project structure, we simply use separate [Mix projects],
+side-by-side with path dependencies between them, in the same source code repository.
 
 [blog post describing poncho projects]: https://embedded-elixir.com/post/2017-05-19-poncho-projects/
+[poncho project structure]: http://embedded-elixir.com/post/2017-05-19-poncho-projects/
+[umbrella project structure]: https://elixir-lang.org/getting-started/mix-otp/dependencies-and-umbrella-projects.html
+[Mix projects]: https://hexdocs.pm/mix/Mix.html
 
-### Using a poncho project structure
+### Create a poncho project
 
 First, we generate the two new Mix projects in a containing directory:
 
 ```bash
+# Create a container directory called "my_app"
 mkdir my_app && cd my_app
+
+# Create a Nerves firmware project called "my_app_firmware"
 mix nerves.new my_app_firmware
+
+# Create a Phoenix 1.6 UI project called "my_app_ui"
 mix phx.new my_app_ui --no-ecto --no-mailer
 ```
 
@@ -38,7 +57,7 @@ as a deployment wrapper around the `my_app_ui` project.
   defp deps do
     [
       # Dependencies for all targets
-      {:nerves, "~> 1.7", runtime: false},
+      {:nerves, "~> 1.7.0", runtime: false},
       # ...
       {:my_app_ui, path: "../my_app_ui", targets: @all_targets, env: Mix.env()},
       # ...
@@ -47,64 +66,24 @@ as a deployment wrapper around the `my_app_ui` project.
 # ...
 ```
 
-If we're using the poncho project structure, we can skip ahead to the section
-where we [configure networking](#configure-networking).
-
-### Using an umbrella project structure
-
-If we would rather use the umbrella project structure instead, we can do so as follows:
-
-```bash
-mix new my_app --umbrella
-cd my_app/apps
-mix nerves.new my_app_firmware
-mix phx.new my_app_ui --no-ecto --no-mailer
-```
-
-Then, we add the Phoenix `my_app_ui` project to the `my_app_firmware` project
-as a dependency using the `in_umbrella` option instead of the `path` option:
+We need one adjustment in the UI project's `mix.exs`.  When `MIX_ENV` is `dev`,
+[`esbuild`] crashes the firmware project on load so we want to prevent `esbuild`
+from getting loaded at runtime on the firmware project.
 
 ```elixir
-# apps/my_app_firmware/mix.exs
+# my_app/my_app_ui/mix.exs
 
-# ...
   defp deps do
     [
-      # Dependencies for all targets
-      {:nerves, "~> 1.7", runtime: false},
+      {:phoenix, "~> 1.6.0"},
       # ...
-      {:my_app_ui, in_umbrella: true, targets: @all_targets, env: Mix.env()},
+      {:esbuild, "~> 0.2", runtime: Mix.env() == :dev && Mix.target() == :host},
       # ...
     ]
   end
-# ...
-```
-#### Specifying configuration order
-
-By default when you use the umbrella project style, the top-level configuration
-loads the sub-project configurations in lexicographic order:
-
-```elixir
-# my_app/config/config.exs
-
-use Mix.Config
-
-import_config "../apps/*/config/config.exs"
 ```
 
-This can cause problems, depending on the names of your sub-projects, because
-it is likely that we will want to override certain device-specific settings in
-the `my_app_firmware` config. We can solve this by specifying the order in
-which the config files get imported:
-
-```elixir
-# my_app/config/config.exs
-
-use Mix.Config
-
-import_config "../apps/my_app_ui/config/config.exs"
-import_config "../apps/my_app_firmware/config/config.exs"
-```
+[`esbuild`]: https://hexdocs.pm/esbuild/Esbuild.html
 
 ### Configure networking
 
@@ -116,37 +95,35 @@ configured and apply defaults for `usb*` and `eth*` interfaces.
 For `eth*` interfaces, the device attempts to connect to the network
 with DHCP using `ipv4` addressing.
 
-For `usb*` interfaces, it uses [`vintage_net_direct`](https://hexdocs.pm/vintage_net_direct/VintageNetDirect.html) to run a simple DHCP server
+For `usb*` interfaces, it uses [`vintage_net_direct`] to run a simple DHCP server
 on the device and assign the host an IP address over a USB cable.
 
 If you want to use some other network configuration, such as wired or wireless
-Ethernet, please refer to the [`nerves_pack` documentation](https://hexdocs.pm/nerves_pack/readme.html) and the
-underlying [`vintage_net` documentation](https://hexdocs.pm/vintage_net/VintageNet.html) as needed.
+Ethernet, please refer to the [`nerves_pack` documentation] and the
+underlying [`vintage_net` documentation] as needed.
 
 [`nerves_pack`]: https://hexdocs.pm/nerves_pack
-[`VintageNetWifi`]: https://hexdocs.pm/vintage_net_wifi
-[`VintageNetEthernet`]: https://hexdocs.pm/vintage_net_ethernet
-[`VintageNetDirect`]: https://hexdocs.pm/vintage_net_direct
-[`VintageNetMobile`]: https://hexdocs.pm/vintage_net_mobile
+[`vintage_net_wifi`]: https://hexdocs.pm/vintage_net_wifi
+[`vintage_net_direct`]: https://hexdocs.pm/vintage_net_direct
+[`nerves_pack` documentation]: https://hexdocs.pm/nerves_pack/readme.html
+[`vintage_net` documentation]: https://hexdocs.pm/vintage_net/VintageNet.html
 
 ### Configure Phoenix
 
-In order to deploy the `my_app_ui` Phoenix-based project along with the
-Nerves-based `my_app_firmware` project, we need to configure our Phoenix
-`Endpoint` using appropriate settings for deployment on an embedded device. If
+In order to deploy the `my_app/my_app_ui` Phoenix-based project along with the
+Nerves-based `my_app/my_app_firmware` project, we need to configure our [`Phoenix.Endpoint`]
+using appropriate settings for deployment on an embedded device. If
 we're using a poncho project structure, we'll need to keep in mind that the
-`my_app_ui` configuration won't be applied automatically, so we should either
+`my_app/my_app_ui` configuration won't be applied automatically, so we should either
 `import` it from there or duplicate the required configuration.
 
-Assuming that we're using the poncho project structure, our configuration might
-look like this:
+Our configuration might look like this (as of Phoenix 1.6.2):
 
 ```elixir
-# my_app_firmware/config/target.exs
+# my_app_/my_app_firmware/config/target.exs
 
 import Config
 
-# as of phoenix 1.6.2
 config :my_app_ui, MyAppUiWeb.Endpoint,
   url: [host: "nerves.local"],
   http: [port: 80],
@@ -170,7 +147,9 @@ Nerves-based embedded device. By separating the Phoenix-based project from the
 Nerves-based project, we enable teams to work on the core functionality and
 user interface code even without having physical hardware. We also minimize the
 hardware/software integration effort by managing both the core software and the
-firmware deployment infrastructure in a single poncho or umbrella project.
+firmware deployment infrastructure in a single poncho project.
+
+[`Phoenix.Endpoint`]: https://hexdocs.pm/phoenix/Phoenix.Endpoint.html
 
 ### Develop the UI
 
@@ -184,10 +163,15 @@ iex -S mix phx.server
 
 ### Deploy the firmware
 
-First we build our assets in the `my_app_ui` project directory and prepare them for deployment to the firmware:
+First we build our assets in the `my_app_ui` project directory and prepare them
+for deployment to the firmware:
 
 ```bash
 cd path/to/my_app_ui
+
+# We want to build assets on our host machine.
+export MIX_TARGET=host
+export MIX_ENV=dev
 
 # This needs to be repeated when you change dependencies for the UI.
 mix deps.get
@@ -196,11 +180,16 @@ mix deps.get
 mix assets.deploy
 ```
 
-When it's time to deploy firmware to our hardware, we can do it from the `my_app_firmware` project directory:
+When it's time to deploy firmware to our hardware, we can do it from the
+`my_app_firmware` project directory:
 
 ```bash
 cd path/to/my_app_firmware
+
+# Specify our target device.
 export MIX_TARGET=rpi3
+export MIX_ENV=dev
+
 mix deps.get
 mix firmware
 # (Connect the SD card)


### PR DESCRIPTION
Updates for Phoenix 1.6 based on what I learned at https://github.com/nerves-project/nerves_examples/pull/220 and my [memo](https://dev.to/mnishiguchi/elixir-poncho-project-with-nerves-firmware-and-phoenix-liveview-ui-48k) on it.

## Changes

- Focus on a poncho project structure so that we can simplify the explanation
- Update the instructions for Phoenix 1.6
- List all the necessary UI configuration in the firmware project's `config/target.exs` instead of importing them the UI project and override (simplicity; consistency with `hello_nerves` example)
- Misc clean up