### PR TITLE
Remove Elixir/Erlang version check

### DIFF
--- a/lib/mix/tasks/nerves.info.ex
+++ b/lib/mix/tasks/nerves.info.ex
@@ -25,7 +25,7 @@ defmodule Mix.Tasks.Nerves.Info do
     Mix.Tasks.Nerves.Env.run(["--info", "--disable"])
     Mix.shell().info("Nerves:           #{Nerves.version()}")
     Mix.shell().info("Nerves Bootstrap: #{Nerves.Bootstrap.version()}")
-    Mix.shell().info("Elixir:           #{Nerves.elixir_version()}")
+    Mix.shell().info("Elixir:           #{System.version()}")
     Nerves.Env.enable()
     debug_info("Info End")
   end

--- a/lib/nerves.ex
+++ b/lib/nerves.ex
@@ -1,37 +1,6 @@
 defmodule Nerves do
   @moduledoc false
 
-  @elixir_version_req ">= 1.7.0"
-  @otp_version_req ">= 21.0.0"
-
-  def version(), do: unquote(Mix.Project.config()[:version])
-  def elixir_version(), do: unquote(System.version())
-  def otp_release(), do: unquote(System.otp_release())
-
-  def system_requirements(elixir_version \\ nil, otp_release \\ nil) do
-    elixir_version = elixir_version || elixir_version()
-    otp_release = otp_release || otp_release()
-
-    with {:ok, otp_rel_version} <- Version.parse(otp_release <> ".0.0"),
-         true <- Version.match?(elixir_version, @elixir_version_req),
-         true <- Version.match?(otp_rel_version, @otp_version_req) do
-      :ok
-    else
-      _ ->
-        Nerves.Utils.Shell.warn("""
-        Nerves #{version()} requires at least Elixir #{@elixir_version_req} and Erlang/OTP #{@otp_version_req}.
-
-        Your system has Elixir #{elixir_version} and Erlang/OTP #{otp_release}.
-
-        Please resolve this by either:
-
-        1. Installing a compatible version of Elixir and Erlang/OTP
-
-        2. Pinning your nerves and nerves_bootstrap dependencies to
-           older versions.
-        """)
-
-        :error
-    end
-  end
+  @spec version() :: String.t()
+  def version(), do: Application.spec(:nerves)[:vsn] |> to_string()
 end

--- a/lib/nerves/env.ex
+++ b/lib/nerves/env.ex
@@ -20,7 +20,6 @@ defmodule Nerves.Env do
   @spec start() :: Agent.on_start()
   @doc used_by: NervesBootstrap
   def start() do
-    Nerves.system_requirements()
     set_source_date_epoch()
     Agent.start_link(fn -> load_packages() end, name: __MODULE__)
   end

--- a/test/nerves/env_test.exs
+++ b/test/nerves/env_test.exs
@@ -2,14 +2,6 @@ defmodule Nerves.EnvTest do
   use NervesTest.Case
   alias Nerves.Env
 
-  test "system requirements" do
-    assert :error = Nerves.system_requirements(Version.parse!("1.6.0"), "20")
-    assert :error = Nerves.system_requirements(Version.parse!("1.7.0"), "20")
-    assert :error = Nerves.system_requirements(Version.parse!("1.7.0"), "ABC")
-    assert :ok = Nerves.system_requirements(Version.parse!("1.7.0"), "21")
-    assert :ok = Nerves.system_requirements(Version.parse!("1.10.2"), "22")
-  end
-
   test "populate Nerves env" do
     in_fixture("simple_app", fn ->
       packages =


### PR DESCRIPTION
Mix already checks for a compatible version of Elixir and the Nerves
system does a very specific check on the version of Erlang. Therefore
the check here is redundant as well as not being as easy to maintain as
the other checks.
