### PR TITLE
Fix potential error in Nerves and Phoenix odcs

### DIFF
--- a/guides/core/user-interfaces.md
+++ b/guides/core/user-interfaces.md
@@ -84,7 +84,7 @@ host:
     [
       {:phoenix, "~> 1.6.0"},
       # ...
-      {:phoenix_live_reload, "~> 1.2", only: :dev && Mix.target() == :host},
+      {:phoenix_live_reload, "~> 1.2", only: :dev},
       # ...
       {:esbuild, "~> 0.5", runtime: Mix.env() == :dev && Mix.target() == :host},
       {:tailwind, "~> 0.1.8", runtime: Mix.env() == :dev && Mix.target() == :host},


### PR DESCRIPTION
I followed the guide to set up Nerves and Phoenix together and kept getting an error on this line `{:phoenix_live_reload, "~> 1.2", only: :dev && Mix.target() == :host},`. There was a compiler warning and also the changed way is how it is in `nerves_examples` [here](https://github.com/nerves-project/nerves_examples/blob/6820ac37c3d5f77cf83be12eba63c085961f1390/hello_phoenix/ui/mix.exs#L41C1-L41C52). Could be wrong though so happy to hear if so, either case it works for me now with the change.