### PR TITLE
Rename and make clear that create_archive is private API

### DIFF
--- a/lib/mix/tasks/nerves.artifact.ex
+++ b/lib/mix/tasks/nerves.artifact.ex
@@ -68,12 +68,11 @@ defmodule Mix.Tasks.Nerves.Artifact do
     package = Nerves.Env.package(package_name)
     toolchain = Nerves.Env.toolchain()
 
-    _ =
-      if is_nil(package) do
-        Mix.raise("Could not find Nerves package #{package_name} in env")
-      else
-        Nerves.Artifact.archive(package, toolchain, opts)
-      end
+    if is_nil(package) do
+      Mix.raise("Could not find Nerves package #{package_name} in env")
+    else
+      Nerves.Artifact.create_archive(package, toolchain, opts)
+    end
 
     debug_info("Nerves.Artifact end")
   end

--- a/lib/nerves/artifact.ex
+++ b/lib/nerves/artifact.ex
@@ -41,19 +41,19 @@ defmodule Nerves.Artifact do
     end
   end
 
-  @doc """
-  Produces an archive of the package artifact which can be fetched when
-  calling `nerves.artifact.get`.
-  """
-  @spec archive(Nerves.Package.t(), Nerves.Package.t(), keyword()) :: {:ok, String.t()}
-  def archive(%{app: app, build_runner: nil}, _toolchain, _opts) do
+  # Produce an archive of the package artifact
+  #
+  # The archive can be fetched when calling `nerves.artifact.get`.
+  @doc false
+  @spec create_archive(Nerves.Package.t(), Nerves.Package.t(), keyword()) :: :ok
+  def create_archive(%{app: app, build_runner: nil}, _toolchain, _opts) do
     Mix.raise("""
     #{inspect(app)} does not declare a build_runner and therefore cannot
     be used to produce an artifact archive.
     """)
   end
 
-  def archive(pkg, toolchain, opts) do
+  def create_archive(pkg, toolchain, opts) do
     Mix.shell().info("Creating Artifact Archive")
     opts = default_archive_opts(pkg, opts)
 
@@ -71,7 +71,7 @@ defmodule Nerves.Artifact do
       File.cp!(archive_path, path)
     end
 
-    {:ok, archive_path}
+    :ok
   end
 
   @doc """


### PR DESCRIPTION
There appears to be no external use of this, so make it more clear that
calling `Artifact.create_archive/3` directly is internal API and you
really should be using `mix nerves.artifact`.
