### PR TITLE
Support other env vars when determining if download progress should be shown

### DIFF
--- a/lib/nerves/utils/http_client.ex
+++ b/lib/nerves/utils/http_client.ex
@@ -233,7 +233,10 @@ defmodule Nerves.Utils.HTTPClient do
   end
 
   defp progress?(%{progress?: progress?}) do
-    System.get_env("NERVES_LOG_DISABLE_PROGRESS_BAR") == nil and progress?
+    System.get_env("DEBIAN_FRONTEND") != "noninteractive" and
+      System.get_env("CI") == nil and
+      System.get_env("NERVES_LOG_DISABLE_PROGRESS_BAR") == nil and 
+      progress?
   end
 
   defp tuple_to_charlist({k, v}) do


### PR DESCRIPTION
GitHub Actions and CircleCI both set `CI` env to `true`.

`DEBIAN_FRONTEND=noninteractive` is commonly used to convey that interactive input isn't supported.

These would allow CI output to be cleaner without having to set `NERVES_LOG_DISABLE_PROGRESS_BAR`