### PR TITLE
add ssl parameter depth 3 to http_opts

### DIFF
--- a/lib/nerves/utils/http_client.ex
+++ b/lib/nerves/utils/http_client.ex
@@ -65,6 +65,7 @@ defmodule Nerves.Utils.HTTPClient do
         ssl: [
           verify: :verify_peer,
           cacertfile: CAStore.file_path(),
+          depth: 3,
           customize_hostname_check: [
             {:match_fun, :public_key.pkix_verify_hostname_match_fun(:https)}
           ]


### PR DESCRIPTION
We are seeing issue with TLS fetching from S3 in CI with the following error:
```
21:26:41.176 [info]  TLS :client: In state :certify at ssl_handshake.erl:1952 generated CLIENT ALERT: Fatal - Handshake Failure
 - {:bad_cert, :max_path_length_reached}
 ```

Setting the ssl `depth` parameter to `3` like recommended in https://erlef.github.io/security-wg/secure_coding_and_deployment_hardening/ssl fixes the issue.