### PR TITLE
Simplify explanation for overriding default console settings

### DIFF
--- a/docs/Connecting to Nerves Target.md
+++ b/docs/Connecting to Nerves Target.md
@@ -154,7 +154,7 @@ target using a UART serial console that was mentioned above.
 
 Here is how to override the default, for `rpi3` as an example:
 
-1. identify an available UART port name in the in the README of your target's system, [`nerves_system_rpi3`](https://hexdocs.pm/nerves_system_rpi3/readme.html)
+1. Look in the README of your target's system's documentation for a UART port name. For example, [`nerves_system_rpi3`](https://hexdocs.pm/nerves_system_rpi3/readme.html)
 1. locate the `erlinit` configuration, which is typically found in your Nerves project's `config/target.exs` file
 1. add `ctty` option with a UART port name as a value
 

--- a/docs/Connecting to Nerves Target.md
+++ b/docs/Connecting to Nerves Target.md
@@ -149,8 +149,8 @@ console is displayed on the screen attached to the HDMI port by default. You
 can simply connect your target device to a monitor or TV.
 
 For troubleshooting start-up issues and for more advanced development
-workflows, it's often desirable to connect from your development host to the
-target using a UART serial console that was mentioned above.
+workflows, it's desirable to connect from your development host to the
+target using a UART serial cable.
 
 Here is how to override the default, for `rpi3` as an example:
 

--- a/docs/Connecting to Nerves Target.md
+++ b/docs/Connecting to Nerves Target.md
@@ -155,8 +155,8 @@ target using a UART serial console that was mentioned above.
 Here is how to override the default, for `rpi3` as an example:
 
 1. Look in the README of your target's system's documentation for a UART port name. For example, [`nerves_system_rpi3`](https://hexdocs.pm/nerves_system_rpi3/readme.html)
-1. locate the `erlinit` configuration, which is typically found in your Nerves project's `config/target.exs` file
-1. add `ctty` option with a UART port name as a value
+1. Locate your project's `erlinit` configuration which is normally in your project's `config/target.exs` file
+1. Add a `ctty` option with the UART port name as a value
 
 ```diff
  config :nerves,

--- a/docs/Connecting to Nerves Target.md
+++ b/docs/Connecting to Nerves Target.md
@@ -144,9 +144,27 @@ Unplug the USB connector and re-plug it.
 
 ## HDMI cable
 
-On some Raspberry Pi family of targets, the `IEx` console is displayed on the
-screen attached to the HDMI port by default. You can simply connect your target
-device to a monitor or TV.
+On some Raspberry Pi family of targets such as `rpi3` and `rpi4`, the `IEx`
+console is displayed on the screen attached to the HDMI port by default. You
+can simply connect your target device to a monitor or TV.
+
+For troubleshooting start-up issues and for more advanced development
+workflows, it's often desirable to connect from your development host to the
+target using a UART serial console that was mentioned above.
+
+Here is how to override the default, for `rpi3` as an example:
+
+1. identify an available UART port name in the in the README of your target's system, [`nerves_system_rpi3`](https://hexdocs.pm/nerves_system_rpi3/readme.html)
+1. locate the `erlinit` configuration, which is typically found in your Nerves project's `config/target.exs` file
+1. add `ctty` option with a UART port name as a value
+
+```diff
+ config :nerves,
+   erlinit: [
++    ctty: "ttyAMA0",
+     hostname_pattern: "nerves-%s"
+   ]
+```
 
 ## USB data cable
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -44,46 +44,6 @@ SSH is a good default for local development and is enabled by default (via `mix 
 
 For production environments you might also want to look at https://www.nerves-hub.org/ (either hosted or self-hosted)
 
-## Using a USB Serial Console
-
-By default on some Raspberry Pi family of targets, the `IEx` console is displayed on the screen attached to the HDMI port, which tends to be easier for new people because they can simply connect their target device to a monitor or TV.
-For troubleshooting start-up issues and for more advanced development workflows, it's often desirable to connect from your development host to the target using a serial port, for example using the popular [FTDI Cable](https://www.sparkfun.com/products/9717).
-This allows you to interact with the console of the target device using a terminal emulator (like `screen`) on your development host.
-
-To override the default, you need to locate the `erlinit.config` for the system you're using and modify it to replace the `-c` option to control the console.
-You can figure out what the correct value is by referring to the hardware description table in the README of your target's system repository.
-For example, for the Raspberry Pi 3 target, you can find the [hardware description README here](https://github.com/nerves-project/nerves_system_rpi3/blob/main/README.md) and the [default `erlinit.config` here](https://github.com/nerves-project/nerves_system_rpi3/blob/main/rootfs_overlay/etc/erlinit.config).
-
- 1. Download the default `erlinit.config` file from the system repository for your target.
- 2. Place it in your project folder under `rootfs_overlay/etc/erlinit.config`.
- 3. Modify the `-c` console setting to match the value shown in the `UART` row of the hardware description table (`rpi3` example shown):
-
-    ```bash
-    # rootfs_overlay/etc/erlinit.config
-
-    ...
-
-    # Specify the UART port that the shell should use.
-    #-c tty1
-    -c ttyAMA0
-    ```
-
- 4. Configure your project to replace this file in your firmware.
-
-    ```elixir
-    # config/config.exs
-
-    config :nerves, :firmware,
-      rootfs_overlay: "rootfs_overlay"
-    ```
-
- 5. Connect your USB serial cable to the desired UART pins (per the I/O pin-out for your particular hardware).
- 6. On your development host, connect to the serial console.
-
-    * On Linux and Mac OS, use `screen /dev/tty<device>`.
-      You may need to specify the baud rate as well, for example: `screen /dev/tty<device> 115200`.
-    * On Windows, use the `Serial` option to connect to `COM<device>`.
-
 ## Change Behavior on BEAM Failure
 
 Similar to the previous question, we have chosen to have the device default to halting on certain kinds of failures that cause the Erlang VM to crash.


### PR DESCRIPTION
### Issue

Currently the instructions for overriding default console settings is in the Frequently-Asked Questions page and it seems confusing and overcomplicating to me. At least a few Nerves users around me had trouble understanding how to enable the UART serial console for `rpi3`.

### Thoughts/proposal

I thought it would be nice to limit the explanation about `erlinit` to the simplest.

### Changes

- Move the "Using a USB Serial Console" FAQ topic to "Connecting to Nerves Target" page and simplify the explanation.

--- 

![](https://user-images.githubusercontent.com/7563926/192672475-91c3e378-393d-4d3f-8a97-518ebd48ac9c.png)

---

### Notes

- We could make a dedicated page for `erlinit` if needed.
- Other FAQ contents can be moved under some context so that they can be easy to discover.
