### PR TITLE
Remove `NERVES_ARTIFACTS_DIR` when testing artifact base_path

### DIFF
--- a/test/nerves/artifact_test.exs
+++ b/test/nerves/artifact_test.exs
@@ -138,12 +138,14 @@ defmodule Nerves.ArtifactTest do
 
   describe "artifact base_path" do
     test "XDG_DATA_HOME" do
+      System.delete_env("NERVES_ARTIFACTS_DIR")
       System.put_env("XDG_DATA_HOME", "xdg_data_home")
       assert "xdg_data_home/nerves/artifacts" = Nerves.Artifact.base_dir()
     end
 
     test "falls back to $HOME/.nerves" do
       System.delete_env("XDG_DATA_HOME")
+      System.delete_env("NERVES_ARTIFACTS_DIR")
       assert Path.expand("~/.nerves/artifacts") == Nerves.Artifact.base_dir()
     end
   end


### PR DESCRIPTION
If a user has `NERVES_ARTIFACTS_DIR` set locally, these tests will fail so delete it before the test runs for good measure