### PR TITLE
Be explicit of behaviours used rather than use macro

### DIFF
--- a/lib/nerves/package/platform.ex
+++ b/lib/nerves/package/platform.ex
@@ -8,14 +8,12 @@ defmodule Nerves.Package.Platform do
   is useful for constructing host tools to be used during the elixir compile
   phase.
 
-  You can implement both `Nerves.Package.Platform` and `Nerves.Artifact.BuildRunner`
-  in the same module with the using macro.
-
   Here is a simple example that touches a file in the `Artifact.build_path`
 
   ```elixir
   defmodule SystemPlatform do
-    use Nerves.Package.Platform
+    @behaviour Nerves.Artifact.BuildRunner
+    @behaviour Nerves.Package.Platform
 
     def bootstrap(_pkg) do
       System.put_env("NERVES_BOOTSTRAP_SYSTEM", "1")
@@ -68,11 +66,4 @@ defmodule Nerves.Package.Platform do
   artifact to the local build_path location.
   """
   @callback build_path_link(package :: Nerves.Package.t()) :: build_path_link :: String.t()
-
-  defmacro __using__(_) do
-    quote do
-      @behaviour Nerves.Artifact.BuildRunner
-      @behaviour Nerves.Package.Platform
-    end
-  end
 end

--- a/lib/nerves/system/br.ex
+++ b/lib/nerves/system/br.ex
@@ -2,7 +2,8 @@ defmodule Nerves.System.BR do
   @moduledoc """
   Package builder for Buildroot-based Nerves systems
   """
-  use Nerves.Package.Platform
+  @behaviour Nerves.Artifact.BuildRunner
+  @behaviour Nerves.Package.Platform
 
   import Mix.Nerves.Utils
   alias Nerves.Artifact

--- a/test/fixtures/host_tool/lib/host_tool/platform.ex
+++ b/test/fixtures/host_tool/lib/host_tool/platform.ex
@@ -1,6 +1,7 @@
 defmodule HostTool.Platform do
   @moduledoc false
-  use Nerves.Package.Platform
+  @behaviour Nerves.Artifact.BuildRunner
+  @behaviour Nerves.Package.Platform
 
   alias Nerves.Artifact
 

--- a/test/fixtures/system_platform/lib/system_platform.ex
+++ b/test/fixtures/system_platform/lib/system_platform.ex
@@ -1,6 +1,8 @@
 defmodule SystemPlatform do
   @moduledoc false
-  use Nerves.Package.Platform
+  @behaviour Nerves.Artifact.BuildRunner
+  @behaviour Nerves.Package.Platform
+
   alias Nerves.Artifact
 
   @impl Nerves.Package.Platform

--- a/test/fixtures/toolchain_platform/lib/toolchain_platform.ex
+++ b/test/fixtures/toolchain_platform/lib/toolchain_platform.ex
@@ -1,6 +1,7 @@
 defmodule ToolchainPlatform do
   @moduledoc false
-  use Nerves.Package.Platform
+  @behaviour Nerves.Artifact.BuildRunner
+  @behaviour Nerves.Package.Platform
 
   alias Nerves.Artifact
 

--- a/test/fixtures/umbrella/apps/toolchain_platform/lib/toolchain_platform.ex
+++ b/test/fixtures/umbrella/apps/toolchain_platform/lib/toolchain_platform.ex
@@ -1,6 +1,7 @@
 defmodule ToolchainPlatform do
   @moduledoc false
-  use Nerves.Package.Platform
+  @behaviour Nerves.Artifact.BuildRunner
+  @behaviour Nerves.Package.Platform
 
   alias Nerves.Artifact
 


### PR DESCRIPTION
This only affects `Nerves.Package.Platform` and its users which should
be almost no one since we never ported Nerves outside of Buildroot.
