### PR TITLE
Add "Using the CLI" link to point to new location

### DIFF
--- a/docs/Using the CLI.md
+++ b/docs/Using the CLI.md
@@ -1,0 +1,4 @@
+# Using the CLI
+
+Command line documentation is now at [IEx with Nerves Page](https://hexdocs.pm/nerves/iex-with-nerves.html).
+

--- a/mix.exs
+++ b/mix.exs
@@ -78,6 +78,7 @@ defmodule Nerves.MixProject do
         "docs/Internals.md",
         "docs/Customizing Systems.md",
         "docs/Experimental Features.md",
+        "docs/Using the CLI.md",
         "CHANGELOG.md"
       ],
       source_ref: "v#{@version}",


### PR DESCRIPTION
This link is used in NervesMOTD and possibly other places. The CLI docs
moved, so this directs the user to the new place until the links can all
be updated.
