### PR TITLE
nerves.loadpaths: Do not crash when invoked without args

### DIFF
--- a/lib/mix/tasks/nerves.loadpaths.ex
+++ b/lib/mix/tasks/nerves.loadpaths.ex
@@ -10,7 +10,7 @@ defmodule Mix.Tasks.Nerves.Loadpaths do
 
   @impl Mix.Task
   def run(_args) do
-    [task | _] = System.argv()
+    task = List.first(System.argv())
 
     if System.get_env("NERVES_PRECOMPILE") != "1" and task != "nerves.system.shell" do
       debug_info("Loadpaths Start")


### PR DESCRIPTION
This prevents a crash when ElixirLS is building a Nerves project with
MIX_TARGET set to something other than host.
