### PR TITLE
Add missing pkg-config dependency to shell.nix

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -124,6 +124,7 @@ mkShell {
     rebar3
     squashfsTools
     x11_ssh_askpass
+    pkg-config
   ];
   shellHook = ''
     SUDO_ASKPASS=${pkgs.x11_ssh_askpass}/libexec/x11-ssh-askpass


### PR DESCRIPTION
Add `pkg-config` dependency to the `shell.nix`.
pkg-config is needed to build the firmware.