### PR TITLE
Handle a nil token with GithubAPI resolver

### DIFF
--- a/lib/nerves/artifact/resolvers/github_api.ex
+++ b/lib/nerves/artifact/resolvers/github_api.ex
@@ -39,7 +39,12 @@ defmodule Nerves.Artifact.Resolvers.GithubAPI do
       if opts.public? do
         []
       else
-        credentials = Base.encode64(opts.username <> ":" <> opts.token)
+        # make safe values here in case nil was supplied as an option
+        # The request will fail and error will be reported later on
+        user = opts.username || ""
+        token = opts.token || ""
+
+        credentials = Base.encode64(user <> ":" <> token)
         [{"Authorization", "Basic " <> credentials}]
       end
 

--- a/test/nerves/artifact/resolvers_github_api_test.exs
+++ b/test/nerves/artifact/resolvers_github_api_test.exs
@@ -50,6 +50,24 @@ defmodule Nerves.Artifact.Resolvers.GithubAPITest do
            """
   end
 
+  test "private release fails with nil token", context do
+    context = start_http_client!(context, [{:error, "Status 404 Not Found"}])
+
+    opts = Keyword.put(context.opts, :token, nil)
+
+    assert {:error, msg} = GithubAPI.get({context.repo, opts})
+
+    assert msg == """
+           Missing token
+
+                For private releases, you must authenticate the request to fetch release assets.
+                You can do this in a few ways:
+
+                  * export or set GITHUB_TOKEN=<your-token>
+                  * set `token: <get-token-function>` for this GitHub repository in your Nerves system mix.exs
+           """
+  end
+
   test "mismatched checksum", context do
     details = {:ok, Jason.encode!(%{assets: [%{name: "howdy.tar.xz"}]})}
     context = start_http_client!(context, [details])


### PR DESCRIPTION
The GithubAPI resolver will crash if someone passes `token: nil` so this handles that case and allows the error later on to report what was wrong