### PR TITLE
Use GitHubAPI for public release artifacts

### DIFF
--- a/lib/nerves/artifact.ex
+++ b/lib/nerves/artifact.ex
@@ -365,21 +365,13 @@ defmodule Nerves.Artifact do
   defp expand_site(_, _, _ \\ [])
 
   defp expand_site({:github_releases, org_proj}, pkg, opts) do
-    # TODO: Switch to GithubAPI once JSON codec expectations are
-    # fixed within the lib
-    # opts =
-    #   opts
-    #   |> Keyword.put(:artifact_name, download_name(pkg, opts) <> ext(pkg))
-    #   |> Keyword.put(:public?, true)
-    #   |> update_in([:tag], &(&1 || "v#{pkg.version}"))
-
-    # {Resolvers.GithubAPI, {org_proj, opts}}
-
-    expand_site(
-      {:prefix, "https://github.com/#{org_proj}/releases/download/v#{pkg.version}/"},
-      pkg,
+    opts =
       opts
-    )
+      |> Keyword.put(:artifact_name, download_name(pkg, opts) <> ext(pkg))
+      |> Keyword.put(:public?, true)
+      |> update_in([:tag], &(&1 || "v#{pkg.version}"))
+
+    {Resolvers.GithubAPI, {org_proj, opts}}
   end
 
   defp expand_site({:prefix, url}, pkg, opts) do

--- a/test/nerves/artifact_test.exs
+++ b/test/nerves/artifact_test.exs
@@ -3,6 +3,7 @@ defmodule Nerves.ArtifactTest do
 
   alias Nerves.Artifact
   alias Nerves.Artifact.BuildRunners, as: P
+  alias Nerves.Artifact.Resolvers.GithubAPI
   alias Nerves.Env
 
   test "Fetch build_runner overrides" do
@@ -102,15 +103,10 @@ defmodule Nerves.ArtifactTest do
       config: [artifact_sites: [{:github_releases, repo}]]
     }
 
-    # TODO: Use this testing once fully switched to GithubAPI resolving
-    # [{GithubAPI, {^repo, opts}}] = Artifact.expand_sites(pkg)
-    # assert String.ends_with?(opts[:artifact_name], checksum_short <> Artifact.ext(pkg))
-
     checksum_short = Nerves.Artifact.checksum(pkg, short: 7)
 
-    [{_, {short, _}}] = Artifact.expand_sites(pkg)
-
-    assert String.ends_with?(short, checksum_short <> Artifact.ext(pkg))
+    [{GithubAPI, {^repo, opts}}] = Artifact.expand_sites(pkg)
+    assert String.ends_with?(opts[:artifact_name], checksum_short <> Artifact.ext(pkg))
   end
 
   test "precompile will raise if packages are stale and not fetched" do


### PR DESCRIPTION
Brings back the use of GitHubAPI for public release artifacts.

Also adds fallback to public URL for public release when the API rate limit is reached rather than just failing. If it still fails, the error message won't be as useful. But that is worth it if it succeeds
