### PR TITLE
More credo and dialyzer fixes

### DIFF
--- a/lib/nerves/artifact.ex
+++ b/lib/nerves/artifact.ex
@@ -165,7 +165,6 @@ defmodule Nerves.Artifact do
       |> expand_paths(pkg.path)
       |> Enum.map(&File.read!/1)
       |> Enum.map(&:crypto.hash(:sha256, &1))
-      |> Enum.join()
 
     checksum =
       :crypto.hash(:sha256, blob)

--- a/lib/nerves/env.ex
+++ b/lib/nerves/env.ex
@@ -402,10 +402,11 @@ defmodule Nerves.Env do
     Enum.each(packages, &export_package_env/1)
 
     # Bootstrap all other packages who define a platform
+    toolchain_package = Nerves.Env.toolchain()
+    system_package = Nerves.Env.system()
+
     packages
-    |> Enum.reject(&(&1 == Nerves.Env.toolchain()))
-    |> Enum.reject(&(&1 == Nerves.Env.system()))
-    |> Enum.reject(&(&1.platform == nil))
+    |> Enum.reject(&(&1 == toolchain_package or &1 == system_package or &1.platform == nil))
     |> Enum.each(fn
       %{platform: platform} = pkg ->
         platform.bootstrap(pkg)

--- a/lib/nerves/package.ex
+++ b/lib/nerves/package.ex
@@ -24,7 +24,7 @@ defmodule Nerves.Package do
   @type t :: %__MODULE__{
           app: atom,
           path: binary,
-          env: Keyword.t(),
+          env: %{String.t() => String.t()},
           type:
             :system
             | :package

--- a/lib/nerves/release.ex
+++ b/lib/nerves/release.ex
@@ -66,10 +66,7 @@ defmodule Nerves.Release do
       (target_beam_files ++ target_app_files ++ target_priv_dirs)
       |> List.flatten()
       |> Enum.zip(32_000..1_000)
-      |> Enum.map(fn {file, priority} ->
-        file <> " " <> to_string(priority)
-      end)
-      |> Enum.join("\n")
+      |> Enum.map(fn {file, priority} -> [file, " ", to_string(priority), "\n"] end)
 
     build_path = Path.join([Mix.Project.build_path(), "nerves"])
     File.mkdir_p!(build_path)


### PR DESCRIPTION
- Fix package environment spec
- Use iodata and remove unneeded join
- Simplify Enum.reject for credo
- Use iodata for creating priorities file
