### PR TITLE
Verify artifact downloads

### DIFF
--- a/lib/nerves/utils/http_client.ex
+++ b/lib/nerves/utils/http_client.ex
@@ -59,7 +59,17 @@ defmodule Nerves.Utils.HTTPClient do
     ]
 
     http_opts =
-      [timeout: :infinity, autoredirect: false]
+      [
+        timeout: :infinity,
+        autoredirect: false,
+        ssl: [
+          verify: :verify_peer,
+          cacertfile: CAStore.file_path(),
+          customize_hostname_check: [
+            {:match_fun, :public_key.pkix_verify_hostname_match_fun(:https)}
+          ]
+        ]
+      ]
       |> Keyword.merge(Nerves.Utils.Proxy.config(url))
       |> Keyword.merge(Keyword.get(opts, :http_opts, []))
 

--- a/mix.exs
+++ b/mix.exs
@@ -37,6 +37,7 @@ defmodule Nerves.MixProject do
 
   defp deps do
     [
+      {:castore, "~> 0.1"},
       {:elixir_make, "~> 0.6", runtime: false},
       {:jason, "~> 1.2", optional: true},
       {:ex_doc, "~> 0.22", only: :docs, runtime: false},

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,5 @@
 %{
+  "castore": {:hex, :castore, "0.1.13", "ccf3ab251ffaebc4319f41d788ce59a6ab3f42b6c27e598ad838ffecee0b04f9", [:mix], [], "hexpm", "a14a7eecfec7e20385493dbb92b0d12c5d77ecfd6307de10102d58c94e8c49c0"},
   "cowboy": {:hex, :cowboy, "2.9.0", "865dd8b6607e14cf03282e10e934023a1bd8be6f6bacf921a7e2a96d800cd452", [:make, :rebar3], [{:cowlib, "2.11.0", [hex: :cowlib, repo: "hexpm", optional: false]}, {:ranch, "1.8.0", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm", "2c729f934b4e1aa149aff882f57c6372c15399a20d54f65c8d67bef583021bde"},
   "cowboy_telemetry": {:hex, :cowboy_telemetry, "0.3.1", "ebd1a1d7aff97f27c66654e78ece187abdc646992714164380d8a041eda16754", [:rebar3], [{:cowboy, "~> 2.7", [hex: :cowboy, repo: "hexpm", optional: false]}, {:telemetry, "~> 0.4", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm", "3a6efd3366130eab84ca372cbd4a7d3c3a97bdfcfb4911233b035d117063f0af"},
   "cowlib": {:hex, :cowlib, "2.11.0", "0b9ff9c346629256c42ebe1eeb769a83c6cb771a6ee5960bd110ab0b9b872063", [:make, :rebar3], [], "hexpm", "2b3e9da0b21c4565751a6d4901c20d1b4cc25cbb7fd50d91d2ab6dd287bc86a9"},


### PR DESCRIPTION
With OTP 24, it now warns you when attempting an HTTPS request without any verification, although TLS still allows it.
    
This takes the hint to get a little more secure when downloading Nerves artifacts and attempts to establish authenticity from trusted certs in `:castore`, which should include the most common github release downloads