### PR TITLE
Ensure a package is loaded before `compile.nerves_package`

### DIFF
--- a/lib/mix/tasks/compile.nerves_package.ex
+++ b/lib/mix/tasks/compile.nerves_package.ex
@@ -1,7 +1,11 @@
 defmodule Mix.Tasks.Compile.NervesPackage do
   @shortdoc "Nerves Package Compiler"
   @moduledoc """
-  Build a Nerves Artifact from a Nerves Package
+  Compile a Nerves package into a local artifact
+
+  This is only intended to be used by Nerves systems and toolchains
+  and configured in thier mix.exs files. It should not be used manually
+  when compiling a Nerves project. See `mix firmware` instead.
   """
   use Mix.Task
   import Mix.Nerves.IO
@@ -15,13 +19,14 @@ defmodule Mix.Tasks.Compile.NervesPackage do
     debug_info("Compile.NervesPackage start")
 
     if Nerves.Env.enabled?() do
-      config = Mix.Project.config()
-
       bootstrap_check!()
 
-      _ = Nerves.Env.ensure_loaded(Mix.Project.config()[:app])
+      package =
+        case Nerves.Env.ensure_loaded(Mix.Project.config()[:app]) do
+          {:ok, package} -> package
+          {:error, err} -> Mix.raise(err)
+        end
 
-      package = Nerves.Env.package(config[:app])
       toolchain = Nerves.Env.toolchain()
 
       ret =


### PR DESCRIPTION
Fixes #927

This previously ignored the return of `Nerves.Env.ensure_loaded/1` which could actually return an `{:error, _}` tuple. When calling the `compile.nerves_package` manually, it would crash with a confusing error.

This instead checks the return and raises on error.

It also adjusts the documentation on how/when this task is used
![image (10)](https://github.com/nerves-project/nerves/assets/11321326/7a3908f0-1e8c-42d3-ba2f-f58fd5ee6357)

