### PR TITLE
Add mix task to display artifact name/information

### DIFF
--- a/lib/mix/tasks/nerves.artifact.details.ex
+++ b/lib/mix/tasks/nerves.artifact.details.ex
@@ -3,7 +3,7 @@ defmodule Mix.Tasks.Nerves.Artifact.Details do
   @moduledoc """
   Prints Nerves artifact details.
 
-  This displays various artifact names/information.
+  This displays various details.
 
   ## Examples
 
@@ -15,6 +15,8 @@ defmodule Mix.Tasks.Nerves.Artifact.Details do
   use Mix.Task
 
   import Mix.Nerves.IO
+
+  alias Nerves.Artifact
 
   require Logger
 
@@ -49,15 +51,31 @@ defmodule Mix.Tasks.Nerves.Artifact.Details do
       if is_nil(package) do
         Mix.raise("Could not find Nerves package #{package_name} in env")
       else
-        Mix.shell().info("Name:               #{Nerves.Artifact.name(package)}")
-        Mix.shell().info("Download Name:      #{Nerves.Artifact.download_name(package)}")
+        Mix.shell().info("Version:            #{package.version}")
+        Mix.shell().info("Checksum:           #{Artifact.checksum(package)}")
+        # TODO - Find a way to get this from Artifact
+        short_checksum_length = 7
 
         Mix.shell().info(
-          "Download File Name: #{Nerves.Artifact.download_name(package)}#{Nerves.Artifact.ext(package)}"
+          "Checksum Short      #{Artifact.checksum(package, short: short_checksum_length)}"
         )
 
-        Mix.shell().info("Download Path:      #{Nerves.Artifact.download_path(package)}")
-        Mix.shell().info("Checksum:           #{Nerves.Artifact.checksum(package)}")
+        Mix.shell().info("Name:               #{Artifact.name(package)}")
+        Mix.shell().info("Download Name:      #{Artifact.download_name(package)}")
+
+        Mix.shell().info(
+          "Download File Name: #{Artifact.download_name(package)}#{Artifact.ext(package)}"
+        )
+
+        Mix.shell().info("Download Path:      #{Artifact.download_path(package)}")
+
+        Mix.shell().info(
+          "Sites:              #{inspect(Keyword.get(package.config, :artifact_sites, []))}"
+        )
+
+        Mix.shell().info("Base Directory:     #{Artifact.base_dir()}")
+        Mix.shell().info("Path:               #{Artifact.dir(package)}")
+        Mix.shell().info("Build Path:         #{Artifact.build_path(package)}")
       end
 
     debug_info("Nerves.Artifact.Details end")

--- a/lib/mix/tasks/nerves.artifact.details.ex
+++ b/lib/mix/tasks/nerves.artifact.details.ex
@@ -1,13 +1,13 @@
-defmodule Mix.Tasks.Nerves.Artifact.Name do
-  @shortdoc "Prints Nerves artifact name/information"
+defmodule Mix.Tasks.Nerves.Artifact.Details do
+  @shortdoc "Prints Nerves artifact details"
   @moduledoc """
-  Prints Nerves artifact name/information.
+  Prints Nerves artifact details.
 
   This displays various artifact names/information.
 
   ## Examples
 
-      $ mix nerves.artifact.name nerves_system_rpi0
+      $ mix nerves.artifact.details nerves_system_rpi0
 
   If the command is called without the package name,
   `Nerves.Project.config()[:app]` will be used by default.
@@ -39,7 +39,7 @@ defmodule Mix.Tasks.Nerves.Artifact.Name do
           {package_name, argv}
       end
 
-    debug_info("Nerves.Artifact.Name start")
+    debug_info("Nerves.Artifact.Details start")
 
     package_name = String.to_atom(package_name)
 
@@ -51,11 +51,15 @@ defmodule Mix.Tasks.Nerves.Artifact.Name do
       else
         Mix.shell().info("Name:               #{Nerves.Artifact.name(package)}")
         Mix.shell().info("Download Name:      #{Nerves.Artifact.download_name(package)}")
-        Mix.shell().info("Download File Name: #{Nerves.Artifact.download_name(package)}#{Nerves.Artifact.ext(package)}")
+
+        Mix.shell().info(
+          "Download File Name: #{Nerves.Artifact.download_name(package)}#{Nerves.Artifact.ext(package)}"
+        )
+
         Mix.shell().info("Download Path:      #{Nerves.Artifact.download_path(package)}")
         Mix.shell().info("Checksum:           #{Nerves.Artifact.checksum(package)}")
       end
 
-    debug_info("Nerves.Artifact.Name end")
+    debug_info("Nerves.Artifact.Details end")
   end
 end

--- a/lib/mix/tasks/nerves.artifact.name.ex
+++ b/lib/mix/tasks/nerves.artifact.name.ex
@@ -1,0 +1,61 @@
+defmodule Mix.Tasks.Nerves.Artifact.Name do
+  @shortdoc "Prints Nerves artifact name/information"
+  @moduledoc """
+  Prints Nerves artifact name/information.
+
+  This displays various artifact names/information.
+
+  ## Examples
+
+      $ mix nerves.artifact.name nerves_system_rpi0
+
+  If the command is called without the package name,
+  `Nerves.Project.config()[:app]` will be used by default.
+  """
+  use Mix.Task
+
+  import Mix.Nerves.IO
+
+  require Logger
+
+  @recursive true
+
+  @impl Mix.Task
+  def run(argv) do
+    # We need to make sure the Nerves env has been set up.
+    # This allows the task to be called from a project level that
+    # does not include aliases to nerves_bootstrap
+    Mix.Task.run("nerves.precompile", [])
+
+    {package_name, _argv} =
+      case argv do
+        [] ->
+          {to_string(Mix.Project.config()[:app]), argv}
+
+        ["-" <> _arg | _] ->
+          {to_string(Mix.Project.config()[:app]), argv}
+
+        [package_name | argv] ->
+          {package_name, argv}
+      end
+
+    debug_info("Nerves.Artifact.Name start")
+
+    package_name = String.to_atom(package_name)
+
+    package = Nerves.Env.package(package_name)
+
+    _ =
+      if is_nil(package) do
+        Mix.raise("Could not find Nerves package #{package_name} in env")
+      else
+        Mix.shell().info("Name:               #{Nerves.Artifact.name(package)}")
+        Mix.shell().info("Download Name:      #{Nerves.Artifact.download_name(package)}")
+        Mix.shell().info("Download File Name: #{Nerves.Artifact.download_name(package)}#{Nerves.Artifact.ext(package)}")
+        Mix.shell().info("Download Path:      #{Nerves.Artifact.download_path(package)}")
+        Mix.shell().info("Checksum:           #{Nerves.Artifact.checksum(package)}")
+      end
+
+    debug_info("Nerves.Artifact.Name end")
+  end
+end


### PR DESCRIPTION
Fixes #771

This fix adds a mix task `mix nerves.artifact.name` which display various artifact  names/information w/o triggering a artifact re-build.

Example:
```
$ mix nerves.artifact.name
==> nerves
==> nerves_system_bbb
Generated nerves_system_bbb app

Nerves environment
  MIX_TARGET:   target
  MIX_ENV:      dev

Name:               nerves_system_bbb-portable-2.15.1
Download Name:      nerves_system_bbb-portable-2.15.1-0C8DD7C
Download File Name: nerves_system_bbb-portable-2.15.1-0C8DD7C.tar.gz
Download Path:      /home/udos/.nerves/dl/nerves_system_bbb-portable-2.15.1-0C8DD7C.tar.gz
Checksum:           0C8DD7CEB69659D7486BBA6B22AE1CB498EF3487A5369411F0C157477F8FF2D0
```