### PR TITLE
Require `:jason` dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -38,7 +38,7 @@ defmodule Nerves.MixProject do
     [
       {:castore, "~> 0.1"},
       {:elixir_make, "~> 0.6", runtime: false},
-      {:jason, "~> 1.2", optional: true},
+      {:jason, "~> 1.2"},
       {:credo, "~> 1.6", only: :test, runtime: false},
       {:ex_doc, "~> 0.22", only: :docs, runtime: false},
       {:dialyxir, "~> 1.0", only: [:test, :dev], runtime: false},


### PR DESCRIPTION
Based on discussions with #833 (and for #830)

This will add some consistency to the tooling and reduce the chances for errors during HTTP requests when `:nerves` may be used in a project that has no JSON codec defined.

Specifying a codec is still supported if the user wishes to use a different one.