### PR TITLE
Add default mksquashfs flags when none specified

### DIFF
--- a/lib/mix/tasks/firmware.ex
+++ b/lib/mix/tasks/firmware.ex
@@ -25,6 +25,8 @@ defmodule Mix.Tasks.Firmware do
   import Mix.Nerves.Utils
   alias Mix.Nerves.Preflight
 
+  @default_mksquashfs_flags ["-no-xattrs", "-quiet"]
+
   @switches [verbose: :boolean, output: :string]
 
   @impl Mix.Task
@@ -79,7 +81,8 @@ defmodule Mix.Tasks.Firmware do
     compiler_check()
     firmware_config = Application.get_env(:nerves, :firmware)
 
-    mksquashfs_flags(firmware_config[:mksquashfs_flags])
+    mksquashfs_flags = firmware_config[:mksquashfs_flags] || @default_mksquashfs_flags
+    set_mksquashfs_flags(mksquashfs_flags)
 
     rootfs_priorities =
       Nerves.Env.package(:nerves_system_br)
@@ -260,9 +263,7 @@ defmodule Mix.Tasks.Firmware do
       end
   end
 
-  defp mksquashfs_flags(nil), do: :noop
-
-  defp mksquashfs_flags(flags) do
+  defp set_mksquashfs_flags(flags) when is_list(flags) do
     System.put_env("NERVES_MKSQUASHFS_FLAGS", Enum.join(flags, " "))
   end
 


### PR DESCRIPTION
The defaults disable use of xattrs since those aren't used on any
official or known unofficial Nerves system now, but even if they were,
some additional accommodation for them would be needed to make sure
they're set right given how merging squashfs archives works.

This has a side effect of removing the warnings on MacOS now since the
latest versions of MacOS add an unknown xattr to all files.

This also includes a default of using the quiet option since the
squashfs printout at the end is very verbose and sometimes scrolls good
warnings off the terminal.
