### PR TITLE
Remove deprecated Mix.Config

### DIFF
--- a/docs/Advanced Configuration.md
+++ b/docs/Advanced Configuration.md
@@ -10,8 +10,6 @@ let's start by modifying our `config.exs` to include configs for each target.
 ```elixir
 # config/config.exs
 
-use Mix.Config
-
 import_config "#{Mix.Project.config[:target]}.exs"
 ```
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -73,8 +73,6 @@ For example, for the Raspberry Pi 3 target, you can find the [hardware descripti
     ```elixir
     # config/config.exs
 
-    use Mix.Config
-
     config :nerves, :firmware,
       rootfs_overlay: "rootfs_overlay"
     ```

--- a/docs/User Interfaces.md
+++ b/docs/User Interfaces.md
@@ -106,8 +106,6 @@ Our configuration might look like this (as of Phoenix 1.6.2):
 ```elixir
 # my_app_/my_app_firmware/config/target.exs
 
-import Config
-
 config :my_app_ui, MyAppUiWeb.Endpoint,
   url: [host: "nerves.local"],
   http: [port: 80],

--- a/test/fixtures/umbrella/config/config.exs
+++ b/test/fixtures/umbrella/config/config.exs
@@ -1,6 +1,6 @@
 # This file is responsible for configuring your application
 # and its dependencies with the aid of the Mix.Config module.
-use Mix.Config
+import Config
 
 # By default, the umbrella project as well as each child
 # application will require this configuration file, ensuring


### PR DESCRIPTION
[Mix.Config](https://hexdocs.pm/mix/Mix.Config.html) has long been deprecated. Let's use [Config](https://hexdocs.pm/elixir/Config.html) instead per Elixir doc.

Also, I removed kind of redundant `import Config` in our example config snippets. I thought it was confusing since we do not need to add it to the existing file. `import Config` is so idiomatic that the user will figure out.