### PR TITLE
Change `burn` task to Upgrade by default

### DIFF
--- a/lib/mix/nerves/fwup_stream.ex
+++ b/lib/mix/nerves/fwup_stream.ex
@@ -1,0 +1,34 @@
+defmodule Mix.Nerves.FwupStream do
+  @moduledoc """
+  IO Stream for Fwup
+
+  This functions the same as IO.Stream to push fwup IO to stdio, but
+  it also captures the IO for cases where you want to check the
+  output programatically as well.
+  """
+
+  defstruct device: :standard_io, line_or_bytes: :line, raw: true, output: ""
+
+  def new(), do: %__MODULE__{}
+
+  defimpl Collectable do
+    def into(%{output: output} = stream) do
+      {[output], collect(stream)}
+    end
+
+    defp collect(%{device: device, raw: raw} = stream) do
+      fn
+        acc, {:cont, x} ->
+          case raw do
+            true -> IO.binwrite(device, x)
+            false -> IO.write(device, x)
+          end
+
+          [acc | x]
+
+        acc, _ ->
+          %{stream | output: IO.iodata_to_binary(acc)}
+      end
+    end
+  end
+end


### PR DESCRIPTION
This changes the `mix burn` (and subsequently `mix firmware.burn`) to use the FWUP `upgrade` task by default. If the upgrade fails because the device does not actually have upgradable firmware on it, then the task will fallback to using the `complete` task to overwrite the device.

You can also now specify `--overwrite` to force the `complete` task and wipe the data on the device with the new firmware.

see #679