### PR TITLE
Remove USB gadget mode serial since not on official platforms

### DIFF
--- a/guides/core/connecting-to-a-nerves-target.md
+++ b/guides/core/connecting-to-a-nerves-target.md
@@ -119,11 +119,6 @@ usually have the letters "USB" somewhere in the name.
 
 You should be at an `iex(1)>` prompt. If not, try pressing `Enter` a few times.
 
-> #### Linux USB gadget mode {: .info}
->
-> Linux USB gadget mode also supplies a virtual serial connection for some
-> Nerves targets.
-
 ### Troubleshooting
 
 #### First boot shows error messages


### PR DESCRIPTION
It had to be removed due to compatibility issues on the official
platforms. While it could be re-enabled, if you know how to do this,
you're probably not reading this guide.
