### PR TITLE
Move `dialyxir` to `:dev` env

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -19,7 +19,7 @@ defmodule Nerves.MixProject do
       docs: docs(),
       dialyzer: dialyzer(),
       preferred_cli_env: %{
-        credo: :test,
+        credo: :dev,
         docs: :docs,
         "hex.publish": :docs,
         "hex.build": :docs
@@ -41,9 +41,9 @@ defmodule Nerves.MixProject do
       {:castore, "~> 0.1 or ~> 1.0"},
       {:elixir_make, "~> 0.6", runtime: false},
       {:jason, "~> 1.2"},
-      {:credo, "~> 1.6", only: :test, runtime: false},
+      {:credo, "~> 1.6", only: :dev, runtime: false},
       {:ex_doc, "~> 0.22", only: :docs, runtime: false},
-      {:dialyxir, "~> 1.0", only: [:test, :dev], runtime: false},
+      {:dialyxir, "~> 1.0", only: :dev, runtime: false},
       {:plug, "~> 1.10", only: :test},
       {:mime, "~> 2.0", only: :test},
       {:plug_cowboy, "~> 1.0 or ~> 2.0", only: :test}


### PR DESCRIPTION
Alternative to #902

The latest dialyxir update only supports Elixir >= 1.12, but Nerves supports 1.11 so CI for that version fails.

This moves the `dialyxir` dep to the `:dev` env since it is not needed during tests and prevents the version check from failing