### PR TITLE
Prevent bad vm.args in Nerves firmware

### DIFF
--- a/lib/nerves/release.ex
+++ b/lib/nerves/release.ex
@@ -174,6 +174,11 @@ defmodule Nerves.Release do
   @legacy_elixir_opts ["-user Elixir.IEx.CLI"]
   defp check_vm_args_compatibility!(release) do
     Mix.shell().info([:yellow, "* [Nerves] ", :reset, "validating vm.args"])
+    vm_args_path = Mix.Release.rel_templates_path(release, "vm.args.eex")
+
+    if not File.exists?(vm_args_path) do
+      Mix.raise("Missing required #{vm_args_path}")
+    end
 
     {exclusions, inclusions} =
       if Version.match?(System.version(), ">= 1.15.0") do

--- a/test/fixtures/release_app/mix.exs
+++ b/test/fixtures/release_app/mix.exs
@@ -27,6 +27,7 @@ defmodule ReleaseApp.Fixture do
     [
       overwrite: true,
       steps: [&Nerves.Release.init/1, :assemble],
+      rel_templates_path: System.get_env("REL_TEMPLATES_PATH", "rel"),
       strip_beams: true
     ]
   end

--- a/test/fixtures/release_app/rel/vm.args.eex
+++ b/test/fixtures/release_app/rel/vm.args.eex
@@ -1,0 +1,1 @@
+# File required by Nerves

--- a/test/nerves/release_test.exs
+++ b/test/nerves/release_test.exs
@@ -29,6 +29,22 @@ defmodule Nerves.ReleaseTest do
 
   @tag :tmp_dir
   @tag :release
+  test "requires vm.args.eex", %{tmp_dir: tmp} do
+    {path, env} = compile_fixture!("release_app", tmp, [], [])
+
+    opts = [
+      cd: path,
+      env: [{"MIX_ENV", "prod"}, {"REL_TEMPLATES_PATH", Path.join(tmp, "no-rel")} | env],
+      stderr_to_stdout: true
+    ]
+
+    assert {output, 1} = System.cmd("mix", ["release"], opts)
+
+    assert output =~ ~r/Missing required .*vm\.args\.eex/
+  end
+
+  @tag :tmp_dir
+  @tag :release
   test "fails if vm.args has incompatible shell setting", %{tmp_dir: tmp} do
     {path, env} = compile_fixture!("release_app", tmp, [], [])
 


### PR DESCRIPTION
With Elixir 1.15, the way the Elixir IEx shell is started on device has changed and using the old way will break things.

This adds a new check during the release (firmware) initialization and stops the firmware build if the old method is still there

> **Note**
> Using Elixir 1.15 
> ![image](https://github.com/nerves-project/nerves/assets/11321326/31d0fce1-b277-466b-8916-4bc15df9bfb1)
>
> Using Elixir < 1.15
> ![image](https://github.com/nerves-project/nerves/assets/11321326/5aaf331d-27fd-488c-96c6-62ae948bc3f5)


