### PR TITLE
Update linux/ubuntu installation instructions

### DIFF
--- a/guides/introduction/installation.md
+++ b/guides/introduction/installation.md
@@ -73,7 +73,7 @@ First, install a few packages.
 ### Ubuntu and Debian
 
 ```bash
-sudo apt install build-essential automake autoconf git squashfs-tools ssh-askpass pkg-config curl libmnl-dev libnl-genl-3-dev libssl-dev libncurses5-dev help2man libconfuse-dev libarchive-dev
+sudo apt install build-essential automake autoconf git squashfs-tools ssh-askpass pkg-config curl libmnl-dev libnl-genl-3-dev libssl-dev libncurses5-dev help2man libconfuse-dev libarchive-dev file unzip libgnutls28-dev
 ```
 
 Then install [fwup](https://github.com/fwup-home/fwup) using `asdf` or `mise` or


### PR DESCRIPTION
I recently set up a fresh Ubuntu 24.04 server for Nerves, and followed the guide. These packages were missing from the default system packages and not listed in the installation instructions