### PR TITLE
Fix sporadically failing cache_test.exs

### DIFF
--- a/test/nerves/cache_test.exs
+++ b/test/nerves/cache_test.exs
@@ -78,6 +78,11 @@ defmodule Nerves.CacheTest do
 
       File.touch(dl_path)
       assert File.exists?(dl_path)
+
+      # This might be leftover from previous test so we need to delete it
+      # here to prevent the code path from resolving to another existing
+      # test artifact and ensure it tries to resolve our corrupted download
+      System.delete_env("NERVES_SYSTEM")
       Mix.Tasks.Nerves.Artifact.Get.get(:system)
       refute File.exists?(dl_path)
     end)


### PR DESCRIPTION
This test has been plaguing our CI runs forever by sporadically and inconsistently failing. The failing test expects a corrupted system download to be deleted and not exist, but sometimes fails because the file is there. It turns out that during this particular file check, we first look for `NERVES_SYSTEM` to be set and use that path if it exists. We just so happen to set that environment variable in other tests to a valid system file and there is a race between that env var being cleaned up and this test running while processing tests asyncronously, which is why it works for some seeds and not for others.

This forcefully deletes that env var before running the test to ensure the expected corrupted test file gets picked up by the tooling instead and cleaned up as expected