### PR TITLE
Officially support Elixir 1.18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ jobs:
 
   automerge:
     docker:
-      - image: alpine:3.18.4
+      - image: alpine:3.21.0
     steps:
       - run:
           name: Install GitHub CLI

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,15 +1,16 @@
 version: 2.1
 
 latest: &latest
-  pattern: "^1.17.*-erlang-27.*$"
+  pattern: "^1.18.*-erlang-27.*$"
 
 tags: &tags
   [
-    1.17.3-erlang-27.1.2-alpine-3.20.3,
+    1.18.1-erlang-27.2-alpine-3.20.3,
+    1.17.3-erlang-27.2-alpine-3.20.3,
     1.16.3-erlang-26.2.5-alpine-3.20.0,
     1.15.7-erlang-26.2.1-alpine-3.18.4,
     1.14.5-erlang-25.3.2-alpine-3.18.0,
-    1.13.4-erlang-24.3.4-alpine-3.15.3
+    1.13.4-erlang-24.3.4.11-alpine-3.18.0
   ]
 
 jobs:
@@ -62,7 +63,7 @@ jobs:
 
   automerge:
     docker:
-        - image: alpine:3.18.4
+      - image: alpine:3.18.4
     steps:
       - run:
           name: Install GitHub CLI

--- a/lib/mix/nerves/preflight.ex
+++ b/lib/mix/nerves/preflight.ex
@@ -56,7 +56,7 @@ defmodule Mix.Nerves.Preflight do
         vsn = String.trim(vsn)
         {:ok, req} = Version.parse_requirement(vsn_requirement)
 
-        unless Version.match?(vsn, req) do
+        if !Version.match?(vsn, req) do
           Mix.raise("""
           #{fwup_bin} #{vsn_requirement} is required for Nerves.
 

--- a/lib/mix/tasks/burn.ex
+++ b/lib/mix/tasks/burn.ex
@@ -57,7 +57,7 @@ defmodule Mix.Tasks.Burn do
 
     fw = firmware_file(opts)
 
-    unless File.exists?(fw) do
+    if !File.exists?(fw) do
       Mix.raise("Firmware for target #{target} not found at #{fw} run `mix firmware` to build")
     end
 

--- a/lib/mix/tasks/firmware.image.ex
+++ b/lib/mix/tasks/firmware.image.ex
@@ -48,7 +48,7 @@ defmodule Mix.Tasks.Firmware.Image do
 
     fw = "#{images_path}/#{otp_app}.fw"
 
-    unless File.exists?(fw) do
+    if !File.exists?(fw) do
       Mix.raise("Firmware for target #{target} not found at #{fw} run `mix firmware` to build")
     end
 

--- a/lib/mix/tasks/firmware.metadata.ex
+++ b/lib/mix/tasks/firmware.metadata.ex
@@ -50,7 +50,7 @@ defmodule Mix.Tasks.Firmware.Metadata do
 
     fw = firmware_file(opts)
 
-    unless File.exists?(fw) do
+    if !File.exists?(fw) do
       Mix.raise("Firmware for target #{target} not found at #{fw} run `mix firmware` to build")
     end
 

--- a/lib/mix/tasks/firmware.patch.ex
+++ b/lib/mix/tasks/firmware.patch.ex
@@ -38,7 +38,7 @@ defmodule Mix.Tasks.Firmware.Patch do
 
     source = (opts[:source] || Nerves.Env.firmware_path(config)) |> Path.expand()
 
-    unless File.exists?(source) do
+    if !File.exists?(source) do
       Mix.raise("""
       Source firmware #{source} does not exist.
       Please pass --source /path/source.fw or run `mix firmware`.

--- a/lib/mix/tasks/firmware.unpack.ex
+++ b/lib/mix/tasks/firmware.unpack.ex
@@ -55,7 +55,7 @@ defmodule Mix.Tasks.Firmware.Unpack do
 
     _ = check_nerves_toolchain_is_set!()
 
-    unless File.exists?(fw) do
+    if !File.exists?(fw) do
       Mix.raise("""
       Firmware not found.
 

--- a/lib/mix/tasks/nerves.env.ex
+++ b/lib/mix/tasks/nerves.env.ex
@@ -24,7 +24,7 @@ defmodule Mix.Tasks.Nerves.Env do
 
     # TODO: Remove this as it should be handled when bootstrapping this tooling
     #       into the current running project. Leave it here for now
-    unless Code.ensure_loaded?(Nerves.Env) do
+    if !Code.ensure_loaded?(Nerves.Env) do
       _ = Mix.Tasks.Deps.Loadpaths.run(["--no-compile"])
 
       Mix.Tasks.Deps.Compile.run(["nerves", "--include-children"])

--- a/lib/mix/tasks/nerves.loadpaths.ex
+++ b/lib/mix/tasks/nerves.loadpaths.ex
@@ -5,7 +5,7 @@ defmodule Mix.Tasks.Nerves.Loadpaths do
 
   @impl Mix.Task
   def run(_args) do
-    unless System.get_env("NERVES_PRECOMPILE") == "1" do
+    if System.get_env("NERVES_PRECOMPILE") != "1" do
       debug_info("Loadpaths Start")
 
       Mix.Task.run("nerves.precompile", ["--no-loadpaths"])

--- a/lib/mix/tasks/nerves.precompile.ex
+++ b/lib/mix/tasks/nerves.precompile.ex
@@ -14,7 +14,7 @@ defmodule Mix.Tasks.Nerves.Precompile do
     # before the nerves dependency is compiled, which is where Nerves.Env
     # currently lives. This would be improved by moving Nerves.Env to
     # nerves_bootstrap.
-    unless System.get_env("NERVES_ENV_DISABLED") do
+    if !System.get_env("NERVES_ENV_DISABLED") do
       System.put_env("NERVES_PRECOMPILE", "1")
 
       {opts, _, _} = OptionParser.parse(args, switches: @switches)

--- a/lib/nerves/artifact/build_runners/docker.ex
+++ b/lib/nerves/artifact/build_runners/docker.ex
@@ -377,7 +377,7 @@ defmodule Nerves.Artifact.BuildRunners.Docker do
         {:ok, requirement} = Version.parse_requirement(@version)
         {:ok, vsn} = parse_docker_version(vsn)
 
-        unless Version.match?(vsn, requirement) do
+        if !Version.match?(vsn, requirement) do
           error_invalid_version(vsn)
         end
 
@@ -394,14 +394,14 @@ defmodule Nerves.Artifact.BuildRunners.Docker do
     {dockerfile, tag} = config(pkg)
 
     # Check for the Build Volume
-    unless Docker.Volume.exists?(name) do
+    if !Docker.Volume.exists?(name) do
       Docker.Volume.create(name)
     end
 
-    unless Docker.Image.exists?(tag) do
+    if !Docker.Image.exists?(tag) do
       Docker.Image.pull(tag)
 
-      unless Docker.Image.exists?(tag) do
+      if !Docker.Image.exists?(tag) do
         Docker.Image.create(dockerfile, tag)
       end
     end

--- a/lib/nerves/artifact/build_runners/docker.ex
+++ b/lib/nerves/artifact/build_runners/docker.ex
@@ -374,10 +374,9 @@ defmodule Nerves.Artifact.BuildRunners.Docker do
     case Nerves.Port.cmd("docker", ["--version"]) do
       {result, 0} ->
         <<"Docker version ", vsn::binary>> = result
-        {:ok, requirement} = Version.parse_requirement(@version)
         {:ok, vsn} = parse_docker_version(vsn)
 
-        if !Version.match?(vsn, requirement) do
+        if !Version.match?(vsn, @version) do
           error_invalid_version(vsn)
         end
 

--- a/lib/nerves/artifact/resolvers/gitea_api.ex
+++ b/lib/nerves/artifact/resolvers/gitea_api.ex
@@ -47,7 +47,16 @@ defmodule Nerves.Artifact.Resolvers.GiteaAPI do
       opts
       | headers: headers,
         url:
-          Path.join([opts.base_url, "api", "v1", "repos", opts.repo, "releases", "tags", opts.tag])
+          Path.join([
+            opts.base_url,
+            "api",
+            "v1",
+            "repos",
+            opts.repo,
+            "releases",
+            "tags",
+            opts.tag
+          ])
     }
   end
 

--- a/lib/nerves/package.ex
+++ b/lib/nerves/package.ex
@@ -58,7 +58,7 @@ defmodule Nerves.Package do
     compilers = config[:compilers] || Mix.compilers()
     env = Map.new(config[:nerves_package][:env] || %{})
 
-    unless type do
+    if !type do
       Mix.shell().error(
         "The Nerves package #{app} does not define a type.\n\n" <>
           "Verify that the key exists in '#{config_path(path)}'.\n"

--- a/lib/nerves/port.ex
+++ b/lib/nerves/port.ex
@@ -81,7 +81,7 @@ defmodule Nerves.Port do
   defp validate(cmd, args, opts) do
     assert_no_null_byte!(cmd)
 
-    unless Enum.all?(args, &is_binary/1) do
+    if !Enum.all?(args, &is_binary/1) do
       raise ArgumentError, "all arguments for Nerves.Port.cmd/3 must be binaries"
     end
 

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule Nerves.MixProject do
     [
       app: :nerves,
       version: @version,
-      elixir: "~> 1.13.0 or ~> 1.14.0 or ~> 1.15.1 or ~> 1.16.0 or ~> 1.17.0",
+      elixir: "~> 1.13.0 or ~> 1.14.0 or ~> 1.15.1 or ~> 1.16.0 or ~> 1.17.0 or ~> 1.18.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       deps: deps(),
       description: description(),

--- a/test/nerves/port_test.exs
+++ b/test/nerves/port_test.exs
@@ -104,7 +104,7 @@ defmodule Nerves.PortTest do
       # There is a bug in OTP where find_executable is finding
       # entries on the current directory. If this is the case,
       # we should avoid the assertion below.
-      unless System.find_executable(@echo) do
+      if !System.find_executable(@echo) do
         assert :enoent = catch_error(Nerves.Port.cmd(@echo, ["hello"]))
       end
 

--- a/test/nerves/release_test.exs
+++ b/test/nerves/release_test.exs
@@ -11,13 +11,27 @@ defmodule Nerves.ReleaseTest do
 
     assert exit_status == 0, output
 
-    expected = """
-    srv/erlang/releases/0.1.0/consolidated/Elixir.String.Chars.beam 32000
-    srv/erlang/releases/0.1.0/consolidated/Elixir.List.Chars.beam 31999
-    srv/erlang/releases/0.1.0/consolidated/Elixir.Inspect.beam 31998
-    srv/erlang/releases/0.1.0/consolidated/Elixir.Enumerable.beam 31997
-    srv/erlang/releases/0.1.0/consolidated/Elixir.Collectable.beam 31996
-    """
+    expected =
+      if Version.match?(System.version(), ">= 1.18.0") do
+        # JSON.Encoder is in 1.18
+        """
+        srv/erlang/releases/0.1.0/consolidated/Elixir.String.Chars.beam 32000
+        srv/erlang/releases/0.1.0/consolidated/Elixir.List.Chars.beam 31999
+        srv/erlang/releases/0.1.0/consolidated/Elixir.JSON.Encoder.beam 31998
+        srv/erlang/releases/0.1.0/consolidated/Elixir.Inspect.beam 31997
+        srv/erlang/releases/0.1.0/consolidated/Elixir.Enumerable.beam 31996
+        srv/erlang/releases/0.1.0/consolidated/Elixir.Collectable.beam 31995
+        """
+      else
+        # Elixir 1.17 and before
+        """
+        srv/erlang/releases/0.1.0/consolidated/Elixir.String.Chars.beam 32000
+        srv/erlang/releases/0.1.0/consolidated/Elixir.List.Chars.beam 31999
+        srv/erlang/releases/0.1.0/consolidated/Elixir.Inspect.beam 31998
+        srv/erlang/releases/0.1.0/consolidated/Elixir.Enumerable.beam 31997
+        srv/erlang/releases/0.1.0/consolidated/Elixir.Collectable.beam 31996
+        """
+      end
 
     # TODO: Adjust this test to better check ordering
     # Asserting a specific generated priorities is brittle as it drastically

--- a/test/support/test_case.ex
+++ b/test/support/test_case.ex
@@ -50,8 +50,8 @@ defmodule NervesTest.Case do
 
   defmacro in_fixture(which, block) do
     module = inspect(__CALLER__.module)
-    function = Atom.to_string(elem(__CALLER__.function, 0))
-    tmp = Path.join(module, function)
+    {function, _} = __CALLER__.function
+    tmp = Path.join(module, Atom.to_string(function))
 
     quote do
       unquote(__MODULE__).in_fixture(unquote(which), unquote(tmp), unquote(block))


### PR DESCRIPTION
Most libraries appear to work just fine with Elixir 1.18 and Nerves, so
remove the warning when building.
