### PR TITLE
Update wording when downloading artifacts

### DIFF
--- a/lib/mix/tasks/nerves.artifact.get.ex
+++ b/lib/mix/tasks/nerves.artifact.get.ex
@@ -8,7 +8,7 @@ defmodule Mix.Tasks.Nerves.Artifact.Get do
 
   @impl true
   def run(opts) do
-    Mix.shell().info("Resolving Nerves artifacts...")
+    Mix.shell().info("Checking for prebuilt Nerves artifacts...")
 
     Nerves.Env.packages()
     |> Enum.each(&get(&1.app, opts))
@@ -32,8 +32,9 @@ defmodule Mix.Tasks.Nerves.Artifact.Get do
             nil ->
               get_artifact(pkg)
 
-            _cache_path ->
-              Nerves.Utils.Shell.success("  Cached #{app}")
+            cache_path ->
+              Nerves.Utils.Shell.success("  Found #{app} in cache")
+              Nerves.Utils.Shell.info("    #{cache_path}")
           end
         end
 
@@ -44,7 +45,7 @@ defmodule Mix.Tasks.Nerves.Artifact.Get do
 
   defp get_artifact(pkg) do
     archive = Artifact.download_path(pkg)
-    Nerves.Utils.Shell.success("  Resolving #{pkg.app}")
+    Nerves.Utils.Shell.success("  Checking #{pkg.app}...")
 
     with true <- File.exists?(archive),
          :ok <- Nerves.Utils.File.validate(archive) do
@@ -66,7 +67,7 @@ defmodule Mix.Tasks.Nerves.Artifact.Get do
         put_cache(pkg, archive)
 
       {:error, reason} ->
-        Nerves.Utils.Shell.error("  => #{reason}")
+        Nerves.Utils.Shell.error("  => Prebuilt #{pkg.app} not found (#{reason})")
     end
   end
 


### PR DESCRIPTION
It wasn't obvious whether errors downloading artifacts were a problem or
not. This is an update to the wording to give more information on what's
happening.

The key changes were to refer to the artifacts as prebuilt versions and
to change the error message from "no_result" to "Prebuilt xyz not
found".

Here's the before:

```
==> nerves_system_rpi0
Resolving Nerves artifacts...
  Resolving nerves_system_rpi0
  => Trying
https://github.com/nerves-project/nerves_system_rpi0/releases/download/v1.18.0/nerves_system_rpi0-portable-1.18.0-792C09C.tar.gz
     Status 404 Not Found
  => Trying
https://github.com/nerves-project/nerves_system_rpi0/releases/download/v1.18.0/nerves_system_rpi0-portable-1.18.0-792C09C4B63C061CB451646DC01DD20DB8BB676441E531E9FA5AF9BE8C4AC5BC.tar.gz
     Status 404 Not Found
  => no_result
  Cached nerves_toolchain_armv6_nerves_linux_gnueabihf
```

Here's after:

```
==> nerves_system_rpi0
Checking for prebuilt Nerves artifacts...
  Checking nerves_system_rpi0...
  => Trying
https://github.com/nerves-project/nerves_system_rpi0/releases/download/v1.18.0/nerves_system_rpi0-portable-1.18.0-E79E41B.tar.gz
     Status 404 Not Found
  => Trying
https://github.com/nerves-project/nerves_system_rpi0/releases/download/v1.18.0/nerves_system_rpi0-portable-1.18.0-E79E41B7649502B2F06DF5F7ECC006AF075DC918032D0908551AA8F394033D86.tar.gz
     Status 404 Not Found
  => Prebuilt nerves_system_rpi0 not found (no_result)
  Found nerves_toolchain_armv6_nerves_linux_gnueabihf in cache
    /home/fhunleth/.nerves/artifacts/nerves_toolchain_armv6_nerves_linux_gnueabihf-linux_x86_64-1.4.3
```
