### PR TITLE
support setting the product in `mix.exs` using `:product`

### DIFF
--- a/lib/mix/tasks/firmware.ex
+++ b/lib/mix/tasks/firmware.ex
@@ -155,7 +155,7 @@ defmodule Mix.Tasks.Firmware do
     # systems do, this will set the .fw metadata to what's in the mix.exs.
     [
       {"NERVES_FW_VERSION", config[:version]},
-      {"NERVES_FW_PRODUCT", config[:name] || to_string(config[:app])},
+      {"NERVES_FW_PRODUCT", config[:product] || config[:name] || to_string(config[:app])},
       {"NERVES_FW_DESCRIPTION", config[:description]},
       {"NERVES_FW_AUTHOR", config[:author]}
     ]


### PR DESCRIPTION
favor using `:product` in `mix.exs` for setting the product variable in the metadata