### PR TITLE
Simplify Nerves.Env by removing package config caching

### DIFF
--- a/lib/mix/tasks/nerves.env.ex
+++ b/lib/mix/tasks/nerves.env.ex
@@ -30,7 +30,8 @@ defmodule Mix.Tasks.Nerves.Env do
       Mix.Tasks.Deps.Compile.run(["nerves", "--include-children"])
     end
 
-    _ = Nerves.Env.start()
+    Nerves.Env.set_source_date_epoch()
+
     debug_info("Env End")
     if opts[:info], do: print_env()
   end

--- a/test/nerves/artifact_test.exs
+++ b/test/nerves/artifact_test.exs
@@ -13,7 +13,6 @@ defmodule Nerves.ArtifactTest do
       |> Path.join("mix.exs")
       |> Code.require_file()
 
-      Env.start()
       assert Env.package(:package_build_runner_override).build_runner == {P.Docker, []}
     end)
   end
@@ -24,7 +23,6 @@ defmodule Nerves.ArtifactTest do
       |> Path.join("mix.exs")
       |> Code.require_file()
 
-      Env.start()
       assert {_, [make_args: []]} = Env.package(:package_build_runner_opts).build_runner
     end)
   end
@@ -82,8 +80,6 @@ defmodule Nerves.ArtifactTest do
       File.cwd!()
       |> Path.join("mix.exs")
       |> Code.require_file()
-
-      Nerves.Env.start()
 
       pkg = Nerves.Env.system()
 

--- a/test/nerves/cache_test.exs
+++ b/test/nerves/cache_test.exs
@@ -36,7 +36,6 @@ defmodule Nerves.CacheTest do
       |> Path.join("mix.exs")
       |> Code.require_file()
 
-      Nerves.Env.start()
       package = Nerves.Env.package(:system)
 
       dl_name = Nerves.Artifact.download_name(package) <> Nerves.Artifact.ext(package)
@@ -66,7 +65,6 @@ defmodule Nerves.CacheTest do
       |> Path.join("mix.exs")
       |> Code.require_file()
 
-      Nerves.Env.start()
       package = Nerves.Env.package(:system)
 
       dl_name = Nerves.Artifact.download_name(package) <> Nerves.Artifact.ext(package)
@@ -90,8 +88,6 @@ defmodule Nerves.CacheTest do
       File.cwd!()
       |> Path.join("mix.exs")
       |> Code.require_file()
-
-      Nerves.Env.start()
 
       File.mkdir_p!(Nerves.Env.download_dir())
 

--- a/test/nerves/env_test.exs
+++ b/test/nerves/env_test.exs
@@ -122,7 +122,7 @@ defmodule Nerves.EnvTest do
         System.put_env("SOURCE_DATE_EPOCH", "")
 
         assert_raise Mix.Error, fn ->
-          Nerves.Env.start()
+          Nerves.Env.set_source_date_epoch()
         end
       end)
     end

--- a/test/support/test_case.ex
+++ b/test/support/test_case.ex
@@ -40,7 +40,6 @@ defmodule NervesTest.Case do
       Mix.ProjectStack.clear_stack()
       delete_tmp_paths()
       reset_system_env(original_env)
-      Nerves.Env.stop()
 
       :ok
     end)
@@ -233,7 +232,8 @@ defmodule NervesTest.Case do
 
     _ = Code.require_file(Path.expand("mix.exs"))
 
-    {:ok, _} = Nerves.Env.start()
+    # TODO: Move this next line to a more appropriate place
+    Nerves.Env.set_source_date_epoch()
     Nerves.Env.packages()
   end
 


### PR DESCRIPTION
It looks like it was more useful when the Nerves package config was kept
in `nerves.exs`. Now it's just returned from the Mix configuration. This
opens up further simplifications since it's no longer important to make
sure that the Agent is loaded. Performance-wise, it doesn't seem like
the cache was used enough for anyone to notice.
