### PR TITLE
Move tooling from Nerves.Bootstrap into Nerves 

### DIFF
--- a/lib/mix/nerves/io.ex
+++ b/lib/mix/nerves/io.ex
@@ -1,0 +1,39 @@
+defmodule Mix.Nerves.IO do
+  @moduledoc false
+  @app Mix.Project.config()[:app]
+
+  @spec debug_info(String.t(), String.t(), atom()) :: :ok
+  def debug_info(header, text \\ "", loc \\ @app) do
+    if System.get_env("NERVES_DEBUG") == "1" do
+      shell_info(header, text, loc)
+    end
+
+    :ok
+  end
+
+  @spec shell_info(String.t(), String.t(), atom()) :: :ok
+  def shell_info(header, text \\ "", loc \\ @app) do
+    Mix.shell().info([:inverse, "|#{loc}| #{header}", :reset])
+    Mix.shell().info(text)
+  end
+
+  @spec shell_warn(String.t(), String.t(), atom()) :: :ok
+  def shell_warn(header, text \\ "", loc \\ @app) do
+    Mix.shell().error([:inverse, :red, "|#{loc}| #{header}", :reset])
+    Mix.shell().error(text)
+  end
+
+  @spec nerves_env_info() :: :ok
+  def nerves_env_info() do
+    Mix.shell().info([
+      :green,
+      """
+
+      Nerves environment
+        MIX_TARGET:   #{Mix.target()}
+        MIX_ENV:      #{Mix.env()}
+      """,
+      :reset
+    ])
+  end
+end

--- a/lib/mix/tasks/nerves.clean.ex
+++ b/lib/mix/tasks/nerves.clean.ex
@@ -1,0 +1,54 @@
+defmodule Mix.Tasks.Nerves.Clean do
+  @shortdoc "Cleans dependencies and build artifacts"
+
+  @moduledoc """
+  Cleans dependencies and build artifacts
+
+  Since this is a destructive action, cleaning of dependencies
+  only occurs when one of the following are specified:
+
+    * `dep1 dep2` - the names of Nerves dependencies to be cleaned, separated by spaces
+    * `--all` - cleans all Nerves dependencies
+  """
+
+  use Mix.Task
+  import Mix.Nerves.IO
+
+  @switches [all: :boolean]
+
+  @impl Mix.Task
+  def run(argv) do
+    debug_info("Clean Start")
+    {opts, packages, _} = OptionParser.parse(argv, switches: @switches)
+
+    # Start the Nerves env with the precompiler disabled
+    #  so we can clean the package without building it.
+    Mix.Tasks.Nerves.Env.run(["--disable"])
+
+    packages =
+      case packages do
+        [] ->
+          if opts[:all] do
+            Nerves.Env.packages()
+          else
+            Mix.raise("""
+            You must specify the Nerves dependencies to clean, separated by spaces
+
+            Example:
+              mix nerves.clean nerves_system_rpi3
+
+            Or by passing --all
+              mix nerves.clean --all
+            """)
+          end
+
+        packages ->
+          packages
+          |> Enum.map(&String.to_existing_atom/1)
+          |> Enum.map(&Nerves.Env.package/1)
+      end
+
+    debug_info("Clean End")
+    Nerves.Env.clean(packages)
+  end
+end

--- a/lib/mix/tasks/nerves.deps.get.ex
+++ b/lib/mix/tasks/nerves.deps.get.ex
@@ -1,0 +1,20 @@
+defmodule Mix.Tasks.Nerves.Deps.Get do
+  @moduledoc false
+  use Mix.Task
+
+  import Mix.Nerves.IO
+
+  @impl Mix.Task
+  def run(_argv) do
+    debug_info("Nerves.Deps.Get Start")
+    nerves_env_info()
+    # We want to start Nerves.Env so it compiles `nerves`
+    # but pass --disable to prevent it from compiling
+    # the system and toolchain during this time.
+    Mix.Tasks.Nerves.Env.run(["--disable"])
+    Mix.Task.run("nerves.artifact.get", [])
+    Nerves.Bootstrap.check_for_update()
+
+    debug_info("Nerves.Deps.Get End")
+  end
+end

--- a/lib/mix/tasks/nerves.env.ex
+++ b/lib/mix/tasks/nerves.env.ex
@@ -1,0 +1,58 @@
+defmodule Mix.Tasks.Nerves.Env do
+  @moduledoc false
+  use Mix.Task
+  import Mix.Nerves.IO
+
+  @switches [info: :boolean, disable: :boolean]
+
+  @impl Mix.Task
+  def run(argv) do
+    debug_info("Env Start")
+    {opts, _, _} = OptionParser.parse(argv, switches: @switches)
+
+    if opts[:disable] do
+      # This is the same code as Nerves.Env.disable/0, but I can't call that
+      # because we're about to load it immediately below. I also can't call it
+      # after it's loaded below because the act of compiling the nerves dep
+      # calls deps.precompile, which causes the system to get compiled unless
+      # Nerves.Env is disabled, which is what I'm trying to do here. :&
+      # This could probably be solved by moving Nerves.Env into nerves_bootstrap
+      System.put_env("NERVES_ENV_DISABLED", "1")
+    else
+      System.delete_env("NERVES_ENV_DISABLED")
+    end
+
+    # TODO: Remove this as it should be handled when bootstrapping this tooling
+    #       into the current running project. Leave it here for now
+    unless Code.ensure_loaded?(Nerves.Env) do
+      _ = Mix.Tasks.Deps.Loadpaths.run(["--no-compile"])
+
+      Mix.Tasks.Deps.Compile.run(["nerves", "--include-children"])
+    end
+
+    Nerves.Env.start()
+    debug_info("Env End")
+    if opts[:info], do: print_env()
+  end
+
+  defp print_env() do
+    System.put_env("NERVES_DEBUG", "1")
+    debug_info("Environment Package List")
+
+    case Nerves.Env.packages() do
+      [] -> Mix.shell().info("  No packages found")
+      packages -> Enum.each(packages, &print_pkg/1)
+    end
+
+    Mix.Tasks.Nerves.Loadpaths.run([])
+  end
+
+  defp print_pkg(pkg) do
+    Mix.shell().info("""
+      Pkg:         #{pkg.app}
+      Vsn:         #{pkg.version}
+      Type:        #{pkg.type}
+      BuildRunner: #{inspect(pkg.build_runner)}
+    """)
+  end
+end

--- a/lib/mix/tasks/nerves.loadpaths.ex
+++ b/lib/mix/tasks/nerves.loadpaths.ex
@@ -1,0 +1,43 @@
+defmodule Mix.Tasks.Nerves.Loadpaths do
+  @moduledoc false
+  use Mix.Task
+  import Mix.Nerves.IO
+
+  @impl Mix.Task
+  def run(_args) do
+    unless System.get_env("NERVES_PRECOMPILE") == "1" do
+      debug_info("Loadpaths Start")
+
+      Mix.Task.run("nerves.precompile", ["--no-loadpaths"])
+
+      try do
+        nerves_env_info()
+        Mix.Task.run("nerves.env", [])
+        Nerves.Env.bootstrap()
+        Mix.Project.clear_deps_cache()
+        env_info()
+      rescue
+        e ->
+          reraise e, __STACKTRACE__
+      end
+
+      debug_info("Loadpaths End")
+    end
+  end
+
+  defp env(k) do
+    case System.get_env(k) do
+      unset when unset == nil or unset == "" -> "unset"
+      set -> Path.relative_to_cwd(set)
+    end
+  end
+
+  defp env_info() do
+    debug_info("Environment Variable List", """
+      target:     #{Mix.target()}
+      toolchain:  #{env("NERVES_TOOLCHAIN")}
+      system:     #{env("NERVES_SYSTEM")}
+      app:        #{env("NERVES_APP")}
+    """)
+  end
+end

--- a/lib/mix/tasks/nerves.precompile.ex
+++ b/lib/mix/tasks/nerves.precompile.ex
@@ -1,0 +1,96 @@
+defmodule Mix.Tasks.Nerves.Precompile do
+  @moduledoc false
+  use Mix.Task
+  import Mix.Nerves.IO
+
+  @switches [loadpaths: :boolean]
+
+  @impl Mix.Task
+  def run(args) do
+    debug_info("Precompile Start")
+
+    # Note: We have to directly use the environment variable here instead of
+    # calling Nerves.Env.enabled?/0 because the nerves.precompile step happens
+    # before the nerves dependency is compiled, which is where Nerves.Env
+    # currently lives. This would be improved by moving Nerves.Env to
+    # nerves_bootstrap.
+    unless System.get_env("NERVES_ENV_DISABLED") do
+      System.put_env("NERVES_PRECOMPILE", "1")
+
+      {opts, _, _} = OptionParser.parse(args, switches: @switches)
+
+      Mix.Task.run("nerves.env", [])
+
+      {app, deps} =
+        Nerves.Env.packages()
+        |> Enum.split_with(&(&1.app == Mix.Project.config()[:app]))
+
+      (deps ++ app)
+      |> compile_check()
+      |> Enum.each(&compile/1)
+
+      Mix.Task.reenable("deps.compile")
+      Mix.Task.reenable("compile")
+
+      System.put_env("NERVES_PRECOMPILE", "0")
+
+      if opts[:loadpaths] != false, do: Mix.Task.rerun("nerves.loadpaths")
+    end
+
+    debug_info("Precompile End")
+  end
+
+  defp compile(%{app: app}) do
+    if Mix.Project.config()[:app] == app do
+      Mix.Tasks.Compile.run([app, "--include-children"])
+    else
+      Mix.Tasks.Deps.Compile.run([app, "--no-deps-check", "--include-children"])
+    end
+  end
+
+  defp error_on_stale_nerves_package?(package) do
+    # Detect packages that need to be rebuilt by the Nerves package compiler
+    # and that the user hasn't explicitly marked as `compile: true`.  These
+    # universally take long to build so force the user to acknowledge it.
+    Mix.Project.config()[:app] != package.app and
+      :nerves_package in Map.get(package, :compilers, Mix.compilers()) and
+      Nerves.Artifact.expand_sites(package) != [] and
+      Nerves.Artifact.stale?(package) and
+      package.dep_opts[:compile] != true
+  end
+
+  defp compile_check(packages) do
+    case Enum.filter(packages, &error_on_stale_nerves_package?/1) do
+      [] ->
+        packages
+
+      stale_packages ->
+        stale_package_text = for package <- stale_packages, into: "", do: "\n  #{package.app}"
+        example = List.first(stale_packages)
+
+        Mix.raise("""
+
+        The following Nerves packages need to be built:
+        #{stale_package_text}
+
+        The build process for each of these can take a significant amount of
+        time so the maintainers have listed URLs for downloading pre-built packages.
+        If you have not modified these packages, please try running `mix deps.get`
+        or `mix deps.update` to download the precompiled versions.
+
+        If you have limited network access and are able to obtain the files via
+        other means, copy them to `~/.nerves/dl` or the location specified by
+        `$NERVES_DL_DIR`.
+
+        If you are making modifications to one of the packages or want to force
+        local compilation, add `nerves: [compile: true]` to the dependency. For
+        example:
+
+          {:#{example.app}, "~> #{example.version}", nerves: [compile: true]}
+
+        If the package is a dependency of a dependency, you will need to
+        override it on the parent project with `override: true`.
+        """)
+    end
+  end
+end

--- a/lib/mix/tasks/nerves.system.shell.ex
+++ b/lib/mix/tasks/nerves.system.shell.ex
@@ -1,0 +1,80 @@
+defmodule Mix.Tasks.Nerves.System.Shell do
+  @shortdoc "Enter a shell to configure a custom system"
+
+  @moduledoc """
+  Open a shell in a system's build directory.
+
+  In order to make the experience as similar as possible, we attach to a Docker
+  container on non-Linux platforms and run a sub-shell on Linux.
+
+  ## Examples
+
+  Configure the system for the current project's target:
+
+      mix nerves.system.shell
+
+  """
+  use Mix.Task
+
+  @standard_error_message """
+  Make sure you run this task from a Nerves-based project or the source directory of a custom Nerves system.
+  Also, set the MIX_TARGET environment variable to allow mix.exs to know which custom system dependency to use.
+  """
+
+  @no_nerves_dep_error """
+  Nerves dependency not found in current Mix project.
+  #{@standard_error_message}
+  """
+
+  @no_system_pkg_error """
+  Unable to locate a relevant Nerves system package.
+  #{@standard_error_message}
+  """
+
+  @no_mix_target_error """
+  MIX_TARGET environment variable not set or set to "host".
+  #{@standard_error_message}
+  """
+
+  @doc false
+  @spec run([String.t()]) :: :ok
+  def run(_argv) do
+    # We unregister :user so that the process currently holding fd 0 (stdin)
+    # can't send an error message to the console when we steal it.
+    user = Process.whereis(:user)
+    Process.unregister(:user)
+
+    # Start disabled so that we can configure the system before building it
+    # for the first time.
+    try do
+      Mix.Task.run("nerves.env", ["--disable"])
+    rescue
+      e ->
+        case e do
+          %Mix.Error{message: "Unknown dependency nerves for environment " <> _env} ->
+            Mix.raise(@no_nerves_dep_error)
+
+          _ ->
+            reraise(e, __STACKTRACE__)
+        end
+    end
+
+    pkg = Nerves.Env.system()
+
+    if is_nil(pkg) do
+      case Mix.target() do
+        :host -> Mix.raise(@no_mix_target_error)
+        _ -> Mix.raise(@no_system_pkg_error)
+      end
+    end
+
+    {build_runner, _opts} = pkg.build_runner
+
+    build_runner.system_shell(pkg)
+
+    # Set :user back to the real one
+    Process.register(user, :user)
+
+    :ok
+  end
+end

--- a/lib/nerves/artifact.ex
+++ b/lib/nerves/artifact.ex
@@ -83,10 +83,7 @@ defmodule Nerves.Artifact do
 
   @doc """
   Determines if the artifact for a package is stale and needs to be rebuilt.
-
-  Used by NervesBootstrap
   """
-  @doc used_by: NervesBootstrap
   @spec stale?(Nerves.Package.t()) :: boolean
   def stale?(pkg) do
     if env_var?(pkg) do
@@ -243,10 +240,7 @@ defmodule Nerves.Artifact do
   ```elixir
   {:prefix, "http://my-organization.com/", headers: [{"Authorization", "Basic " <> System.get_env("BASIC_AUTH")}}]}
   ```
-
-  Used by NervesBootstrap
   """
-  @doc used_by: NervesBootstrap
   def expand_sites(pkg) do
     case pkg.config[:artifact_url] do
       nil ->

--- a/lib/nerves/env.ex
+++ b/lib/nerves/env.ex
@@ -14,11 +14,8 @@ defmodule Nerves.Env do
   Starts the Nerves environment agent and loads package information.
   If the Nerves.Env is already started, the function returns
   `{:error, {:already_started, pid}}` with the pid of that process
-
-  Used by NervesBootstrap
   """
   @spec start() :: Agent.on_start()
-  @doc used_by: NervesBootstrap
   def start() do
     set_source_date_epoch()
     Agent.start_link(fn -> load_packages() end, name: __MODULE__)
@@ -111,10 +108,7 @@ defmodule Nerves.Env do
 
   @doc """
   Cleans the artifacts for the package build_runners of all specified packages.
-
-  Used by NervesBootstrap
   """
-  @doc used_by: NervesBootstrap
   @spec clean([Nerves.Package.t()]) :: :ok
   def clean(pkgs) do
     Enum.each(pkgs, &Artifact.clean/1)
@@ -241,10 +235,7 @@ defmodule Nerves.Env do
 
   @doc """
   Lists all Nerves packages loaded in the Nerves environment.
-
-  Used by NervesBootstrap
   """
-  @doc used_by: NervesBootstrap
   @spec packages() :: [Nerves.Package.t()]
   def packages() do
     Agent.get(__MODULE__, & &1) || Mix.raise("Nerves packages are not loaded")
@@ -252,10 +243,7 @@ defmodule Nerves.Env do
 
   @doc """
   Gets a package by app name.
-
-  Used by NervesBootstrap
   """
-  @doc used_by: NervesBootstrap
   @spec package(name :: atom) :: Nerves.Package.t() | nil
   def package(name) do
     packages()
@@ -298,10 +286,7 @@ defmodule Nerves.Env do
 
   @doc """
   Helper function for returning the system type package
-
-  Used by NervesBootstrap
   """
-  @doc used_by: NervesBootstrap
   @spec system() :: Nerves.Package.t() | nil
   def system() do
     system =
@@ -345,10 +330,7 @@ defmodule Nerves.Env do
 
   For a comprehensive list of environment variables, see the documentation
   for the package defining system_platform.
-
-  Used by NervesBootstrap
   """
-  @doc used_by: NervesBootstrap
   @spec bootstrap() :: :ok
   def bootstrap() do
     nerves_system_path = system_path()

--- a/mix.exs
+++ b/mix.exs
@@ -72,9 +72,6 @@ defmodule Nerves.MixProject do
         "docs/Experimental Features.md",
         "CHANGELOG.md"
       ],
-      groups_for_functions: [
-        "Used By NervesBootstrap": &(&1[:used_by] == NervesBootstrap)
-      ],
       source_ref: "v#{@version}",
       source_url: @source_url,
       skip_undefined_reference_warnings_on: ["docs/Updating Projects.md", "CHANGELOG.md"]


### PR DESCRIPTION
Companion PR to https://github.com/nerves-project/nerves_bootstrap/pull/225

Moves all the tasks and tooling into `:nerves` package to help simplify
maintenance and execution. This PR simply copies the tasks over and does
not alter functionality.