### PR TITLE
Relax Erlang compiler check

### DIFF
--- a/lib/mix/tasks/firmware.ex
+++ b/lib/mix/tasks/firmware.ex
@@ -174,16 +174,15 @@ defmodule Mix.Tasks.Firmware do
 
   defp compiler_check() do
     {:ok, otpc} = erlang_compiler_version()
-    {:ok, otp_requirement} = Version.parse_requirement("~> #{otpc.major}.#{otpc.minor}")
     {:ok, elixirc} = elixir_compiler_version()
 
-    unless Version.match?(elixirc, otp_requirement) do
+    if otpc.major != elixirc.major do
       Mix.raise("""
       Elixir was compiled by a different version of the Erlang/OTP compiler
       than is being used now. This may not work.
 
-      Compiler used for Elixir: #{elixirc.major}.#{elixirc.minor}.#{elixirc.patch}
-      Current compiler:         #{otpc.major}.#{otpc.minor}.#{otpc.patch}
+      Erlang compiler used for Elixir: #{elixirc.major}.#{elixirc.minor}.#{elixirc.patch}
+      Current Erlang compiler:         #{otpc.major}.#{otpc.minor}.#{otpc.patch}
 
       Please use a version of Elixir that was compiled using the same major
       version.


### PR DESCRIPTION
Nerves checks that the version of Erlang used to compile Elixir is
compatible with the one that will be used. The error message says that
the major version number needs to be the same and this makes sense. The
check, however, was that Elixir had to be compiled using an Erlang
compiler major/minor that was the same or later than the currently used
one.

Erlang/OTP 24.3 bumped the compiler's minor version so this error gets
generated:

```
** (Mix) Elixir was compiled by a different version of the Erlang/OTP compiler
than is being used now. This may not work.

Compiler used for Elixir: 8.0.4
Current compiler:         8.1.0
```

This is not a problem, so this change simplifies the version check to
compare major numbers just like the error message says.

For posterity, here is the release note for the Erlang compiler update:
https://github.com/erlang/otp/commit/8f1888b5349c53dbf04211a48d6aa18f9d126cf0#diff-3de9e7927f8219014f2069732eb5d70ffb23766fbaa534b7bf2aefa137eeb7f5
