### PR TITLE
Inspect error in case non-strings passed

### DIFF
--- a/lib/nerves/artifact.ex
+++ b/lib/nerves/artifact.ex
@@ -23,7 +23,7 @@ defmodule Nerves.Artifact do
           {:error, error} ->
             Mix.raise("""
             Nerves encountered an error while constructing the artifact
-            #{error}
+            #{inspect(error)}
             """)
         end
 


### PR DESCRIPTION
A bug in the toolchain was causing a non-string to be passed around as
the error. This would give a stack trace when trying to print the error.
This is fixed now. However, in retrospect, having quotes around the
error message looks better and inspecting the error bulletproofs it
anyway.
