### PR TITLE
Prevent `mix nerves.system.shell` from compiling the system

### DIFF
--- a/lib/mix/tasks/nerves.loadpaths.ex
+++ b/lib/mix/tasks/nerves.loadpaths.ex
@@ -10,7 +10,9 @@ defmodule Mix.Tasks.Nerves.Loadpaths do
 
   @impl Mix.Task
   def run(_args) do
-    if System.get_env("NERVES_PRECOMPILE") != "1" do
+    [task | _] = System.argv()
+
+    if System.get_env("NERVES_PRECOMPILE") != "1" and task != "nerves.system.shell" do
       debug_info("Loadpaths Start")
 
       Mix.Task.run("nerves.precompile", ["--no-loadpaths"])


### PR DESCRIPTION
With the base tooling setup, running `mix nerves.system.shell` could trigger a full build for systems because will attempt to ensure the Elixir code is compiled. However, the tooling also ties into `mix compile` to ensure the whole system is built also.

The result is a long time to get to a shell when the goal is to run the system shell for the intent of fixing and/or configuring.

This adds a simple check if the task being run is `nerves.system.shell` and skips this precompilation while also using the parts of the tooling needed to get the right build directories and Docker image/settings setup before the shell