### PR TITLE
Add space between system CFLAGS and environment flags

### DIFF
--- a/lib/nerves/env.ex
+++ b/lib/nerves/env.ex
@@ -455,8 +455,8 @@ defmodule Nerves.Env do
 
   defp process_target_gcc_flags(%{"TARGET_GCC_FLAGS" => flags} = env) do
     env
-    |> Map.put("CFLAGS", flags <> System.get_env("CFLAGS", ""))
-    |> Map.put("CXXFLAGS", flags <> System.get_env("CXXFLAGS", ""))
+    |> Map.put("CFLAGS", flags <> " " <> System.get_env("CFLAGS", ""))
+    |> Map.put("CXXFLAGS", flags <> " " <> System.get_env("CXXFLAGS", ""))
   end
 
   defp process_target_gcc_flags(env), do: env


### PR DESCRIPTION
This fixes an issue where the flags could smash together if not careful
and amazingly this didn't cause an error.
