### PR TITLE
artifact.ex: Print string errors instead of &inspect/1

### DIFF
--- a/lib/nerves/artifact.ex
+++ b/lib/nerves/artifact.ex
@@ -23,7 +23,7 @@ defmodule Nerves.Artifact do
           {:error, error} ->
             Mix.raise("""
             Nerves encountered an error while constructing the artifact
-            #{inspect(error)}
+            #{if String.valid?(error), do: error, else: inspect(error)}
             """)
         end
 


### PR DESCRIPTION
When the error message is a string, calling `inspect` on it limits it to
50 chars, which often ends up being something like
```
"[output of configure]" <> ...
```
and doesn't show the actual error.