### PR TITLE
Force `TERM` for docker system shell

### DIFF
--- a/lib/nerves/artifact/build_runners/docker.ex
+++ b/lib/nerves/artifact/build_runners/docker.ex
@@ -312,7 +312,13 @@ defmodule Nerves.Artifact.BuildRunners.Docker do
   defp env(:root), do: env(0, 0)
 
   defp env(uid, gid) do
-    ["--env", "UID=#{uid}", "--env", "GID=#{gid}"]
+    term =
+      case System.get_env("TERM") do
+        term when is_binary(term) and byte_size(term) > 0 -> term
+        _ -> "xterm-256color"
+      end
+
+    ["--env", "UID=#{uid}", "--env", "GID=#{gid}", "--env", "TERM=#{term}"]
   end
 
   defp uid() do


### PR DESCRIPTION
Fixes #1004

EDIT:
Turns out we [added `TERM=dumb` to the `nerves_system_br` image starting with v1.28](https://github.com/nerves-project/nerves_system_br/commit/db6f9a2a5848ca75f26c9c4a3b2a7bf80e606da1#diff-181ba968e8b37dc7c64319846e544967221e3b5c1ec96bd070456abe37b2ccf2R17) based on CircleCI Docker template recommendations. This is nice to have for CI envs which is the majority of uses for that image, so this adjusts the Nerves tooling to put the `TERM` value of the user in _or_ default to `xterm-256color` if not set