### PR TITLE
Add minimum nerves_system_br version for buid env

### DIFF
--- a/docs/Compiling Non-BEAM Code.md
+++ b/docs/Compiling Non-BEAM Code.md
@@ -72,8 +72,6 @@ CXXFLAGS_FOR_BUILD | `nerves_system_br` | Recommended C++ compiler flags for the
 ERL_CFLAGS         | `nerves_system_br` | Additional compilation flags for Erlang NIFs and ports
 ERL_EI_INCLUDE_DIR | `nerves_system_br` | Rebar variable for finding erl interface include files
 ERL_EI_LIBDIR      | `nerves_system_br` | Rebar variable for finding erl interface libraries
-ERL_INTERFACE_LIB_DIR | `nerves_system_br` | erlang.mk variable for finding erl interface libraries
-ERL_INTERFACE_INCLUDE_DIR | `nerves_system_br` | erlang.mk variable for finding erl interface include files
 ERL_LDFLAGS        | `nerves_system_br` | Additional linker flags for Erlang NIFs and ports
 ERTS_INCLUDE_DIR   | `nerves_system_br` | erlang.mk variable for finding erts include files
 GCC_FOR_BUILD      | `nerves_system_br` | The host's `gcc`

--- a/docs/Compiling Non-BEAM Code.md
+++ b/docs/Compiling Non-BEAM Code.md
@@ -53,40 +53,40 @@ guide compilation. These environment variables are available to `mix`, `rebar3`
 and any code invoked from them. For example, these are frequently used in the
 `Makefiles` invoked by [`elixir_make`](https://hex.pm/packages/elixir_make).
 
-Name               | Where set          | Description
------------------- | ------------------ | -----------
-AR_FOR_BUILD       | `nerves_system_br` | The host's `ar`
-AS_FOR_BUILD       | `nerves_system_br` | The host's `as`
-CC                 | `nerves_system_br` | The path to `gcc` for crosscompiling to the target
-CC_FOR_BUILD       | `nerves_system_br` | The host's `cc`
-CFLAGS             | `nerves_system_br` | Recommended C compilation flags
-CFLAGS_FOR_BUILD   | `nerves_system_br` | Recommended C compiler flags for the host
-CMAKE_TOOLCHAIN_FILE | `nerves_system_br` | To build CMake projects, configure CMake with `-DCMAKE_TOOLCHAIN_FILE="$(CMAKE_TOOLCHAIN_FILE)"`
-CPPFLAGS           | `nerves_system_br` | Recommended C preprocessor flags
-CPPFLAGS_FOR_BUILD | `nerves_system_br` | Recommended C preprocessor flags for the host
-CROSSCOMPILE       | `nerves_system_br` | The path and prefix for the crosscompilers (e.g., "$CROSSCOMPILE-gcc" is the path to gcc)
-CXX                | `nerves_system_br` | The path to `g++` for crosscompiling to the target
-CXX_FOR_BUILD      | `nerves_system_br` | The host's `g++`
-CXXFLAGS           | `nerves_system_br` | Recommended C++ compilation flags
-CXXFLAGS_FOR_BUILD | `nerves_system_br` | Recommended C++ compiler flags for the host
-ERL_CFLAGS         | `nerves_system_br` | Additional compilation flags for Erlang NIFs and ports
-ERL_EI_INCLUDE_DIR | `nerves_system_br` | Rebar variable for finding erl interface include files
-ERL_EI_LIBDIR      | `nerves_system_br` | Rebar variable for finding erl interface libraries
-ERL_LDFLAGS        | `nerves_system_br` | Additional linker flags for Erlang NIFs and ports
-ERTS_INCLUDE_DIR   | `nerves_system_br` | erlang.mk variable for finding erts include files
-GCC_FOR_BUILD      | `nerves_system_br` | The host's `gcc`
-LD_FOR_BUILD       | `nerves_system_br` | The host's `ld`
-LDFLAGS            | `nerves_system_br` | Recommended linker flags
-LDFLAGS_FOR_BUILD  | `nerves_system_br` | Recommended linker flags for the host
-PKG_CONFIG_SYSROOT_DIR | `nerves_system_br` | Sysroot for using `pkg-config` to find libraries in the Nerves system
-PKG_CONFIG_LIBDIR  | `nerves_system_br` | Metadata for `pkg-config` on the target
-QMAKESPEC          | `nerves_system_br` | If Qt is available, this points to the spec file
-REBAR_TARGET_ARCH  | `nerves_system_br` | Set to the binutils prefix (e.g., `arm-linux-gnueabi`) for [rebar2](https://github.com/rebar/rebar)
-STRIP              | `nerves_system_br` | The path to `strip` for target binaries (Nerves strips binaries by default)
-TARGET_ABI         | `nerves_system_*`  | The target ABI (e.g., `gnueabihf`, `musl`)
-TARGET_ARCH        | `nerves_system_*`  | The target CPU architecture (e.g., `arm`, `aarch64`, `mipsel`, `x86_64`, `riscv64`)
-TARGET_CPU         | `nerves_system_*`  | The target CPU (e.g., `cortex_a7`)
-TARGET_OS          | `nerves_system_*`  | The target OS. Always `linux` for Nerves.
+Name                   | Min `nerves_system_br` version | Description
+---------------------- | ------------------------------ | -----------
+AR_FOR_BUILD           | `v1.13.1`                      | The host's `ar`
+AS_FOR_BUILD           | `v1.13.1`                      | The host's `as`
+CC                     | All                            | The path to `gcc` for crosscompiling to the target
+CC_FOR_BUILD           | `v1.13.1`                      | The host's `cc`
+CFLAGS                 | All                            | Recommended C compilation flags
+CFLAGS_FOR_BUILD       | `v1.13.1`                      | Recommended C compiler flags for the host
+CMAKE_TOOLCHAIN_FILE   | `v1.18.3`                      | To build CMake projects, configure CMake with `-DCMAKE_TOOLCHAIN_FILE="$(CMAKE_TOOLCHAIN_FILE)"`
+CPPFLAGS               | `v1.14.5`                      | Recommended C preprocessor flags
+CPPFLAGS_FOR_BUILD     | `v1.13.1`                      | Recommended C preprocessor flags for the host
+CROSSCOMPILE           | All                            | The path and prefix for the crosscompilers (e.g., "$CROSSCOMPILE-gcc" is the path to gcc)
+CXX                    | All                            | The path to `g++` for crosscompiling to the target
+CXX_FOR_BUILD          | `v1.13.1`                      | The host's `g++`
+CXXFLAGS               | All                            | Recommended C++ compilation flags
+CXXFLAGS_FOR_BUILD     | `v1.13.1`                      | Recommended C++ compiler flags for the host
+ERL_CFLAGS             | All                            | Additional compilation flags for Erlang NIFs and ports
+ERL_EI_INCLUDE_DIR     | All                            | Rebar variable for finding erl interface include files
+ERL_EI_LIBDIR          | All                            | Rebar variable for finding erl interface libraries
+ERL_LDFLAGS            | All                            | Additional linker flags for Erlang NIFs and ports
+ERTS_INCLUDE_DIR       | All                            | erlang.mk variable for finding erts include files
+GCC_FOR_BUILD          | `v1.13.1`                      | The host's `gcc`
+LD_FOR_BUILD           | `v1.13.1`                      | The host's `ld`
+LDFLAGS                | All                            | Recommended linker flags
+LDFLAGS_FOR_BUILD      | `v1.13.1`                      | Recommended linker flags for the host
+PKG_CONFIG_SYSROOT_DIR | `v1.8.5`                       | Sysroot for using `pkg-config` to find libraries in the Nerves system
+PKG_CONFIG_LIBDIR      | `v1.8.5`                       | Metadata for `pkg-config` on the target
+QMAKESPEC              | `v1.4.0`                       | If Qt is available, this points to the spec file
+REBAR_TARGET_ARCH      | All                            | Set to the binutils prefix (e.g., `arm-linux-gnueabi`) for [rebar2](https://github.com/rebar/rebar)
+STRIP                  | All                            | The path to `strip` for target binaries (Nerves strips binaries by default)
+TARGET_ABI             | See below                      | The target ABI (e.g., `gnueabihf`, `musl`)
+TARGET_ARCH            | See below                      | The target CPU architecture (e.g., `arm`, `aarch64`, `mipsel`, `x86_64`, `riscv64`)
+TARGET_CPU             | See below                      | The target CPU (e.g., `cortex_a7`)
+TARGET_OS              | See below                      | The target OS. Always `linux` for Nerves.
 
 Also see the [`elixir_make`
 documentation](https://hexdocs.pm/elixir_make/Mix.Tasks.Compile.ElixirMake.html#module-default-environment-variables)


### PR DESCRIPTION
- Remove erl_interface references since removed in OTP 23
- Add minimum nerves_system_br version for buid env
