### PR TITLE
Add mix discovery command for device discovery

### DIFF
--- a/lib/mix/tasks/discover.ex
+++ b/lib/mix/tasks/discover.ex
@@ -1,0 +1,28 @@
+defmodule Mix.Tasks.Discover do
+  @moduledoc """
+  Find Nerves devices on the local network.
+
+  Should find across wired network, wireless and even USB gadget mode.
+
+  Currently using the MNDP library implementing the MicroTik Neighbor
+  Discovery Protocol. This is more reliable than mDNS which often gets
+  tangled up with general usage by the system.
+  """
+  use Mix.Task
+
+  @impl Mix.Task
+  def run(args) do
+    if Code.ensure_loaded?(MNDP) do
+      Mix.Task.run("mndp.discover", args)
+    else
+      Mix.Nerves.IO.shell_warn("Discovery requires :mndp to be installed in your Nerves project.")
+      Mix.Nerves.IO.shell_info("""
+      You can add it to your dependencies with:
+
+      {:mndp, "~> 0.1.2"}
+
+      Re-build your firmware, update your device with it and then try again.
+      """)
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -46,7 +46,7 @@ defmodule Nerves.MixProject do
       {:dialyxir, "~> 1.0", only: :dev, runtime: false},
       {:plug, "~> 1.10", only: :test},
       {:mime, "~> 2.0", only: :test},
-      {:plug_cowboy, "~> 1.0 or ~> 2.0", only: :test}
+      {:plug_cowboy, "~> 1.0 or ~> 2.0", only: :test},
     ]
   end
 


### PR DESCRIPTION
Uses :mndp library and delegates to mix mndp.discover. If we switch discovery method over time this means we can fairly easily switch without changing the command.

It requires MNDP to be running in your app and a matching change to mix nerves.new might be reasonable to include mndp.