### PR TITLE
Build from from `rootfs.tar` system files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ jobs:
             - run: mix format --check-formatted
             - run: mix deps.unlock --check-unused
             - run: mix docs
-            - run: mix hex.build
+            # - run: mix hex.build
             - run: mix test || mix test
             - run: mix credo -a --strict
             - run: mix dialyzer

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - run:
           name: Install system dependencies
-          command: apk add --no-cache build-base procps
+          command: apk add --no-cache build-base procps git
       - checkout
       - run:
           name: Install hex, rebar, and nerves_bootstrap

--- a/lib/mix/nerves/preflight.ex
+++ b/lib/mix/nerves/preflight.ex
@@ -22,7 +22,7 @@ defmodule Mix.Nerves.Preflight do
   # OSX
   defp check_platform!(:darwin) do
     ensure_fwup_version!()
-    ensure_available!("mksquashfs", package: "squashfs")
+    ensure_fs_tools!()
     ensure_available!("gstat", package: "gstat (coreutils)")
   end
 
@@ -35,13 +35,23 @@ defmodule Mix.Nerves.Preflight do
   defp check_platform!(:wsl) do
     ensure_fwup_version!()
     ensure_fwup_version!("fwup.exe")
-    ensure_available!("mksquashfs", package: "squashfs")
+    ensure_fs_tools!()
   end
 
   # Non-WSL Linux
   defp check_platform!(_) do
     ensure_fwup_version!()
-    ensure_available!("mksquashfs", package: "squashfs")
+    ensure_fs_tools!()
+  end
+
+  defp ensure_fs_tools!() do
+    fs_type = Application.get_env(:nerves, :firmware, [])[:fs_type]
+
+    if fs_type == :erofs do
+      ensure_available!("mkfs.erofs", package: "erofs-utils")
+    else
+      ensure_available!("mksquashfs", package: "squashfs")
+    end
   end
 
   @doc """

--- a/mix.exs
+++ b/mix.exs
@@ -30,7 +30,7 @@ defmodule Nerves.MixProject do
   end
 
   def application do
-    [extra_applications: [:ssl, :inets, :eex, :nerves_bootstrap]]
+    [extra_applications: [:ssl, :inets, :eex, :nerves_bootstrap, :tar_merger]]
   end
 
   defp elixirc_paths(:test), do: ["lib", "test/support"]
@@ -46,7 +46,8 @@ defmodule Nerves.MixProject do
       {:dialyxir, "~> 1.0", only: :dev, runtime: false},
       {:plug, "~> 1.10", only: :test},
       {:mime, "~> 2.0", only: :test},
-      {:plug_cowboy, "~> 1.0 or ~> 2.0", only: :test}
+      {:plug_cowboy, "~> 1.0 or ~> 2.0", only: :test},
+      {:tar_merger, github: "jjcarstens/tar_merger", branch: "scan-dir-root", runtime: false}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -21,5 +21,6 @@
   "plug_cowboy": {:hex, :plug_cowboy, "2.7.1", "87677ffe3b765bc96a89be7960f81703223fe2e21efa42c125fcd0127dd9d6b2", [:mix], [{:cowboy, "~> 2.7", [hex: :cowboy, repo: "hexpm", optional: false]}, {:cowboy_telemetry, "~> 0.3", [hex: :cowboy_telemetry, repo: "hexpm", optional: false]}, {:plug, "~> 1.14", [hex: :plug, repo: "hexpm", optional: false]}], "hexpm", "02dbd5f9ab571b864ae39418db7811618506256f6d13b4a45037e5fe78dc5de3"},
   "plug_crypto": {:hex, :plug_crypto, "2.0.0", "77515cc10af06645abbfb5e6ad7a3e9714f805ae118fa1a70205f80d2d70fe73", [:mix], [], "hexpm", "53695bae57cc4e54566d993eb01074e4d894b65a3766f1c43e2c61a1b0f45ea9"},
   "ranch": {:hex, :ranch, "1.8.0", "8c7a100a139fd57f17327b6413e4167ac559fbc04ca7448e9be9057311597a1d", [:make, :rebar3], [], "hexpm", "49fbcfd3682fab1f5d109351b61257676da1a2fdbe295904176d5e521a2ddfe5"},
+  "tar_merger": {:git, "https://github.com/jjcarstens/tar_merger.git", "4ba437d595870f6efe2418d8db8603eff3d593c6", [branch: "scan-dir-root"]},
   "telemetry": {:hex, :telemetry, "1.2.1", "68fdfe8d8f05a8428483a97d7aab2f268aaff24b49e0f599faa091f1d4e7f61c", [:rebar3], [], "hexpm", "dad9ce9d8effc621708f99eac538ef1cbe05d6a874dd741de2e689c47feafed5"},
 }


### PR DESCRIPTION
Starts support to allow building firmware from a `rootfs.tar` tarball file more efficiently in Elixir, rather than relying on bash scripts to unsquash, combine, and resquash an FS. 

The `mix firmware` task was due for a good refactoring, so it looks like a lot. The old way of building is maintained for the typical `rootfs.squashfs` file that systems have traditionally provided.

It also adjusts the build process to allow using EROFS instead of squashfs when making the firmware

> [!NOTE]
> This adds `config :nerves, :firmware, fs_type: :erofs` to specify to use EROFS. If there is a preferred option name and/or location, let me know
>
> Other pieces to still consider:
> - [ ] Scrubbing the OTP release (replacing [`scrub-otp-release.sh`](https://github.com/nerves-project/nerves_system_br/blob/main/scripts/scrub-otp-release.sh))
> - [ ] If priorities need to be adjusted or [these Erlang pieces added](https://github.com/nerves-project/nerves_system_br/blob/main/scripts/rel2fw.sh#L45-L50) 
> - [ ] Maybe support building `*.img` firmware file [like the end of `rel2fw.sh`](https://github.com/nerves-project/nerves_system_br/blob/main/scripts/rel2fw.sh#L165-L179)
> - [ ] Keeping the same `echo` statements from [`rel2fw.sh`](https://github.com/nerves-project/nerves_system_br/blob/main/scripts/rel2fw.sh)