### PR TITLE
Fix Elixir 1.17 warning

### DIFF
--- a/lib/nerves/release.ex
+++ b/lib/nerves/release.ex
@@ -73,7 +73,7 @@ defmodule Nerves.Release do
     priorities =
       (target_beam_files ++ target_app_files ++ target_priv_dirs)
       |> List.flatten()
-      |> Enum.zip(32_000..1_000)
+      |> Enum.zip(32_000..1_000//-1)
       |> Enum.map(fn {file, priority} -> [file, " ", to_string(priority), "\n"] end)
 
     build_path = Path.join([Mix.Project.build_path(), "nerves"])


### PR DESCRIPTION
```
warning: 32000..1000 has a default step of -1, please write 32000..1000//-1 instead
  lib/nerves/release.ex:76: Nerves.Release.write_rootfs_priorities/3
```
