### PR TITLE
Add a tip of deleting cached artifacts

### DIFF
--- a/docs/Getting Started.md
+++ b/docs/Getting Started.md
@@ -88,6 +88,11 @@ can be shared across projects.
 For remote deployment information, see "How do I push firmware updates
 remotely?" in the [FAQ](FAQ.md#how-do-i-push-firmware-updates-remotely).
 
+> #### Deleting cached artifacts {: .tip}
+>
+> It is always OK to `rm -fr ~/.nerves`. The consequence is that the archives
+> that you're using will need to be re-downloaded when you run `mix deps.get`.
+
 ### Create the firmware bundle
 
 You can create the firmware bundle with the following command:


### PR DESCRIPTION
### Description

Nerves automatically caches Nerves artifacts that are downloaded for our Nerves projects for our convenience. As time progresses, it may result it a pile of old unused Nerves artifacts in our development host machine.

How about show the Nerves users how to delete those archives?

### Changes

Add a pro tip box with a brief explanation

![](https://user-images.githubusercontent.com/7563926/190834105-d9b3911c-7661-494a-98f7-b6d385ea75fd.png)
