### PR TITLE
Adding installation instructions for NixOS and Nix package manager

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -102,6 +102,46 @@ need to build a custom system. On Debian and Ubuntu, run the following:
 sudo apt install libssl-dev libncurses5-dev bc m4 unzip cmake python
 ```
 
+### For NixOS or Nix package manager
+
+Create a `shell.nix` file with the following contents:
+
+```nix
+{ pkgs ? import <nixpkgs> {} }:
+
+with pkgs;
+
+mkShell {
+  name = "nervesShell";
+  buildInputs = [
+    autoconf
+    automake
+    curl
+    erlangR24
+    fwup
+    git
+    pkgs.beam.packages.erlangR24.elixir
+    rebar3
+    squashfsTools
+    x11_ssh_askpass
+  ];
+  shellHook = ''
+    SUDO_ASKPASS=${pkgs.x11_ssh_askpass}/libexec/x11-ssh-askpass
+  '';
+}
+```
+
+Use `nix-shell shell.nix` to start a shell with all the Nerves dependencies
+needed for building firmware.
+
+If instead, you'd like to install the dependencies on your host system, you can
+include the same packages listed under `buildInputs` in the
+`environment.systemPackages` section of your NixOS `configuration.nix` file.
+
+Please notes that you may need to adjust the `SUDO_ASKPASS` environment
+variable to include the correct path to the askpass program of your choice. A
+known, working alternative to `x11_ssh_askpass` is `lxqt.lxqt-openssh-askpass`
+
 > For other host Linux distributions, you will need to install equivalent
 > packages, but we don't have the exact list documented. If you'd like to help
 > out, [send us an improvement to this


### PR DESCRIPTION
I've narrowed and tested the packages required to build firmware with Nerves. This brief description covers how to use them with `nix-shell` (on any linux based system with Nix package manager) or by including them in the `configuration.nix` file of a NixOS system. 

I tested that the build inputs work as expected on a clean nix instance on replit.com to make sure none of my host system's installed packages could cause false positives. 

Hopefully, this description makes sense and adds value to the Nerves installation docs. Please feel free to ask questions or make suggestions for changes. 

One thing I wasn't sure about, which you may want to change, is the addition of a heading above the note "For other linux host distributions...". It seems like it's easily lost as it blends with the text from the section I added. 