### PR TITLE
Remove duplicate artifact request

### DIFF
--- a/lib/nerves/artifact.ex
+++ b/lib/nerves/artifact.ex
@@ -251,14 +251,8 @@ defmodule Nerves.Artifact do
   def expand_sites(pkg) do
     case pkg.config[:artifact_url] do
       nil ->
-        # |> Enum.map(&expand_site(&1, pkg))
-        # Check entire checksum length
-        # This code can be removed sometime after nerves 1.0
-        # and instead use the commented line above
         Keyword.get(pkg.config, :artifact_sites, [])
-        |> Enum.reduce([], fn site, urls ->
-          [expand_site(site, pkg), expand_site(site, pkg, checksum_short: 64) | urls]
-        end)
+        |> Enum.map(&expand_site(&1, pkg))
 
       urls when is_list(urls) ->
         # artifact_url is deprecated and this code can be removed sometime following

--- a/test/nerves/artifact_test.exs
+++ b/test/nerves/artifact_test.exs
@@ -100,13 +100,11 @@ defmodule Nerves.ArtifactTest do
       config: [artifact_sites: [{:github_releases, "nerves-project/system"}]]
     }
 
-    checksum_long = Nerves.Artifact.checksum(pkg)
     checksum_short = Nerves.Artifact.checksum(pkg, short: 7)
 
-    [{_, {short, _}}, {_, {long, _}}] = Artifact.expand_sites(pkg)
+    [{_, {short, _}}] = Artifact.expand_sites(pkg)
 
     assert String.ends_with?(short, checksum_short <> Artifact.ext(pkg))
-    assert String.ends_with?(long, checksum_long <> Artifact.ext(pkg))
   end
 
   test "precompile will raise if packages are stale and not fetched" do


### PR DESCRIPTION
In the very beginning, artifacts were stored in releases with their full checksum value. Now they are stored with the 7 byte checksum shorthand, but we still try to request both.

I think its been long enough using the shorthand that we can remove this second request which should clear up the logs a bit and make it less confusing when an artifact can't be found

Also, the work in #822 should provide better output when artifacts can't be found which would help as well