### PR TITLE
Remove build_embedded

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -13,7 +13,6 @@ defmodule Nerves.MixProject do
       deps: deps(),
       description: description(),
       package: package(),
-      build_embedded: true,
       compilers: [:elixir_make | Mix.compilers()],
       make_targets: ["all"],
       make_clean: ["clean"],


### PR DESCRIPTION
build_embedded isn't needed here and probably will be removed in Elixir
1.15.
