### PR TITLE
Completely remove nerves_bootstrap dependency

### DIFF
--- a/guides/introduction/getting-started.md
+++ b/guides/introduction/getting-started.md
@@ -327,7 +327,7 @@ defmodule HelloNerves.MixProject do
       app: @app,
       version: @version,
       elixir: "~> 1.17",
-      archives: [nerves_bootstrap: "~> 1.14"],
+      archives: [nerves_bootstrap: "~> 1.15"],
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       releases: [{@app, release()}],

--- a/mix.exs
+++ b/mix.exs
@@ -15,6 +15,7 @@ defmodule Nerves.MixProject do
       app: :nerves,
       version: @version,
       elixir: "~> 1.15.1 or ~> 1.16.0 or ~> 1.17.0 or ~> 1.18.0 or ~> 1.19.0",
+      archives: [nerves_bootstrap: "~> 1.15.1 or ~> 1.16"],
       elixirc_paths: elixirc_paths(Mix.env()),
       deps: deps(),
       description: description(),
@@ -25,13 +26,12 @@ defmodule Nerves.MixProject do
       docs: docs(),
       dialyzer: dialyzer(),
       aliases: ["archive.build": &raise_on_archive_build/1],
-      xref: [exclude: [Nerves.Bootstrap]],
       test_ignore_filters: [~r/test.fixtures.*/]
     ]
   end
 
   def application do
-    [extra_applications: [:ssl, :inets, :eex, :nerves_bootstrap]]
+    [extra_applications: [:ssl, :inets, :eex]]
   end
 
   defp elixirc_paths(:test), do: ["lib", "test/support"]

--- a/test/fixtures/integration_app/mix.exs
+++ b/test/fixtures/integration_app/mix.exs
@@ -5,7 +5,7 @@ defmodule IntegrationApp do
     [
       app: :integration_app,
       version: "0.1.0",
-      archives: [nerves_bootstrap: "~> 1.0"],
+      archives: [nerves_bootstrap: "~> 1.15"],
       deps: deps()
     ]
   end

--- a/test/fixtures/simple_app/mix.exs
+++ b/test/fixtures/simple_app/mix.exs
@@ -5,7 +5,7 @@ defmodule SimpleApp.Fixture do
     [
       app: :simple_app,
       version: "0.1.0",
-      archives: [nerves_bootstrap: "~> 1.0"],
+      archives: [nerves_bootstrap: "~> 1.15"],
       deps: deps()
     ]
   end

--- a/test/fixtures/simple_app_artifact/mix.exs
+++ b/test/fixtures/simple_app_artifact/mix.exs
@@ -5,7 +5,7 @@ defmodule SimpleAppArtifact.Fixture do
     [
       app: :simple_app_artifact,
       version: "0.1.0",
-      archives: [nerves_bootstrap: "~> 1.0"],
+      archives: [nerves_bootstrap: "~> 1.15"],
       deps: deps()
     ]
   end


### PR DESCRIPTION
This requires https://github.com/nerves-project/nerves_bootstrap/pull/398 to build on Elixir 1.18 and earlier.