### PR TITLE
Add TARGET_GCC_FLAGS to pass custom gcc flags

### DIFF
--- a/docs/Compiling Non-BEAM Code.md
+++ b/docs/Compiling Non-BEAM Code.md
@@ -86,6 +86,7 @@ STRIP                  | All                            | The path to `strip` fo
 TARGET_ABI             | See below                      | The target ABI (e.g., `gnueabihf`, `musl`)
 TARGET_ARCH            | See below                      | The target CPU architecture (e.g., `arm`, `aarch64`, `mipsel`, `x86_64`, `riscv64`)
 TARGET_CPU             | See below                      | The target CPU (e.g., `cortex_a7`)
+TARGET_GCC_FLAGS       | See below                      | Additional options to be passed to `gcc`. For example, enable CPU-specific features or force ASLR or stack smash protections
 TARGET_OS              | See below                      | The target OS. Always `linux` for Nerves.
 
 Also see the [`elixir_make`
@@ -125,6 +126,16 @@ Raspberry Pi Zero:
     ]
   end
 ```
+
+While the `TARGET_*` environment variables are mostly geared for non-gcc
+compilers, it's useful to add custom flags to gcc invocations as well. The
+`TARGET_GCC_FLAGS` option supports this. The Nerves tooling will prepend the
+contents of `TARGET_GCC_FLAGS` to the `CFLAGS` and `CXXFLAGS` used when
+compiling NIFs and ports. This can be used to enable features like ARM NEON
+support that would otherwise be off when using crosscompiler toolchain defaults.
+Most users don't need to concern themselves with `TARGET_GCC_FLAGS`. If you are
+creating a custom system, not setting `TARGET_GCC_FLAGS` is almost always fine,
+but will result in NIFs and ports being built with generic compiler options.
 
 ## Library recommendations
 

--- a/lib/nerves/package.ex
+++ b/lib/nerves/package.ex
@@ -55,7 +55,7 @@ defmodule Nerves.Package do
     version = config[:version]
     type = config[:nerves_package][:type]
     compilers = config[:compilers] || Mix.compilers()
-    env = config[:nerves_package][:env] || %{}
+    env = Map.new(config[:nerves_package][:env] || %{})
 
     unless type do
       Mix.shell().error(

--- a/lib/nerves/package.ex
+++ b/lib/nerves/package.ex
@@ -89,6 +89,22 @@ defmodule Nerves.Package do
       version: version,
       config: config
     }
+    |> process_target_gcc_flags()
+  end
+
+  defp process_target_gcc_flags(package) do
+    case Map.get(package.env, "TARGET_GCC_FLAGS") do
+      nil ->
+        package
+
+      flags when is_binary(flags) ->
+        new_env =
+          package.env
+          |> Map.put("CFLAGS", flags <> System.get_env("CFLAGS", ""))
+          |> Map.put("CXXFLAGS", flags <> System.get_env("CXXFLAGS", ""))
+
+        %{package | env: new_env}
+    end
   end
 
   @doc """

--- a/test/fixtures/system/mix.exs
+++ b/test/fixtures/system/mix.exs
@@ -24,7 +24,8 @@ defmodule System.MixProject do
         defconfig: "nerves_defconfig"
       ],
       env: [
-        {"FOO", "BAR"}
+        {"TARGET_CPU", "a_cpu"},
+        {"TARGET_GCC_FLAGS", "--testing"}
       ],
       checksum: package_files()
     ]

--- a/test/nerves/env_test.exs
+++ b/test/nerves/env_test.exs
@@ -164,13 +164,18 @@ defmodule Nerves.EnvTest do
         ~w(system toolchain system_platform toolchain_platform)
         |> load_env
 
-        System.delete_env("FOO")
+        System.delete_env("TARGET_CPU")
+        System.delete_env("TARGET_GCC_FLAGS")
 
         Nerves.Env.packages()
         |> Enum.each(&Nerves.Env.export_package_env/1)
 
-        assert System.get_env("FOO") == "BAR"
-        System.delete_env("FOO")
+        assert System.get_env("TARGET_CPU") == "a_cpu"
+        assert String.starts_with?(System.get_env("CFLAGS"), "--testing")
+        assert String.starts_with?(System.get_env("CXXFLAGS"), "--testing")
+
+        System.delete_env("TARGET_CPU")
+        System.delete_env("TARGET_GCC_FLAGS")
       end)
     end
   end


### PR DESCRIPTION
This makes it possible to pass custom flags to all of the gcc tools
generically rather than update `CFLAGS`, etc. individually.

Here's an example for the RPi3a:

```elixir
{"TARGET_GCC_FLAGS", "-mabi=aapcs-linux -mfpu=neon-vfpv4 -marm -fstack-protector-strong -mfloat-abi=hard -mcpu=cortex-a53 -fPIE -pie -Wl,-z,now -Wl,-z,relro"}
```

This enables NEON and VFPv4 support (default is VFPv3 w/ 16 registers). There are other changes from the default toolchain options so that the NIF and port compilation is consistent with Buildroot. Things like the ABI happen to be the defaults, though.