### PR TITLE
Update documentation for GRiSP 2 Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ community.
 | **[NervesSystemRPi4](https://github.com/nerves-project/nerves_system_rpi4)** | Base Nerves system configuration for the Raspberry Pi 4 | [![Hex.pm](https://img.shields.io/hexpm/v/nerves_system_rpi4.svg)](https://hex.pm/packages/nerves_system_rpi4) |
 | **[NervesSystemVultr](https://github.com/nerves-project/nerves_system_vultr)** | Experimental configuration for a Vultr cloud server | [![Hex.pm](https://img.shields.io/hexpm/v/nerves_system_vultr.svg)](https://hex.pm/packages/nerves_system_vultr) |
 | **[NervesSystemX86_64](https://github.com/nerves-project/nerves_system_x86_64)** | Generic Nerves system configuration x86_64 based hardware | [![Hex.pm](https://img.shields.io/hexpm/v/nerves_system_x86_64.svg)](https://hex.pm/packages/nerves_system_x86_64) |
+| **[NervesSystemGrisp2](https://github.com/nerves-project/nerves_system_grisp2)** |Base Nerves system configuration for the GRiSP 2 | [![Hex.pm](https://img.shields.io/hexpm/v/nerves_system_grisp2.svg)](https://hex.pm/packages/nerves_system_grisp2) |
 
 ### Networking
 

--- a/docs/Targets.md
+++ b/docs/Targets.md
@@ -37,7 +37,7 @@ Raspberry Pi 4 | [nerves_system_rpi4](https://github.com/nerves-project/nerves_s
 BeagleBone Black, BeagleBone Green, BeagleBone Green Wireless, and PocketBeagle. | [nerves_system_bbb](https://github.com/nerves-project/nerves_system_bbb) | `bbb`
 Generic x86_64 | [nerves_system_x86_64](https://github.com/nerves-project/nerves_system_x86_64) | `x86_64`
 OSD32MP1 | [nerves_system_osd32mp1](https://github.com/nerves-project/nerves_system_osd32mp1) | `osd32mp1`
-Grisp 2 | [nerves_system_grisp2](https://github.com/nerves-project/nerves_system_grisp2) | `grisp2`
+GRiSP 2 | [nerves_system_grisp2](https://github.com/nerves-project/nerves_system_grisp2) | `grisp2`
 
 While the Nerves core team only officially supports the above hardware, the
 community has added support for other boards. See [Nerves Systems on

--- a/docs/Targets.md
+++ b/docs/Targets.md
@@ -37,6 +37,7 @@ Raspberry Pi 4 | [nerves_system_rpi4](https://github.com/nerves-project/nerves_s
 BeagleBone Black, BeagleBone Green, BeagleBone Green Wireless, and PocketBeagle. | [nerves_system_bbb](https://github.com/nerves-project/nerves_system_bbb) | `bbb`
 Generic x86_64 | [nerves_system_x86_64](https://github.com/nerves-project/nerves_system_x86_64) | `x86_64`
 OSD32MP1 | [nerves_system_osd32mp1](https://github.com/nerves-project/nerves_system_osd32mp1) | `osd32mp1`
+Grisp 2 | [nerves_system_grisp2](https://github.com/nerves-project/nerves_system_grisp2) | `grisp2`
 
 While the Nerves core team only officially supports the above hardware, the
 community has added support for other boards. See [Nerves Systems on


### PR DESCRIPTION
We now officially support GRiSP2, adding [nerves_system_grisp2](https://github.com/nerves-project/nerves_system_grisp2).

## Changes

* Add NervesSystemGrisp2 to the Hardware section in README.md
* Add `grisp2` to the Supporded Targets and Systems documentation

