### PR TITLE
Revert `:github_releases` artifact fetching

### DIFF
--- a/lib/nerves/artifact.ex
+++ b/lib/nerves/artifact.ex
@@ -365,13 +365,21 @@ defmodule Nerves.Artifact do
   defp expand_site(_, _, _ \\ [])
 
   defp expand_site({:github_releases, org_proj}, pkg, opts) do
-    opts =
-      opts
-      |> Keyword.put(:artifact_name, download_name(pkg, opts) <> ext(pkg))
-      |> Keyword.put(:public?, true)
-      |> update_in([:tag], &(&1 || "v#{pkg.version}"))
+    # TODO: Switch to GithubAPI once JSON codec expectations are
+    # fixed within the lib
+    # opts =
+    #   opts
+    #   |> Keyword.put(:artifact_name, download_name(pkg, opts) <> ext(pkg))
+    #   |> Keyword.put(:public?, true)
+    #   |> update_in([:tag], &(&1 || "v#{pkg.version}"))
 
-    {Resolvers.GithubAPI, {org_proj, opts}}
+    # {Resolvers.GithubAPI, {org_proj, opts}}
+
+    expand_site(
+      {:prefix, "https://github.com/#{org_proj}/releases/download/v#{pkg.version}/"},
+      pkg,
+      opts
+    )
   end
 
   defp expand_site({:prefix, url}, pkg, opts) do

--- a/test/nerves/artifact_test.exs
+++ b/test/nerves/artifact_test.exs
@@ -103,11 +103,15 @@ defmodule Nerves.ArtifactTest do
       config: [artifact_sites: [{:github_releases, repo}]]
     }
 
+    # TODO: Use this testing once fully switched to GithubAPI resolving
+    # [{GithubAPI, {^repo, opts}}] = Artifact.expand_sites(pkg)
+    # assert String.ends_with?(opts[:artifact_name], checksum_short <> Artifact.ext(pkg))
+
     checksum_short = Nerves.Artifact.checksum(pkg, short: 7)
 
-    [{GithubAPI, {^repo, opts}}] = Artifact.expand_sites(pkg)
+    [{_, {short, _}}] = Artifact.expand_sites(pkg)
 
-    assert String.ends_with?(opts[:artifact_name], checksum_short <> Artifact.ext(pkg))
+    assert String.ends_with?(short, checksum_short <> Artifact.ext(pkg))
   end
 
   test "precompile will raise if packages are stale and not fetched" do


### PR DESCRIPTION
Using the GitHubAPI resolver for github releases exposed another issue within the lib in how it expects JSON to be available. Revert this change back until that change is investigated and fixed