### PR TITLE
Update User Interfaces.md

### DIFF
--- a/docs/User Interfaces.md
+++ b/docs/User Interfaces.md
@@ -135,7 +135,7 @@ Note that this minimal configuration corresponds to our freshly generated
 phoenix application without Ecto or Swoosh as we passed the `--no-ecto` and
 `--no-mailer` flags to the generator earlier. If you wish to use those features, 
 remember to add the relevant configuration. An example for Ecto can be seen 
-in the [Nerves + Phoenix example]: https://github.com/nerves-project/nerves_examples/blob/1da4597bee5d9f26c643cb32523fc70e136d1e2b/hello_phoenix/firmware/config/target.exs#L17 .
+in the [Nerves + Phoenix example](https://github.com/nerves-project/nerves_examples/blob/1da4597bee5d9f26c643cb32523fc70e136d1e2b/hello_phoenix/firmware/config/target.exs#L17).
 
 There we have it! A Phoenix-based web application is now ready to run on our
 Nerves-based embedded device. By separating the Phoenix-based project from the

--- a/docs/User Interfaces.md
+++ b/docs/User Interfaces.md
@@ -44,7 +44,7 @@ mkdir my_app && cd my_app
 # Create a Nerves firmware project called "my_app_firmware"
 mix nerves.new my_app_firmware
 
-# Create a Phoenix 1.6 UI project called "my_app_ui"
+# Create a Phoenix 1.6 UI project called "my_app_ui", without Ecto or Swoosh Mailer
 mix phx.new my_app_ui --no-ecto --no-mailer
 ```
 
@@ -130,6 +130,12 @@ config :my_app_ui, MyAppUiWeb.Endpoint,
 # Use Jason for JSON parsing in Phoenix
 config :phoenix, :json_library, Jason
 ```
+
+Note that this minimal configuration corresponds to our freshly generated 
+phoenix application without Ecto or Swoosh as we passed the `--no-ecto` and
+`--no-mailer` flags to the generator earlier. If you wish to use those features, 
+remember to add the relevant configuration. An example for Ecto can be seen 
+in the [Nerves + Phoenix example]: https://github.com/nerves-project/nerves_examples/blob/1da4597bee5d9f26c643cb32523fc70e136d1e2b/hello_phoenix/firmware/config/target.exs#L17 .
 
 There we have it! A Phoenix-based web application is now ready to run on our
 Nerves-based embedded device. By separating the Phoenix-based project from the


### PR DESCRIPTION
Some precisions on the relevant Phoenix configuration - the point isn't to give every possible variation on Phoenix configuration in the Nerves docs, but since the advice given is to copy some of Phoenix's required config in `target.exs`, this can result in confusion on some boards that do not have an easy way to give feedback before they fully boot. 

Maybe this is too much hand-holding ? The idea isn't to merge as-is but first discuss if that kind of "notice" has its place. In my case, I lost a few minutes before realizing that Swoosh defaulted to `hackney` on my board as its transport layer if you did not configure it to use Finch, and hackney isn't included in phoenix dependencies..