### PR TITLE
Exclude IO.Stream from `mix firmware` output

### DIFF
--- a/lib/mix/tasks/firmware.ex
+++ b/lib/mix/tasks/firmware.ex
@@ -66,6 +66,12 @@ defmodule Mix.Tasks.Firmware do
     """)
   end
 
+  def result({%IO.Stream{}, err}) do
+    # Any output was already sent through the stream,
+    # so just halt at this point
+    System.halt(err)
+  end
+
   def result({result, _}) do
     Mix.raise("""
     Nerves encountered an error. #{inspect(result)}
@@ -141,7 +147,7 @@ defmodule Mix.Tasks.Firmware do
     |> File.mkdir_p!()
 
     shell(cmd, args, env: env)
-    |> result
+    |> result()
   end
 
   defp standard_fwup_variables(config) do


### PR DESCRIPTION
Fixes https://github.com/nerves-project/nerves/issues/877

The command during `mix firmware` uses an `IO.Stream` by default which means the stderr and stdout is written as it happens. So when handling a non-success status, we would inspect the stream struct leaving a slightly confusing error.

This instead halts with the received command error status and avoids printing the stream struct

