### PR TITLE
Remove last references to the old nerves.exs

### DIFF
--- a/lib/nerves/env.ex
+++ b/lib/nerves/env.ex
@@ -2,10 +2,9 @@ defmodule Nerves.Env do
   @moduledoc """
   Contains package info for Nerves dependencies
 
-  The Nerves Env is used to load information from dependencies that
-  contain a nerves.exs config file in the root of the dependency
-  path. Nerves loads this config because it needs access to information
-  about Nerves compile time dependencies before any code is compiled.
+  The Nerves Env is used to load information from dependencies that have nerves
+  config. Nerves loads this config because it needs access to information about
+  Nerves compile time dependencies before any code is compiled.
   """
 
   alias Nerves.{Artifact, Package}
@@ -524,8 +523,7 @@ defmodule Nerves.Env do
 
     package_config != nil
   rescue
-    _e ->
-      File.exists?(Package.config_path(path))
+    _e -> false
   end
 
   defp mix_config() do


### PR DESCRIPTION
This was where Nerves package configuration existed before it was moved
to the mix.exs. This is REALLY old.
