### PR TITLE
Include `MIX_BUILD_PATH` in the firmware build process

### DIFF
--- a/lib/mix/tasks/firmware.ex
+++ b/lib/mix/tasks/firmware.ex
@@ -129,7 +129,7 @@ defmodule Mix.Tasks.Firmware do
     release_path = Path.join(Mix.Project.build_path(), "rel/#{otp_app}")
     output = [release_path]
     args = args ++ fwup_conf ++ rootfs_overlays ++ fw ++ rootfs_priorities ++ output
-    env = standard_fwup_variables(config)
+    env = [{"MIX_BUILD_PATH", Mix.Project.build_path()} | standard_fwup_variables(config)]
 
     set_provisioning(firmware_config[:provisioning])
 


### PR DESCRIPTION
For https://github.com/nerves-project/nerves/issues/576

This allows us to use the build path for the specific target/env when compiling the firmware. Requires https://github.com/nerves-project/nerves_system_br/pull/674