### PR TITLE
Add `compile_fixture` to `NervesTest.case`

### DIFF
--- a/test/fixtures/integration_app/config/config.exs
+++ b/test/fixtures/integration_app/config/config.exs
@@ -1,0 +1,3 @@
+import Config
+
+Application.start(:nerves_bootstrap)

--- a/test/fixtures/system/mix.exs
+++ b/test/fixtures/system/mix.exs
@@ -33,7 +33,7 @@ defmodule System.MixProject do
 
   defp deps() do
     [
-      # {:nerves, path: System.get_env("NERVES_PATH") || "../../../"},
+      {:nerves, path: System.get_env("NERVES_PATH") || "../../../"},
       {:toolchain, path: "../toolchain"},
       {:system_platform, path: "../system_platform"}
     ]

--- a/test/fixtures/system_artifact/mix.exs
+++ b/test/fixtures/system_artifact/mix.exs
@@ -32,7 +32,7 @@ defmodule SystemArtifact.MixProject do
 
   defp deps() do
     [
-      # {:nerves, path: System.get_env("NERVES_PATH") || "../../../"},
+      {:nerves, path: System.get_env("NERVES_PATH") || "../../../"},
       {:system_platform, path: "../system_platform"}
     ]
   end

--- a/test/fixtures/toolchain/mix.exs
+++ b/test/fixtures/toolchain/mix.exs
@@ -32,7 +32,7 @@ defmodule Toolchain.MixProject do
 
   defp deps() do
     [
-      # {:nerves, path: System.get_env("NERVES_PATH") || "../../../"},
+      {:nerves, path: System.get_env("NERVES_PATH") || "../../../"},
       {:toolchain_platform, path: "../toolchain_platform"}
     ]
   end

--- a/test/nerves/integration_test.exs
+++ b/test/nerves/integration_test.exs
@@ -1,23 +1,16 @@
 defmodule Nerves.IntegrationTest do
-  use NervesTest.Case
+  use NervesTest.Case, async: true
 
+  @tag :tmp_dir
   @tag :integration
-  test "bootstrap is called for other env packages" do
-    in_fixture("integration_app", fn ->
-      packages = ~w(system toolchain system_platform toolchain_platform host_tool)
+  test "bootstrap is called for other env packages", %{tmp_dir: tmp} do
+    deps = ~w(system toolchain system_platform toolchain_platform host_tool)
 
-      load_env(packages)
-      Mix.Tasks.Deps.Get.run([])
-      Mix.Tasks.Nerves.Env.run([])
-      Mix.Tasks.Nerves.Precompile.run([])
-      Mix.Tasks.Compile.run([])
+    {path, _env} = compile_fixture!("integration_app", tmp, deps)
 
-      file =
-        File.cwd!()
-        |> Path.join("hello")
+    file = Path.join(path, "hello")
 
-      assert File.exists?(file)
-      assert File.read!(file) == "Hello, world!\n"
-    end)
+    assert File.exists?(file)
+    assert File.read!(file) == "Hello, world!\n"
   end
 end

--- a/test/nerves/release_test.exs
+++ b/test/nerves/release_test.exs
@@ -1,30 +1,29 @@
 defmodule Nerves.ReleaseTest do
   use NervesTest.Case, async: true
 
+  @tag :tmp_dir
   @tag :release
-  test "rootfs priorities from valid bootfile" do
-    in_fixture("release_app", fn ->
-      load_env()
+  test "rootfs priorities from valid bootfile", %{tmp_dir: tmp} do
+    {path, env} = compile_fixture!("release_app", tmp, [], [])
 
-      {_, 0} = System.cmd("mix", ["deps.get"], env: [{"MIX_ENV", "#{Mix.env()}"}])
-      {_, 0} = System.cmd("mix", ["release"], env: [{"MIX_ENV", "#{Mix.env()}"}])
+    opts = [cd: path, env: [{"MIX_ENV", "prod"} | env], stderr_to_stdout: true]
+    {_, 0} = System.cmd("mix", ["release"], opts)
 
-      expected = """
-      srv/erlang/releases/0.1.0/consolidated/Elixir.String.Chars.beam 32000
-      srv/erlang/releases/0.1.0/consolidated/Elixir.List.Chars.beam 31999
-      srv/erlang/releases/0.1.0/consolidated/Elixir.Inspect.beam 31998
-      srv/erlang/releases/0.1.0/consolidated/Elixir.Enumerable.beam 31997
-      srv/erlang/releases/0.1.0/consolidated/Elixir.Collectable.beam 31996
-      """
+    expected = """
+    srv/erlang/releases/0.1.0/consolidated/Elixir.String.Chars.beam 32000
+    srv/erlang/releases/0.1.0/consolidated/Elixir.List.Chars.beam 31999
+    srv/erlang/releases/0.1.0/consolidated/Elixir.Inspect.beam 31998
+    srv/erlang/releases/0.1.0/consolidated/Elixir.Enumerable.beam 31997
+    srv/erlang/releases/0.1.0/consolidated/Elixir.Collectable.beam 31996
+    """
 
-      # TODO: Adjust this test to better check ordering
-      # Asserting a specific generated priorities is brittle as it drastically
-      # changes with each Elixir version. The ordering is also currently suboptimal.
-      # For now, just check the file begins with the consolidated protocols
-      # until the ordering is optimized and a better test can be constructed
-      assert Path.join(Mix.Project.build_path(), "nerves/rootfs.priorities")
-             |> File.read!()
-             |> String.starts_with?(expected)
-    end)
+    # TODO: Adjust this test to better check ordering
+    # Asserting a specific generated priorities is brittle as it drastically
+    # changes with each Elixir version. The ordering is also currently suboptimal.
+    # For now, just check the file begins with the consolidated protocols
+    # until the ordering is optimized and a better test can be constructed
+    assert Path.join(path, "_build/prod/nerves/rootfs.priorities")
+           |> File.read!()
+           |> String.starts_with?(expected)
   end
 end


### PR DESCRIPTION
Many tests currently rely on `File.cd!/2`, but this [changes the directory globally](https://hexdocs.pm/elixir/File.html#cd!/2) causing race conditions and flaky tests.

This allows us to separate out fixture setup and runs by process by only managing the setup and letting the test process use safe directory changes like with `System.cmd`

This also updates the easier tests to use this new function as a starting point