### PR TITLE
Fix incorrect exclusion in vm.args.eex when Elixir 1.15/1.16

### DIFF
--- a/lib/nerves/release.ex
+++ b/lib/nerves/release.ex
@@ -187,7 +187,7 @@ defmodule Nerves.Release do
           {["-run elixir start_iex" | @legacy_elixir_opts], @elixir_1_17_opts}
 
         Version.match?(System.version(), ">= 1.15.0") ->
-          {["-run elixir start_iex" | @legacy_elixir_opts], @elixir_1_15_opts}
+          {["-run elixir start_cli" | @legacy_elixir_opts], @elixir_1_15_opts}
 
         true ->
           exclude = Enum.uniq(@elixir_1_15_opts ++ @elixir_1_17_opts)

--- a/test/nerves/release_test.exs
+++ b/test/nerves/release_test.exs
@@ -79,13 +79,22 @@ defmodule Nerves.ReleaseTest do
           """
 
         Version.match?(System.version(), ">= 1.15.0") ->
-          assert :ok = File.write(bad_vm_args, "# test.vm.args\n-user Elixir.IEx.CLI")
+          assert :ok =
+                   File.write(
+                     bad_vm_args,
+                     "# test.vm.args\n-user Elixir.IEx.CLI\n-run elixir start_cli"
+                   )
 
+          # Check both the older conditions and those in Elixir 1.17
+          # in the same test. This won't happen in practice, so this is mostly
+          # asserting the underlying logic works for both cases
           ~r"""
           Please remove the following lines:
 
           \* #{bad_vm_args}:2:
             -user Elixir.IEx.CLI
+          \* #{bad_vm_args}:3:
+            -run elixir start_cli
 
           Please ensure the following lines are in #{bad_vm_args}:
             -user elixir


### PR DESCRIPTION
This was a copy/paste error. When Elixir 1.16/1.15, we should be checking for the Elixir 1.17 function `start_cli` to be changed instead