### PR TITLE
Add Connecting to Nerves Target page and do adjustment around it

### DIFF
--- a/docs/Connecting to Nerves Target.md
+++ b/docs/Connecting to Nerves Target.md
@@ -1,0 +1,234 @@
+# Connecting to Nerves Target
+
+There are multiple ways to connect to your Nerves target device and different
+target may support different connection methods.
+
+The default features are different depending on Nerves targets. For example,
+some Nerves targets support a UART serial console by default; others,
+HDMI and USB keyboard instead.
+
+> #### What features does Nerves support for my device? {: .tip}
+>
+> Refer to the documentation of `nerves_system_<target>` projects for their
+> supported features. As an example, when your target is `rpi0`,
+> visit https://hexdocs.pm/nerves_system_rpi0.
+
+## USB to TTL serial cable (UART)
+
+A target device can be accessed via a serial connection with a USB to TTL serial
+cable, which is connected between the host USB port and a couple of header pins
+on the target.
+
+This connection method allows you to interact with the console of the target
+device using a terminal emulator program on your development host. It is useful
+for debugging networking or the boot process and for advanced development
+workflows.
+
+First of all, locate the documentation of the Nerve system that corresponds to
+your target device, and find out how your Nerves system supports the IEx
+terminal feature.
+
+As an example, as of this writing, the documentation of
+[nerves_system_rpi0] (a Nerves system for [Raspberry Pi Zero]) says the system
+supports one UART port named `ttyAMA0` available for IEx terminal.
+It is `/dev/ttyAMA0` in the file system.
+
+![](https://user-images.githubusercontent.com/7563926/181918220-00733048-8706-4b40-957d-b621d308fc2f.png)
+
+It is configured [here](https://github.com/nerves-project/nerves_system_rpi0/blob/ddb128989cf9bb28dd78f4467992d00b89828f02/rootfs_overlay/etc/erlinit.config#L12)
+in the `nerves_system_rpi0` source code.
+
+On the Raspberry Pi Zero, the UART that is known as `UART0` in the hardware
+descriptions is routed to pins 8 and 10.
+
+On Linux on the Raspberry Pi Zero, `UART0` is exposed as the device file
+ `/dev/ttyAMA0`.
+
+> #### Enabling USB serial console {: .info}
+>
+> Depending on your target's default settings, you may need to modify your
+> Nerves configuration as described in the
+> [Using a USB Serial Console](faq.html#using-a-usb-serial-console)
+> FAQ topic.
+
+[raspberry pi zero]: https://www.raspberrypi.com/products/raspberry-pi-zero-w
+[raspberry pi zero w]: https://www.raspberrypi.com/products/raspberry-pi-zero-w
+[nerves_system_rpi0]: https://hexdocs.pm/nerves_system_rpi0
+
+### Get a USB-to-TTL serial cable
+
+We've had good luck with [this cable](https://www.adafruit.com/product/954) if
+you haven't already found one.
+
+You may need to install to your host machine the driver software for the cable.
+If you use the above-mentioned cable, Adafruits provides [this guide][usb-to-ttl serial cable - software installation].
+
+[usb-to-ttl serial cable - software installation]: https://learn.adafruit.com/adafruits-raspberry-pi-lesson-5-using-a-console-cable/software-installation-mac
+
+### Connect the leads
+
+| Raspberry Pi             | USB-to-TTL Serial Cable |
+| ------------------------ | ----------------------- |
+| `TX0` (pin 8 / GPIO 14)  | `RX`                    |
+| `RX0` (pin 10 / GPIO 15) | `TX`                    |
+| `GND`                    | `GND`                   |
+
+![](https://user-images.githubusercontent.com/7563926/181919087-03649fb1-b7c5-4601-bbb4-994fb07ea39e.png)
+
+Image credit: https://pinout.xyz
+
+> #### Tips {: .tip}
+>
+> Most likely you don't need the power line since your purpose here is the
+> serial data communication.
+>
+> `TX` (transmit) and `RX` (receive) are relative terms. What is `TX` for one
+> is `RX` for the other.
+
+For visual learners, [Adafruit's Raspberry Pi Lesson](https://learn.adafruit.com/adafruits-raspberry-pi-lesson-5-using-a-console-cable/connect-the-lead)
+has some helpful images.
+
+### Run a terminal emulation program
+
+The USB-to-TTL serial cable converts the text into a standard serial USB port.
+There are multiple open source terminal emulator programs out there that
+support the serial console.
+
+- [screen](https://en.wikipedia.org/wiki/GNU_Screen)
+- [picocom](https://github.com/npat-efault/picocom)
+- [tio](https://github.com/tio/tio)
+- [bootterm](https://github.com/wtarreau/bootterm)
+
+As an example,  on a macOS host machine, you can open a terminal and try these
+commands.
+
+#### List TTY devices available
+
+```bash
+ls /dev/tty.*
+```
+
+#### Start communication with the Raspberry Pi using the `screen` command
+
+```bash
+screen /dev/tty.usb* 115200
+```
+
+The terminal emulation program will replace `usb*` with the name of your host's
+USB port.
+
+You should be at an `iex(1)>` prompt. If not, try pressing `Enter` a few times.
+
+> #### Linux USB gadget mode {: .info}
+>
+> Linux USB gadget mode also supplies a virtual serial connection for some
+> Nerves targets.
+
+### Troubleshooting
+
+#### First boot shows error messages
+
+First boot shows error messages due to the file system not being formatted.
+Seems like something is wrong even though it isn't. This is visible if you
+attach to the UART and watch the messages the very first time that you boot off
+a MicroSD card.
+
+#### Toolshed's `exit` not working in the serial console
+
+It works, but Erlang doesn't automatically restart the shell. You should be
+able to type CTRL-G to get the Erlang job menu.
+
+#### **"could not find a PTY" Error when running `screen` command**
+
+Unplug the USB connector and re-plug it.
+
+## HDMI cable
+
+On some Raspberry Pi family of targets, the `IEx` console is displayed on the
+screen attached to the HDMI port by default. You can simply connect your target
+device to a monitor or TV.
+
+## USB data cable
+
+Some Nerves targets can operate in Linux USB gadget mode, which means a network
+connection can be made with a USB cable between your host and target. The USB
+cable provides both power and network connectivity. This can be a convenient way
+to work with your target device.
+
+> #### Use correct USB port {: .warning}
+>
+> Make sure to plug the USB cable into the USB OTG port. For example, the
+> Raspberry Pi Zero has two USB ports. The OTG one is the "middle" one. The
+> other one is power-only.
+
+> #### Use correct USB cable {: .warning}
+>
+> Make sure your USB cable supports data transfer. Generally there are two types
+> of USB cables:
+> - charging only
+> - charging and data transfer
+
+### Test the connection
+
+Once the target is powered up, test the connection from your host:
+
+```bash
+ping nerves.local
+```
+
+### Make the network connection
+
+To make a connection via the Linux USB gadget mode virtual Ethernet interface:
+
+```bash
+ssh nerves.local
+```
+
+You should find yourself at the `iex(hello_nerves@nerves.local)1>` prompt.
+
+To end your ssh connection type `exit`, or you can use the `ssh` command
+`<enter>~.`
+
+> #### _nerves.local_ is an mDNS address {: .info}
+>
+> Most examples in this page are done with a macOS host, which has mDNS enabled
+> by default. Linux and Windows hosts may have to enable mDNS networking.
+
+### Gadget-mode virtual serial connection
+
+USB gadget mode also supplies a virtual serial connection. Use it with any
+terminal emulator like `screen` or `picocom`:
+
+```bash
+screen /dev/usb* 115200
+```
+
+> #### Windows _Device Manager / Network adapters_ has no _USB Ethernet/RNDIS Gadget_ device? {: .info}
+>
+> It might be caused by
+> [this](https://www.ghacks.net/2020/09/28/should-you-install-windows-10s-optional-driver-updates),
+> so install the optional `USB Ethernet/RNDIS Gadget` driver to fix it.
+
+## Wireless and wired Ethernet connections
+
+The `config/config.exs` generated in a new Nerves project will set up
+connections for USB and Ethernet by default.
+
+The [`nerves_pack`] dependency simplifies the network setup and configuration
+process. At runtime, `nerves_pack` will detect all available interfaces that
+have not been configured and apply defaults for `usb*` and `eth*` interfaces.
+
+- For `eth*` interfaces, the device attempts to connect to the network
+with DHCP using `ipv4` addressing.
+- For `usb*` interfaces, it uses [`vintage_net_direct`] to run a simple DHCP
+server on the device and assign the host an IP address over a USB cable.
+
+If you want to use some other network configuration, such as wired or wireless
+Ethernet, refer to the [`nerves_pack`] documentation and the underlying
+[`vintage_net`] documentation as needed.
+
+[`nerves_pack`]: https://hexdocs.pm/nerves_pack
+[`vintage_net_wifi`]: https://hexdocs.pm/vintage_net_wifi
+[`vintage_net_direct`]: https://hexdocs.pm/vintage_net_direct
+[`nerves_pack`]: https://hexdocs.pm/nerves_pack
+[`vintage_net`]: https://hexdocs.pm/vintage_net

--- a/docs/Connecting to Nerves Target.md
+++ b/docs/Connecting to Nerves Target.md
@@ -200,7 +200,7 @@ USB gadget mode also supplies a virtual serial connection. Use it with any
 terminal emulator like `screen` or `picocom`:
 
 ```bash
-screen /dev/usb* 115200
+picocom -b115200 /dev/ttyUSB0
 ```
 
 > #### Windows _Device Manager / Network adapters_ has no _USB Ethernet/RNDIS Gadget_ device? {: .info}

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -46,7 +46,7 @@ For production environments you might also want to look at https://www.nerves-hu
 
 ## Using a USB Serial Console
 
-By default on the Raspberry Pi family of targets (except for the Raspberry Pi Zero), the `iex` console is displayed on the screen attached to the HDMI port, which tends to be easier for new people because they can simply connect their target device to a monitor or TV.
+By default on some Raspberry Pi family of targets, the `IEx` console is displayed on the screen attached to the HDMI port, which tends to be easier for new people because they can simply connect their target device to a monitor or TV.
 For troubleshooting start-up issues and for more advanced development workflows, it's often desirable to connect from your development host to the target using a serial port, for example using the popular [FTDI Cable](https://www.sparkfun.com/products/9717).
 This allows you to interact with the console of the target device using a terminal emulator (like `screen`) on your development host.
 

--- a/docs/Getting Started.md
+++ b/docs/Getting Started.md
@@ -186,7 +186,7 @@ hello_nerves 0.2.0 (40705268-3e85-52b6-7c7a-05ffd33a31b8) arm rpi0
   wlan0        : 10.0.0.25/24, 2601:14d:8602:2a0:ba27:ebff:fecb:222a/64, fe80::ba27:ebff:fecb:222a/64
   usb0         : 172.31.36.97/30, fe80::3c43:59ff:fec9:6716/64
 
-Nerves CLI help: https://hexdocs.pm/nerves/using-the-cli.html
+Nerves CLI help: https://hexdocs.pm/nerves/iex-with-nerves.html
 
 Toolshed imported. Run h(Toolshed) for more info.
 iex(nerves@nerves.local)1>

--- a/docs/Getting Started.md
+++ b/docs/Getting Started.md
@@ -2,15 +2,13 @@
 
 ## Introduction
 
-Nerves defines a new way to build embedded systems using Elixir.  It is
+Nerves defines a new way to build embedded systems using [Elixir](https://elixir-lang.org/). It is
 specifically designed for embedded systems, not desktop or server systems.  You
 can think of Nerves as containing three parts:
 
-**Platform** - a customized, minimal Buildroot-derived Linux that boots directly to the BEAM VM.
-
-**Framework** - ready-to-go library of Elixir modules to get you up and running quickly.
-
-**Tooling** - powerful command-line tools to manage builds, update firmware, configure devices, and more.
+- **Platform** - a customized, minimal [Buildroot](https://buildroot.org)-derived Linux that boots directly to the [BEAM VM](https://en.wikipedia.org/wiki/BEAM_(Erlang_virtual_machine)).
+- **Framework** - ready-to-go library of Elixir modules to get you up and running quickly.
+- **Tooling** - powerful command-line tools to manage builds, update firmware, configure devices, and more.
 
 Taken together, the Nerves platform, framework, and tooling provide a highly specialized environment for using Elixir to build advanced embedded devices.
 
@@ -21,7 +19,7 @@ In the following guides, support channels, and forums, you may hear the followin
 Term | Definition
 --- | ---
 host | The computer on which you are editing source code, compiling, and assembling firmware
-target | The platform for which your firmware is built (for example, Raspberry Pi, Raspberry Pi 2, or Beaglebone Black)
+target | The platform for which your firmware is built (for example, Raspberry Pi Zero W, Raspberry Pi 4, or Beaglebone Black)
 toolchain | The tools required to build code for the target, such as compilers, linkers, binutils, and C runtime
 system | A lean Buildroot-based Linux distribution that has been customized and cross-compiled for a particular target
 assemble | The process of combining system, application, and configuration into a firmware bundle
@@ -37,13 +35,6 @@ configured for running Nerves.
 Let's create a new project.  The `nerves.new` project generator can be called
 from anywhere and can take either an absolute path or a relative path.
 
-> NOTE: If you've used Nerves in the past, you may have noticed that you no
-> longer need to specify a `--target` option when creating a new project.  Since
-> Nerves Bootstrap 0.3.0, the default target is `host` unless you specify a
-> different target in your environment.  This allows for more seamless
-> interaction with tools on your host without cross-compilers getting in the way
-> until you're ready to build firmware for a particular target.
-
 ``` bash
 mix nerves.new hello_nerves
 ```
@@ -53,9 +44,13 @@ application. If you chose not to fetch dependencies during project generation, y
 to do that yourself.
 
 As described by the project generator, the next step is to change to the project
-directory, choose a target, and fetch the target-specific dependencies.  Visit
-the [Targets Page](targets.html) for more information on what target name to use
-for each of the boards that Nerves supports.
+directory, choose a target, and fetch the target-specific dependencies.
+
+> #### What is my device's _MIX_TARGET_? {: .tip}
+>
+> Visit the [Targets Page](targets.html) for information on what target name to
+> use for each of the boards that Nerves supports. The default target is `host`
+> unless you specify a different target in your environment.
 
 The target is chosen using a shell environment variable, so if you use the
 `export` command, it will remain in effect as long as you leave that window
@@ -80,9 +75,6 @@ MIX_TARGET=rpi0 mix deps.get
 This allows you quick access to use host-based tooling in the former and
 deploy updated firmware from the latter, all without having to modify the
 `MIX_TARGET` variable in your shell.
-
-> REMINDER: To choose the correct target for your specific device refer to the
-> [Targets Page](targets.html)
 
 ## Building and deploying firmware
 
@@ -127,124 +119,104 @@ MIX_TARGET=rpi0 mix firmware.burn
 ```
 
 This command will attempt to automatically discover the SD card inserted in your
-host.  This may fail to correctly detect your SD card, for example, if you have
-more than one SD card inserted or you have disk images mounted.  If this
-happens, you can specify the intended device by passing the `-d <device>`
-argument to the command. For example:
+host.
 
-```bash
-mix firmware.burn -d /dev/rdisk3
-```
-
-> NOTE: You can also use `-d <filename>` to specify an output file that is a raw image of the SD card.
-This binary image can be burned to an SD card using `fwup`, `dd`, `Win32DiskImager`, or some other image copying utility.
+> #### More than one SD cards or disk images? {: .tip}
+>
+> `mix firmware.burn` may fail to correctly detect your SD card, for example,
+> if you have more than one SD card inserted or you have disk images mounted.
+> If this happens, you can specify the intended device by passing the
+> `-d <device>` argument to the command. For example
+> `mix firmware.burn -d /dev/rdisk3`
+>
+> You can alse use `-d <filename>` to specify an output file that is a raw
+> image of the SD card. This binary image can be burned to an SD card using
+> `fwup`, `dd`, `Win32DiskImager`, or some other image copying utility.
 
 For more options, refer to the `mix firmware.burn` documentation.
 
 Now that you have your SD card burned, you can insert it into your device and
-boot it up.  For Raspberry Pi, be sure to connect it to an HDMI display and USB
-keyboard so you can see it boot to the IEx console.
+boot it up.
 
 ## Connecting to your Nerves target
 
-You can connect to an RPi0, RPi3A, and BBB with just a USB cable. These Nerves
-targets can operate in Linux USB gadget mode, which means a network connection
-can be made with a USB cable between your host and target. The USB cable
-provides both power and network connectivity. This is a very convenient way to
-work with your target device.
+There are multiple ways to connect to your Nerves target device and different
+target may support different connection methods:
 
-The RPi3B/B+ does not have USB gadget mode capability, but you can make a
-network connection using either wired or wireless Ethernet.
+- USB to TTL serial cable (aka FTDI cable)
+- HDMI cable
+- USB data cable
+- Ethernet
+- WiFi
 
-### Attach a USB cable to the RPi0 / RPi0W / RPi0WH
+When connecting with a USB to TTL serial cable or an HDMI cable before booting
+up your device, you can see your device booting to the IEx console.
 
-Connect a USB cable between your host and the RPi0 USB port closest to the
-middle of the board that is labeled "USB". This USB port, via the USB cable,
-will provide both power to the board and a virtual Ethernet network
-connection.
+For more info, refer to [Connecting to Nerves Target page](connecting-to-nerves-target.html).
 
-If you don't see any activity lights blinking on the board after plugging in
-your USB cable, something's not working right. So then, rather power up your
-RPi0 using a dedicated power supply, and use your USB cable only for
-communication.
-
-#### Test the connection
-
-Once the target is powered up, test the connection from your host:
-
-```bash
-ping nerves.local
-```
-
-> Note: If this does not work it may be because your USB cable only has power
-> lines. You need a cable with both power and data lines, so try a different USB
-> cable.
+> #### What features does Nerves support for my device? {: .tip}
 >
-> Note: If Windows `Device Manager`/`Network adapters` does not have a
-> `USB Ethernet/RNDIS Gadget` device, it might be caused by
-> [this](https://www.ghacks.net/2020/09/28/should-you-install-windows-10s-optional-driver-updates),
-> so install the optional `USB Ethernet/RNDIS Gadget` driver to fix it.
->
-> Note: `nerves.local` is an mDNS address. These examples were done with a Mac
-> host, which has mDNS enabled by default. Linux and Windows hosts may have to
-> enable mDNS networking.
+> Refer to the documentation of `nerves_system_<target>` projects for their
+> supported features. As an example, when your target is `rpi0`,
+> visit https://hexdocs.pm/nerves_system_rpi0.
 
-#### Make the network connection
+## Inspecting your target in `IEx`
 
-To make a connection via the USB gadget mode virtual Ethernet interface:
+Once you are connected to your target device, an `IEx` prompt will appear with
+[`NervesMOTD`](https://hexdocs.pm/nerves_motd/readme.html).
+`IEx` is your main entry point to interacting with Elixir, your program, and hardware.
 
 ```bash
 ssh nerves.local
+
+Interactive Elixir (1.13.4) - press Ctrl+C to exit (type h() ENTER for help)
+████▄▄    ▐███
+█▌  ▀▀██▄▄  ▐█
+█▌  ▄▄  ▀▀  ▐█   N  E  R  V  E  S
+█▌  ▀▀██▄▄  ▐█
+███▌    ▀▀████
+hello_nerves 0.2.0 (40705268-3e85-52b6-7c7a-05ffd33a31b8) arm rpi0
+  Uptime       : 1 days, 3 hours, 6 minutes and 29 seconds
+  Clock        : 2022-08-11 21:44:09 EDT
+
+  Firmware     : Valid (B)               Applications : 57 started
+  Memory usage : 87 MB (28%)             Part usage   : 2 MB (0%)
+  Hostname     : nerves-mn02             Load average : 0.15 0.12 0.14
+
+  wlan0        : 10.0.0.25/24, 2601:14d:8602:2a0:ba27:ebff:fecb:222a/64, fe80::ba27:ebff:fecb:222a/64
+  usb0         : 172.31.36.97/30, fe80::3c43:59ff:fec9:6716/64
+
+Nerves CLI help: https://hexdocs.pm/nerves/using-the-cli.html
+
+Toolshed imported. Run h(Toolshed) for more info.
+iex(nerves@nerves.local)1>
 ```
 
-You should find yourself at the `iex(hello_nerves@nerves.local)1>` prompt. Enter the following command:
+The [Toolshed](https://hexdocs.pm/toolshed/Toolshed.html) package contains
+many useful commands. Enter the following command to display the help for the
+[Toolshed](https://hexdocs.pm/toolshed/Toolshed.html) package.
 
 ```elixir
 h Toolshed
 ```
 
-This displays the help for the
-[Toolshed](https://hexdocs.pm/toolshed/Toolshed.html) package, which contains
-many useful commands. Go ahead and try them out to explore your target's runtime
-environment.
+Go ahead and try them out to explore your target's runtime environment.
 
-To end your ssh connection type `exit`, or you can use the `ssh` command
-`<enter>~.`
+For more info on Nerves-specific use of the IEx prompt, refer to
+[IEx with Nerves Page](https://hexdocs.pm/nerves/iex-with-nerves.html).
 
-### Wireless and wired Ethernet connections
-The `config/config.exs` generated in a new Nerves project will setup connections
-for USB and Ethernet by default. Instructions on further configuring them, or to
-configure wireless connections, please refer to [Configure networking](https://hexdocs.pm/nerves/user-interfaces.html#configure-networking) or [VintageNet](https://hexdocs.pm/vintage_net)
-documentation.
+## Nerves Livebook
 
-### Alternate connection methods
+The [Nerves Livebook firmware](https://github.com/livebook-dev/nerves_livebook)
+lets you try out the Nerves projects on real hardware without needing to build
+anything. Within minutes, you'll have a Raspberry Pi or Beaglebone running
+Nerves. You'll be able to run code in [Livebook](https://livebook.dev/) and
+work through Nerves tutorials from the comfort of your browser.
 
-There are a couple alternate connection methods:
+Looking for a quick demo first? Click below for
+[Underjord](https://www.youtube.com/c/Underjord)'s Nerves Quickstart video.
 
-#### Gadget-mode virtual serial connection
-
-USB gadget mode also supplies a virtual serial connection. Use it with any
-terminal emulator like `screen` or `picocom`:
-
-```bash
-screen /dev/usb* 115200     # replace "usb*" with the name of your host's USB port
-```
-
-You should be at an `iex(1)>` prompt. If not, try pressing `Enter` a few times.
-
-#### USB to TTL serial cable
-
-In addition to the wired and wireless connection method described above, targets
-without USB gadget mode can be accessed via a serial connection with a TTL
-cable. The TTL cable is connected between the host USB port and a couple of
-header pins on the target. We've had good luck with [this
-cable](https://www.adafruit.com/product/954) and the site also contains a
-[tutorial](https://learn.adafruit.com/adafruits-raspberry-pi-lesson-5-using-a-console-cable/overview)
-on how to use it.
-
-You will also need to modify your Nerves configuration as described in the
-[Using a USB Serial Console](https://hexdocs.pm/nerves/faq.html#using-a-usb-serial-console) FAQ
-topic.
+[![Install video](https://github.com/livebook-dev/nerves_livebook/raw/main/assets/video.jpg)](https://www.youtube.com/watch?v=-b5TPb_MwQE)
 
 ## Nerves examples
 
@@ -266,6 +238,13 @@ export MIX_TARGET=rpi0
 cd nerves_examples/blinky
 mix do deps.get, firmware, firmware.burn
 ```
+
+## Nerves communities
+
+- [Elixir Slack #nerves channel](https://elixir-slackin.herokuapp.com/)
+- [Nerves Forum](https://elixirforum.com/c/elixir-framework-forums/nerves-forum/74)
+- [Nerves Meetup](https://www.meetup.com/nerves)
+- [Nerves Newsletter](https://underjord.io/nerves-newsletter.html)
 
 <p align="center">
 Is something wrong?

--- a/docs/Getting Started.md
+++ b/docs/Getting Started.md
@@ -131,7 +131,7 @@ host.
 >
 > You can alse use `-d <filename>` to specify an output file that is a raw
 > image of the SD card. This binary image can be burned to an SD card using
-> `fwup`, `dd`, `Win32DiskImager`, or some other image copying utility.
+> [Raspberry Pi Imager](https://www.raspberrypi.com/software/), [Etcher](https://www.balena.io/etcher/), `dd`, `Win32DiskImager`, or other image copying utilities.
 
 For more options, refer to the `mix firmware.burn` documentation.
 

--- a/docs/User Interfaces.md
+++ b/docs/User Interfaces.md
@@ -90,26 +90,7 @@ host:
 
 ### Configure networking
 
-By default, the `my_app_firmware` project will include the [`nerves_pack`]
-dependency, which simplifies the network setup and configuration process. At
-runtime, `nerves_pack` will detect all available interfaces that have not been
-configured and apply defaults for `usb*` and `eth*` interfaces.
-
-For `eth*` interfaces, the device attempts to connect to the network
-with DHCP using `ipv4` addressing.
-
-For `usb*` interfaces, it uses [`vintage_net_direct`] to run a simple DHCP server
-on the device and assign the host an IP address over a USB cable.
-
-If you want to use some other network configuration, such as wired or wireless
-Ethernet, please refer to the [`nerves_pack` documentation] and the
-underlying [`vintage_net` documentation] as needed.
-
-[`nerves_pack`]: https://hexdocs.pm/nerves_pack
-[`vintage_net_wifi`]: https://hexdocs.pm/vintage_net_wifi
-[`vintage_net_direct`]: https://hexdocs.pm/vintage_net_direct
-[`nerves_pack` documentation]: https://hexdocs.pm/nerves_pack/readme.html
-[`vintage_net` documentation]: https://hexdocs.pm/vintage_net/VintageNet.html
+Refer to the [Connecting to Nerves Target page](connecting-to-nerves-target.html).
 
 ### Configure Phoenix
 

--- a/mix.exs
+++ b/mix.exs
@@ -65,10 +65,11 @@ defmodule Nerves.MixProject do
       extras: [
         "docs/Installation.md",
         "docs/Getting Started.md",
+        "docs/Connecting to Nerves Target.md",
+        "docs/IEx with Nerves.md",
         "docs/FAQ.md",
         "docs/Targets.md",
         "docs/Systems.md",
-        "docs/IEx with Nerves.md",
         "docs/User Interfaces.md",
         "docs/Environment Variables.md",
         "docs/Compiling Non-BEAM Code.md",


### PR DESCRIPTION

### Description

This is a sequel of https://github.com/nerves-project/nerves/pull/775 and updated the rest of the "Getting Started" page and related pages.

Some ideas on my mind are:

- to simplify the "Getting Started" guide so beginers can get to know about the Nerves without technical details
- to remove target-specific info where possible, leaving the Nerves documentation as generic as possible
- to take advantage of catchy [admonition-blocks](https://hexdocs.pm/ex_doc/readme.html#admonition-blocks) `ex_doc` provides 
- to let Nerves users use serial console if they have not already
- to update content

Most content is from existing Nerves documentations; some from my learning notes.

## Changes

- Add "Connecting to Nerves Target" page (`docs/Connecting to Nerves Target.md`)
- Add hyperlinks for Elixir language, BEAM, Buildroot etc
- Remove some outdated content 
  - Nerves Bootstrap 0.3.0 info
- Add Nerves Livebook section to "Getting Started"
- Add Nerves communities section to "Getting Started"
- Move "IEx with Nerves" page closer to "Getting Started" in the sidebar

## Screenshots

<details>
  <summary>Getting Started</summary>
  <img src="https://user-images.githubusercontent.com/7563926/184496360-bde08808-26ac-4ed8-9247-c5e54c15584f.png"/>
</details>
<details>
  <summary>Connecting to Nerves Target</summary>
  <img src="https://user-images.githubusercontent.com/7563926/184496363-02eb40c5-a42d-49bf-8032-24882f2b8e29.png"/>
</details>

