### PR TITLE
Upgrade asdf examples to asdf 0.16 syntax

### DIFF
--- a/guides/introduction/installation.md
+++ b/guides/introduction/installation.md
@@ -83,7 +83,7 @@ images. Here are the `asdf` instructions:
 ```bash
 asdf plugin add fwup https://github.com/fwup-home/asdf-fwup.git
 asdf install fwup latest
-asdf global fwup latest
+asdf set -u fwup latest
 ```
 
 ### Fedora
@@ -102,7 +102,7 @@ images. Here are the `asdf` instructions:
 ```bash
 asdf plugin add fwup https://github.com/fwup-home/asdf-fwup.git
 asdf install fwup latest
-asdf global fwup latest
+asdf set -u fwup latest
 ```
 
 ### Arch
@@ -195,20 +195,20 @@ Erlang/OTP and Elixir:
 ### asdf
 
 ```sh
-asdf plugin-add erlang
-asdf plugin-add elixir
+asdf plugin add erlang
+asdf plugin add elixir
 
-asdf install erlang 27.1.2
-asdf install elixir 1.17.3-otp-27
-asdf global erlang 27.1.2
-asdf global elixir 1.17.3-otp-27
+asdf install erlang 27.3.2
+asdf install elixir 1.18.3-otp-27
+asdf set -u erlang 27.3.2
+asdf set -u elixir 1.18.3-otp-27
 ```
 
 ### mise
 
 ```sh
-mise use -g erlang@27.1.2
-mise use -g elixir@1.17.3-otp-27
+mise use -g erlang@27.3.2
+mise use -g elixir@1.18.3-otp-27
 ```
 
 > #### Auto plugin install {: .tip}

--- a/lib/mix/tasks/firmware.ex
+++ b/lib/mix/tasks/firmware.ex
@@ -208,7 +208,7 @@ defmodule Mix.Tasks.Firmware do
       If you're using asdf to manage Elixir versions, run:
 
       asdf install elixir #{System.version()}-otp-#{System.otp_release()}
-      asdf global elixir #{System.version()}-otp-#{System.otp_release()}
+      asdf set -u elixir #{System.version()}-otp-#{System.otp_release()}
       """)
     end
   end


### PR DESCRIPTION
See https://asdf-vm.com/guide/upgrading-to-v0-16 for details.
