### PR TITLE
Delay applying TARGET_GCC_FLAGS to CFLAGS

### DIFF
--- a/lib/nerves/env.ex
+++ b/lib/nerves/env.ex
@@ -444,9 +444,20 @@ defmodule Nerves.Env do
     |> validate_source_date_epoch()
   end
 
+  @spec export_package_env(Package.t()) :: :ok
   def export_package_env(%Package{env: env}) do
-    System.put_env(env)
+    env
+    |> process_target_gcc_flags()
+    |> System.put_env()
   end
+
+  defp process_target_gcc_flags(%{"TARGET_GCC_FLAGS" => flags} = env) do
+    env
+    |> Map.put("CFLAGS", flags <> System.get_env("CFLAGS", ""))
+    |> Map.put("CXXFLAGS", flags <> System.get_env("CXXFLAGS", ""))
+  end
+
+  defp process_target_gcc_flags(env), do: env
 
   defp set_source_date_epoch() do
     case source_date_epoch() do

--- a/lib/nerves/package.ex
+++ b/lib/nerves/package.ex
@@ -89,22 +89,6 @@ defmodule Nerves.Package do
       version: version,
       config: config
     }
-    |> process_target_gcc_flags()
-  end
-
-  defp process_target_gcc_flags(package) do
-    case Map.get(package.env, "TARGET_GCC_FLAGS") do
-      nil ->
-        package
-
-      flags when is_binary(flags) ->
-        new_env =
-          package.env
-          |> Map.put("CFLAGS", flags <> System.get_env("CFLAGS", ""))
-          |> Map.put("CXXFLAGS", flags <> System.get_env("CXXFLAGS", ""))
-
-        %{package | env: new_env}
-    end
   end
 
   @doc """


### PR DESCRIPTION
This fixes an issue where the TARGET_GCC_FLAGS were applied too early
and they missed some CFLAGS being set by the Nerves system.

This fixes a compiler error finding `libmnl` include files.
