### PR TITLE
Add doc link to "Edit this page on GitHub"

### DIFF
--- a/docs/Advanced Configuration.md
+++ b/docs/Advanced Configuration.md
@@ -467,3 +467,10 @@ You can modify the kernel parameters for your application or custom Nerves
 system by copying the default `sysctl.conf` file to your `rootfs_overlay/etc`
 directory and making the desired changes. Use `System.cmd/3` to run `sysctl` to
 change settings after initialization.
+
+<p align="center">
+Is something wrong?
+<a href="https://github.com/nerves-project/nerves/edit/main/docs/Advanced%20Configuration.md">
+Edit this page on GitHub
+</a>
+</p>

--- a/docs/Compiling Non-BEAM Code.md
+++ b/docs/Compiling Non-BEAM Code.md
@@ -158,3 +158,10 @@ works well with Nerves and embedded Linux, see the [circuits_i2c
 Makefile](https://github.com/elixir-circuits/circuits_i2c/blob/main/Makefile).
 Also consider [zigler](https://github.com/ityonemo/zigler) for a safer
 alternative to C and C++ that works with Nerves.
+
+<p align="center">
+Is something wrong?
+<a href="https://github.com/nerves-project/nerves/edit/main/docs/Compiling%20Non-BEAM%20Code.md">
+Edit this page on GitHub
+</a>
+</p>

--- a/docs/Customizing Systems.md
+++ b/docs/Customizing Systems.md
@@ -387,3 +387,10 @@ You can also use the GitHub interface to do this:
 ```text
 https://github.com/YourGitHubUserName/custom_rpi3/compare/main...nerves-project:main?expand=1
 ```
+
+<p align="center">
+Is something wrong?
+<a href="https://github.com/nerves-project/nerves/edit/main/docs/Customizing%20Systems.md">
+Edit this page on GitHub
+</a>
+</p>

--- a/docs/Experimental Features.md
+++ b/docs/Experimental Features.md
@@ -236,3 +236,10 @@ export system specific information for llvm-based tools. Here is an example from
     ]
   end
 ```
+
+<p align="center">
+Is something wrong?
+<a href="https://github.com/nerves-project/nerves/edit/main/docs/Experimental%20Features.md">
+Edit this page on GitHub
+</a>
+</p>

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -118,3 +118,10 @@ documentation.  You may also find what you need by searching
 [hex.pm](https://hex.pm) for libraries that use that feature.
 
 If you still don't see what you're looking for, please let us know in the #nerves channel on [the Elixir-Lang Slack](https://elixir-slackin.herokuapp.com/), or create an Issue or Pull Request to the [relevant `nerves_system-<target>` repository](https://github.com/nerves-project?query=nerves_system_).
+
+<p align="center">
+Is something wrong?
+<a href="https://github.com/nerves-project/nerves/edit/main/docs/FAQ.md">
+Edit this page on GitHub
+</a>
+</p>

--- a/docs/Getting Started.md
+++ b/docs/Getting Started.md
@@ -259,3 +259,8 @@ export MIX_TARGET=rpi3
 cd nerves_examples/blinky
 mix do deps.get, firmware, firmware.burn
 ```
+
+<p align="center">
+Is something wrong? [Edit this page on GitHub].
+</p>
+[Edit this page on GitHub]: https://github.com/nerves-project/nerves/edit/main/docs/Getting%20Started.md

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -179,3 +179,10 @@ to create new Nerves projects. To install the `nerves_bootstrap` archive:
 ```bash
 mix archive.install hex nerves_bootstrap
 ```
+
+<p align="center">
+Is something wrong?
+<a href="https://github.com/nerves-project/nerves/edit/main/docs/Installation.md">
+Edit this page on GitHub
+</a>
+</p>

--- a/docs/Internals.md
+++ b/docs/Internals.md
@@ -74,3 +74,10 @@ you produce a system directly using Buildroot and want to force Nerves to use it
 ### nerves_system/.nerves/artifacts/nerves_system_*
    * "package" directory
    * Gets fetched from nerves_env.exs artifact_url
+
+<p align="center">
+Is something wrong?
+<a href="https://github.com/nerves-project/nerves/edit/main/docs/Internals.md">
+Edit this page on GitHub
+</a>
+</p>

--- a/docs/Systems.md
+++ b/docs/Systems.md
@@ -247,3 +247,10 @@ The following keys are supported:
 ## Customizing Your Own Nerves System
 
 [This document has been moved](https://hexdocs.pm/nerves/customizing-systems.html)
+
+<p align="center">
+Is something wrong?
+<a href="https://github.com/nerves-project/nerves/edit/main/docs/Systems.md">
+Edit this page on GitHub
+</a>
+</p>

--- a/docs/Targets.md
+++ b/docs/Targets.md
@@ -68,3 +68,9 @@ System as follows:
 > NOTE: You probably want to disable any userland packages that may be included
 > by default to avoid distraction.
 
+<p align="center">
+Is something wrong?
+<a href="https://github.com/nerves-project/nerves/edit/main/docs/Targets.md">
+Edit this page on GitHub
+</a>
+</p>

--- a/docs/Updating Projects.md
+++ b/docs/Updating Projects.md
@@ -762,3 +762,10 @@ Run `mix deps.get` and build as normal. You may also need to update your Nerves
 system to a newer official build. Many systems have dependency requirements on
 Nerves 1.5 that can be updated to Nerves 1.6 without issue. Please review the
 Nerves system release notes when you upgrade.
+
+<p align="center">
+Is something wrong?
+<a href="https://github.com/nerves-project/nerves/edit/main/docs/Updating%20Projects.md">
+Edit this page on GitHub
+</a>
+</p>

--- a/docs/User Interfaces.md
+++ b/docs/User Interfaces.md
@@ -198,3 +198,10 @@ mix firmware
 # (Connect the SD card)
 mix firmware.burn
 ```
+
+<p align="center">
+Is something wrong?
+<a href="https://github.com/nerves-project/nerves/edit/main/docs/User%20Interfaces.md">
+Edit this page on GitHub
+</a>
+</p>

--- a/docs/Using the CLI.md
+++ b/docs/Using the CLI.md
@@ -364,3 +364,10 @@ application, it may be better to not use Nerves.
 [Raspberry Pi OS](https://www.raspberrypi.org/), and other embedded Linux
 projects run Erlang and Elixir too. Many Nerves-related libraries work well
 outside of Nerves.
+
+<p align="center">
+Is something wrong?
+<a href="https://github.com/nerves-project/nerves/edit/main/docs/Using%20the%20CLI.md">
+Edit this page on GitHub
+</a>
+</p>


### PR DESCRIPTION
Making it easier for community contribution,
this is similiar to the link at the bottom of Elixir guides like
https://elixir-lang.org/getting-started/introduction.html