### PR TITLE
Remove :json_codec configuration option 

### DIFF
--- a/lib/nerves/artifact/resolvers/github_api.ex
+++ b/lib/nerves/artifact/resolvers/github_api.ex
@@ -2,7 +2,7 @@ defmodule Nerves.Artifact.Resolvers.GithubAPI do
   @moduledoc false
   @behaviour Nerves.Artifact.Resolver
 
-  alias Nerves.{Utils, Utils.HTTPClient}
+  alias Nerves.Utils.{HTTPClient, Shell}
 
   @base_url "https://api.github.com/"
 
@@ -76,10 +76,10 @@ defmodule Nerves.Artifact.Resolvers.GithubAPI do
   defp fetch_artifact(opts) do
     info = if System.get_env("NERVES_DEBUG") == "1", do: opts.url, else: opts.artifact_name
 
-    Utils.Shell.info(["  [GitHub] ", info])
+    Shell.info(["  [GitHub] ", info])
 
     with {:ok, data} <- release_details(opts),
-         %{"assets" => assets} <- Utils.json_decode(data),
+         {:ok, %{"assets" => assets}} <- Jason.decode(data),
          {:ok, asset_url} <- get_asset_url(assets, opts) do
       opts.http_client.get(opts.http_pid, asset_url,
         headers: [{"Accept", "application/octet-stream"} | opts.headers]

--- a/lib/nerves/utils.ex
+++ b/lib/nerves/utils.ex
@@ -2,7 +2,9 @@ defmodule Nerves.Utils do
   @moduledoc false
   @alphanum 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_'
 
-  @json_codec Jason
+  if Application.compile_env(:nerves, :json_codec) do
+    IO.warn(":json_codec is no longer supported. Please remove from your config", [])
+  end
 
   <<i1::32-unsigned-integer, i2::32-unsigned-integer, i3::32-unsigned-integer>> =
     :crypto.strong_rand_bytes(12)
@@ -19,34 +21,5 @@ defmodule Nerves.Utils do
   def untar(file, destination \\ nil) do
     destination = destination || File.cwd!()
     Nerves.Port.cmd("tar", ["xf", file, "--strip-components=1", "-C", destination])
-  end
-
-  @spec json_decode(String.t()) :: map()
-  def json_decode(data) do
-    json_codec().decode!(data)
-  end
-
-  @spec json_encode(term) :: String.t()
-  def json_encode(data) do
-    json_codec().encode!(data)
-  end
-
-  defp json_codec() do
-    json_codec = Application.get_env(:nerves, :json_codec) || @json_codec
-
-    case Code.ensure_loaded?(json_codec) do
-      true ->
-        json_codec
-
-      false ->
-        Nerves.Utils.Shell.error("""
-        Nerves is attempting to decode JSON data but there is no JSON codec defined.
-
-        Please include :jason as a dependency or configure your own JSON parser
-        by updating your config.exs
-
-          config :nerves, json_codec: Poison
-        """)
-    end
   end
 end


### PR DESCRIPTION
Since `Jason` is now a required dependency, this removes the ability to specify alternate JSON libraries and emits a warning if is found in the Application config environment