### PR TITLE
Remove dependency on Nerves.Bootstrap

### DIFF
--- a/lib/mix/tasks/nerves.info.ex
+++ b/lib/mix/tasks/nerves.info.ex
@@ -29,9 +29,19 @@ defmodule Mix.Tasks.Nerves.Info do
 
     Mix.Tasks.Nerves.Env.run(["--info", "--disable"])
     Mix.shell().info("Nerves:           #{Nerves.version()}")
-    Mix.shell().info("Nerves Bootstrap: #{Nerves.Bootstrap.version()}")
+    Mix.shell().info("Nerves Bootstrap: #{bootstrap_version()}")
     Mix.shell().info("Elixir:           #{System.version()}")
     Nerves.Env.enable()
     debug_info("Info End")
+  end
+
+  defp bootstrap_version() do
+    archives_path = Mix.path_for(:archives)
+    prefix = Path.join(archives_path, "nerves_bootstrap-")
+
+    case Path.wildcard("#{prefix}*") do
+      [] -> "not installed"
+      [entry | _] -> String.trim_leading(entry, prefix)
+    end
   end
 end

--- a/test/mix/nerves.info_test.exs
+++ b/test/mix/nerves.info_test.exs
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: 2025 Frank Hunleth
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+defmodule Mix.Nerves.InfoTest do
+  use NervesTest.Case
+
+  test "info returns versions" do
+    in_fixture("simple_app", fn ->
+      File.cwd!()
+      |> Path.join("mix.exs")
+      |> Code.require_file()
+
+      load_env()
+
+      Mix.Tasks.Nerves.Info.run([])
+
+      assert_receive {:mix_shell, :info, ["Nerves:           " <> nerves]}
+      assert_receive {:mix_shell, :info, ["Nerves Bootstrap: " <> bootstrap]}
+      assert_receive {:mix_shell, :info, ["Elixir:           " <> elixir]}
+
+      elixir_vsn = Version.parse!(elixir)
+      bootstrap_vsn = Version.parse!(bootstrap)
+      nerves_vsn = Version.parse!(nerves)
+
+      assert Version.match?(elixir_vsn, "~> 1.15")
+      assert Version.match?(bootstrap_vsn, "~> 1.5")
+      assert Version.match?(nerves_vsn, "~> 1.13")
+    end)
+  end
+end


### PR DESCRIPTION
The only place it was ever called was in the `nerves.info` task. Due to
how loadpaths works, you can't call Nerves.Bootstrap from just anywhere.
The simplest solution seems to be to avoid it altogether.

This also adds a test for `nerves.info`.
