### PR TITLE
nerves_bootstrap automatically calls add_alias

### DIFF
--- a/test/fixtures/host_tool/mix.exs
+++ b/test/fixtures/host_tool/mix.exs
@@ -8,7 +8,6 @@ defmodule HostTool.MixProject do
       elixir: "~> 1.5",
       compilers: Mix.compilers() ++ [:nerves_package],
       nerves_package: nerves_package(),
-      aliases: Nerves.Bootstrap.add_aliases([]),
       xref: [
         exclude: [
           Nerves.Artifact,

--- a/test/fixtures/integration_app/mix.exs
+++ b/test/fixtures/integration_app/mix.exs
@@ -7,8 +7,7 @@ defmodule IntegrationApp do
       version: "0.1.0",
       archives: [nerves_bootstrap: "~> 1.0"],
       compilers: Mix.compilers() ++ [:host_tool],
-      deps: deps(),
-      aliases: Nerves.Bootstrap.add_aliases([])
+      deps: deps()
     ]
   end
 

--- a/test/fixtures/package/mix.exs
+++ b/test/fixtures/package/mix.exs
@@ -11,8 +11,7 @@ defmodule Package.Fixture.MixProject do
       version: @version,
       compilers: Mix.compilers() ++ [:nerves_package],
       nerves_package: nerves_package(),
-      deps: deps(),
-      aliases: Nerves.Bootstrap.add_aliases([])
+      deps: deps()
     ]
   end
 

--- a/test/fixtures/package_build_runner_opts/mix.exs
+++ b/test/fixtures/package_build_runner_opts/mix.exs
@@ -11,8 +11,7 @@ defmodule PackageBuildRunnerOpts.Fixture.MixProject do
       version: @version,
       compilers: Mix.compilers() ++ [:nerves_package],
       nerves_package: nerves_package(),
-      deps: deps(),
-      aliases: Nerves.Bootstrap.add_aliases([])
+      deps: deps()
     ]
   end
 

--- a/test/fixtures/package_build_runner_override/mix.exs
+++ b/test/fixtures/package_build_runner_override/mix.exs
@@ -11,8 +11,7 @@ defmodule PackageBuildRunnerOverride.Fixture.MixProject do
       version: @version,
       compilers: Mix.compilers() ++ [:nerves_package],
       nerves_package: nerves_package(),
-      deps: deps(),
-      aliases: Nerves.Bootstrap.add_aliases([])
+      deps: deps()
     ]
   end
 

--- a/test/fixtures/simple_app/mix.exs
+++ b/test/fixtures/simple_app/mix.exs
@@ -6,8 +6,7 @@ defmodule SimpleApp.Fixture do
       app: :simple_app,
       version: "0.1.0",
       archives: [nerves_bootstrap: "~> 1.0"],
-      deps: deps(),
-      aliases: Nerves.Bootstrap.add_aliases([])
+      deps: deps()
     ]
   end
 

--- a/test/fixtures/simple_app_artifact/mix.exs
+++ b/test/fixtures/simple_app_artifact/mix.exs
@@ -6,7 +6,6 @@ defmodule SimpleAppArtifact.Fixture do
       app: :simple_app_artifact,
       version: "0.1.0",
       archives: [nerves_bootstrap: "~> 1.0"],
-      aliases: aliases(),
       deps: deps()
     ]
   end
@@ -19,9 +18,5 @@ defmodule SimpleAppArtifact.Fixture do
     [
       {:system_artifact, path: "../system_artifact"}
     ]
-  end
-
-  def aliases() do
-    [] |> Nerves.Bootstrap.add_aliases()
   end
 end

--- a/test/fixtures/system_artifact/mix.exs
+++ b/test/fixtures/system_artifact/mix.exs
@@ -11,8 +11,7 @@ defmodule SystemArtifact.MixProject do
       version: @version,
       compilers: Mix.compilers() ++ [:nerves_package],
       nerves_package: nerves_package(),
-      deps: deps(),
-      aliases: Nerves.Bootstrap.add_aliases([])
+      deps: deps()
     ]
   end
 

--- a/test/fixtures/toolchain/mix.exs
+++ b/test/fixtures/toolchain/mix.exs
@@ -11,8 +11,7 @@ defmodule Toolchain.MixProject do
       version: @version,
       compilers: Mix.compilers() ++ [:nerves_package],
       nerves_package: nerves_package(),
-      deps: deps(),
-      aliases: Nerves.Bootstrap.add_aliases([])
+      deps: deps()
     ]
   end
 

--- a/test/fixtures/umbrella/apps/toolchain/mix.exs
+++ b/test/fixtures/umbrella/apps/toolchain/mix.exs
@@ -14,8 +14,7 @@ defmodule Toolchain.MixProject do
       deps: deps(),
       deps_path: "../../deps",
       build_path: "../../_build",
-      config_path: "../../config/config.exs",
-      aliases: Nerves.Bootstrap.add_aliases([])
+      config_path: "../../config/config.exs"
     ]
   end
 


### PR DESCRIPTION
These aren't needed, so delete all calls.
