### PR TITLE
Refactor GitHub artifact fetching

### DIFF
--- a/lib/nerves/artifact.ex
+++ b/lib/nerves/artifact.ex
@@ -365,11 +365,13 @@ defmodule Nerves.Artifact do
   defp expand_site(_, _, _ \\ [])
 
   defp expand_site({:github_releases, org_proj}, pkg, opts) do
-    expand_site(
-      {:prefix, "https://github.com/#{org_proj}/releases/download/v#{pkg.version}/"},
-      pkg,
+    opts =
       opts
-    )
+      |> Keyword.put(:artifact_name, download_name(pkg, opts) <> ext(pkg))
+      |> Keyword.put(:public?, true)
+      |> update_in([:tag], &(&1 || "v#{pkg.version}"))
+
+    {Resolvers.GithubAPI, {org_proj, opts}}
   end
 
   defp expand_site({:prefix, url}, pkg, opts) do

--- a/test/nerves/artifact/resolver_test.exs
+++ b/test/nerves/artifact/resolver_test.exs
@@ -103,48 +103,6 @@ defmodule Nerves.Artifact.ResolverTest do
     end)
   end
 
-  test "github api validates required fields" do
-    in_fixture("resolver", fn ->
-      set_artifact_path()
-
-      sites = [
-        {:github_api, "my_org/my_repo", username: "my_user"}
-      ]
-
-      pkg = %{app: :example, version: "0.1.0", path: "./", config: [artifact_sites: sites]}
-      resolvers = Artifact.expand_sites(pkg)
-
-      assert {:error, _} = Artifact.Resolver.get(resolvers, pkg)
-
-      sites = [
-        {:github_api, "my_org/my_repo", token: "my_token"}
-      ]
-
-      pkg = %{app: :example, version: "0.1.0", path: "./", config: [artifact_sites: sites]}
-      resolvers = Artifact.expand_sites(pkg)
-
-      assert {:error, _} = Artifact.Resolver.get(resolvers, pkg)
-
-      sites = [
-        {:github_api, "my_org/my_repo", username: "my_username", token: "my_token"}
-      ]
-
-      pkg = %{app: :example, version: "0.1.0", path: "./", config: [artifact_sites: sites]}
-      resolvers = Artifact.expand_sites(pkg)
-
-      assert {:error, _} = Artifact.Resolver.get(resolvers, pkg)
-    end)
-  end
-
-  test "github api returns error when missing required options" do
-    assert {:error, _} = Artifact.Resolvers.GithubAPI.validate_opts([])
-    assert {:error, _} = Artifact.Resolvers.GithubAPI.validate_opts(username: "foo")
-    assert {:error, _} = Artifact.Resolvers.GithubAPI.validate_opts(username: "foo", token: "bar")
-
-    assert {:ok, _} =
-             Artifact.Resolvers.GithubAPI.validate_opts(username: "foo", token: "bar", tag: "baz")
-  end
-
   test "download validations will raise" do
     in_fixture("resolver", fn ->
       set_artifact_path()

--- a/test/nerves/artifact/resolvers_github_api_test.exs
+++ b/test/nerves/artifact/resolvers_github_api_test.exs
@@ -1,0 +1,146 @@
+defmodule Nerves.Artifact.Resolvers.GithubAPITest do
+  use ExUnit.Case, async: true
+
+  alias Nerves.Artifact.Resolvers.GithubAPI
+
+  setup do
+    %{
+      repo: "nerves-project/nerves_system_rpi4",
+      opts: [
+        artifact_name: "nerves_system_rpi-portable-1.0.0-1234567.tar.gz",
+        http_client: NervesTest.HTTPClient,
+        tag: "v1.0.0",
+        token: "1234"
+      ]
+    }
+  end
+
+  test "public release not found", context do
+    context = start_http_client!(context, [{:error, "Status 404 Not Found"}])
+
+    opts =
+      context.opts
+      |> Keyword.put(:public?, true)
+      |> Keyword.delete(:token)
+
+    assert GithubAPI.get({context.repo, opts}) == {:error, "No release"}
+  end
+
+  test "private release not found", context do
+    context = start_http_client!(context, [{:error, "Status 404 Not Found"}])
+
+    assert GithubAPI.get({context.repo, context.opts}) == {:error, "No release"}
+  end
+
+  test "private release fails without token", context do
+    context = start_http_client!(context, [{:error, "Status 404 Not Found"}])
+
+    opts = Keyword.delete(context.opts, :token)
+
+    assert {:error, msg} = GithubAPI.get({context.repo, opts})
+
+    assert msg == """
+           Missing token
+
+                For private releases, you must authenticate the request to fetch release assets.
+                You can do this in a few ways:
+
+                  * export or set GITHUB_TOKEN=<your-token>
+                  * set `token: <get-token-function>` for this GitHub repository in your Nerves system mix.exs
+           """
+  end
+
+  test "mismatched checksum", context do
+    details = {:ok, Jason.encode!(%{assets: [%{name: "howdy.tar.xz"}]})}
+    context = start_http_client!(context, [details])
+
+    assert {:error, msg} = GithubAPI.get({context.repo, context.opts})
+
+    assert msg == [
+             "No artifact with valid checksum\n\n     Found:\n",
+             [["       * ", "howdy.tar.xz", "\n"]]
+           ]
+  end
+
+  test "no artifacts in release", context do
+    no_artifacts = {:ok, Jason.encode!(%{assets: []})}
+    context = start_http_client!(context, [no_artifacts])
+
+    assert {:error, "No release artifacts"} = GithubAPI.get({context.repo, context.opts})
+  end
+
+  test "valid artifact", context do
+    artifact_url = "http://example.com"
+
+    details =
+      {:ok, Jason.encode!(%{assets: [%{name: context.opts[:artifact_name], url: artifact_url}]})}
+
+    data = {:ok, "artifact data!"}
+    context = start_http_client!(context, [details, data], self())
+
+    assert ^data = GithubAPI.get({context.repo, context.opts})
+
+    # Requests the GitHubAPI for release details first
+    expected_details_url =
+      "https://api.github.com/repos/#{context.repo}/releases/tags/#{context.opts[:tag]}"
+
+    assert_receive {:get, ^expected_details_url, _opts}
+
+    # Uses the URL for the artifact provided by GitHub to download
+    assert_receive {:get, ^artifact_url, _opts}
+  end
+
+  test "GITHUB_TOKEN takes precedence", context do
+    env_token = "look-at-me!"
+    gh_token = "dont-look-at-me!"
+    refute context.opts[:token] == env_token
+    refute context.opts[:token] == gh_token
+    context = start_http_client!(context, [], self())
+
+    System.put_env("GITHUB_TOKEN", env_token)
+    System.put_env("GH_TOKEN", gh_token)
+    _ = GithubAPI.get({context.repo, context.opts})
+    System.delete_env("GITHUB_TOKEN")
+    System.delete_env("GH_TOKEN")
+
+    assert_receive {:get, _url, opts}
+
+    # A bit hacky since you need to know the internals, but this
+    # breaks apart the Authorization header that was created with
+    # the token given to the request and confirms it is the one
+    # we wanted
+    [{"Authorization", "Basic " <> encoded}] = opts[:headers]
+    [_, req_token] = String.split(Base.decode64!(encoded), ":")
+
+    assert env_token == req_token
+  end
+
+  test "supports GH_TOKEN shorthand", context do
+    env_token = "look-at-me!"
+    refute context.opts[:token] == env_token
+
+    context = start_http_client!(context, [], self())
+
+    System.put_env("GH_TOKEN", env_token)
+    _ = GithubAPI.get({context.repo, context.opts})
+    System.delete_env("GH_TOKEN")
+
+    assert_receive {:get, _url, opts}
+
+    # A bit hacky since you need to know the internals, but this
+    # breaks apart the Authorization header that was created with
+    # the token given to the request and confirms it is the one
+    # we wanted
+    [{"Authorization", "Basic " <> encoded}] = opts[:headers]
+    [_, req_token] = String.split(Base.decode64!(encoded), ":")
+
+    assert env_token == req_token
+  end
+
+  defp start_http_client!(context, returns, echo \\ nil) do
+    client = context.opts[:http_client]
+    opts = [name: context.test, returns: returns, echo: echo]
+    http_pid = start_supervised!({client, opts})
+    put_in(context, [:opts, :http_pid], http_pid)
+  end
+end

--- a/test/nerves/artifact_test.exs
+++ b/test/nerves/artifact_test.exs
@@ -3,6 +3,7 @@ defmodule Nerves.ArtifactTest do
 
   alias Nerves.Artifact
   alias Nerves.Artifact.BuildRunners, as: P
+  alias Nerves.Artifact.Resolvers.GithubAPI
   alias Nerves.Env
 
   test "Fetch build_runner overrides" do
@@ -93,18 +94,20 @@ defmodule Nerves.ArtifactTest do
   end
 
   test "artifact sites are expanded" do
+    repo = "nerves-project/system"
+
     pkg = %{
       app: "my_system",
       version: "1.0.0",
       path: "./",
-      config: [artifact_sites: [{:github_releases, "nerves-project/system"}]]
+      config: [artifact_sites: [{:github_releases, repo}]]
     }
 
     checksum_short = Nerves.Artifact.checksum(pkg, short: 7)
 
-    [{_, {short, _}}] = Artifact.expand_sites(pkg)
+    [{GithubAPI, {^repo, opts}}] = Artifact.expand_sites(pkg)
 
-    assert String.ends_with?(short, checksum_short <> Artifact.ext(pkg))
+    assert String.ends_with?(opts[:artifact_name], checksum_short <> Artifact.ext(pkg))
   end
 
   test "precompile will raise if packages are stale and not fetched" do

--- a/test/support/test_http_client.ex
+++ b/test/support/test_http_client.ex
@@ -1,0 +1,41 @@
+defmodule NervesTest.HTTPClient do
+  @moduledoc """
+  Test HTTPClient to use in tests
+
+  Start this GenServer in your tests with a list of `:returns` which
+  will be returned on each call until empty
+
+  You can optionally provide `:echo` with a pid where the get/3
+  call will be echoed to for verification
+  """
+  use GenServer
+
+  @type opt :: {:name, GenServer.name()} | {:returns, [any()]} | {:echo, pid()}
+
+  @spec start_link([opt()]) :: GenServer.on_start()
+  def start_link(opts) do
+    name = opts[:name] || __MODULE__
+    GenServer.start_link(__MODULE__, opts, name: name)
+  end
+
+  defdelegate stop(pid), to: GenServer
+
+  @spec get(pid(), String.t(), [any()]) :: :ok | any()
+  def get(pid, url, opts), do: GenServer.call(pid, {:get, url, opts})
+
+  @impl GenServer
+  def init(opts) do
+    {:ok, %{returns: opts[:returns] || [], echo: opts[:echo]}}
+  end
+
+  @impl GenServer
+  def handle_call({:get, _url, _opts} = msg, _from, %{returns: []} = state) do
+    if state.echo, do: send(state.echo, msg)
+    {:reply, :ok, state}
+  end
+
+  def handle_call({:get, _url, _opts} = msg, _from, %{returns: [next | rem]} = state) do
+    if state.echo, do: send(state.echo, msg)
+    {:reply, next, %{state | returns: rem}}
+  end
+end


### PR DESCRIPTION
* Switches `:github_releases` artifact site to also use `Resolvers.GithubAPI`
* `Resolvers.GithubAPI` has been totally refactored
  * Fixed issue with errors reporting to use `GITHUB_TOKEN`, but that env var would never actually be used in the code
  * Supports `GITHUB_TOKEN` or the `GH_TOKEN` shorthand that GitHub also supports
  * Adjusted errors to better report the situation discovered
    * No release
    * Release found but no artifacts * Artifacts found, but none with matching checksum * Missing token when unable to authenticate a GitHub request to private repo

## No valid checksum
![image](https://user-images.githubusercontent.com/11321326/215791240-c4e5df77-c908-479d-b5f2-b3ac2cb0b7a5.png)

## No release found
![image](https://user-images.githubusercontent.com/11321326/215791849-c7d68df4-e24b-4f03-a47b-5c248c5b7bd2.png)

## Missing token
![image](https://user-images.githubusercontent.com/11321326/215792285-96c30a74-bb1c-469f-a011-82a1aed087d3.png)

## No artifacts in release
![image](https://user-images.githubusercontent.com/11321326/215793142-48c000a2-4444-420b-98d3-8ef6555d2daa.png)
