### PR TITLE
Update custom system doc dep line-breaks

### DIFF
--- a/docs/Customizing Systems.md
+++ b/docs/Customizing Systems.md
@@ -103,7 +103,13 @@ mix nerves.new your_project --target rpi3
 
       # Dependencies for specific targets
       {:nerves_system_rpi3, "~> 1.6", runtime: false, targets: :rpi},
-      {:custom_rpi3, path: "../custom_rpi3", runtime: false, targets: :custom_rpi3, nerves: [compile: true]}, # <===
+
+      # Add the entry below vvv
+      {:custom_rpi3,
+       path: "../custom_rpi3",
+       runtime: false,
+       targets: :custom_rpi3,
+       nerves: [compile: true]},
     ]
   end
 ```


### PR DESCRIPTION
With everything on one line the doc cannot be read without horizontal scrolling. This makes it particularly hard to read on smaller screens.

On smaller screens the docs currently look like this:
![image](https://user-images.githubusercontent.com/9973/197573748-bc9c3cd0-baf7-48d2-9007-363f6dd52763.png)

And on larger screens it looks like this:
![image](https://user-images.githubusercontent.com/9973/197573592-ff81ec7e-94ff-4d71-b89b-9eed1bb09262.png)

This is what it looks like after:
![image](https://user-images.githubusercontent.com/9973/197574478-e4bb5c69-5449-4e59-b412-7be137c9f9e3.png)
