### PR TITLE
Recommend fwup_delta for creating firmware patches

### DIFF
--- a/guides/advanced/experimental-features.md
+++ b/guides/advanced/experimental-features.md
@@ -23,20 +23,20 @@ where the cost of every byte counts. This problem can be alleviated with firmwar
 patches.
 
 A firmware patch file's content structure is identical to that of a regular
-firmware update file, it contains your root file system, the Linux kernel, and
-so on. The main difference is that the contents of these files are no longer a
-bit for bit representation but instead the delta between two known versions of
-firmware. Currently, the system will only apply patches to the root file system,
-but there are plans to support other files. It is important to note that in order
-to generate a firmware patch file, you will need to supply two full firmware
+firmware update file. The main difference is that the contents of these files
+are no longer a bit for bit representation but instead the delta between two
+known versions of firmware.
+
+To generate a firmware patch file, you will need to supply two full firmware
 update files, the firmware that the target is updating from (currently running)
 and the firmware the device will be updating to (the desired new firmware).
 Attempting to apply a firmware patch to a target that is not running the "from"
-firmware will result in returning an error when attempting to apply it.
-Generating and applying firmware patch files will require that your host machine
-and your target have `fwup` >= 1.6.0 installed.
+firmware will return an error.
 
-### Preparing your Nerves system
+See [fwup_delta](https://hex.pm/packages/fwup_delta) for an Elixir library that
+creates patches.
+
+### Preparing your Nerves system for patches
 
 Firmware update patches will require modifications to the `fwup.conf` of your
 Nerves system. These updates must be applied in full to a running target before
@@ -100,17 +100,28 @@ fwup: Upgrading partition B
 fwup: File 'rootfs.img' isn't expected size (7373 vs 49201152) and xdelta3 patch support not enabled on it. (Add delta-source-raw-offset or delta-source-raw-count at least)
 ```
 
-### Preparing your project
+### Tips for smaller patches
 
-Generating a root filesystem patch requires a bit comparison between two root
-file systems. We use xdelta3 and provide it the "from" and "to" SquashFS files.
-SquashFS will compress the root filesystem structure and data by default. The
-resulting patch file size is often quite higher compared to the expected source
-modification size due to the bit for bit comparison being inefficient when
-comparing compressed data. SquashFS can be configured to disable compression,
-allowing us to create more efficient patches. Disabling SquashFS compression
-allows us to create more effective patches. Add the following `mksquashfs_flags`
-to your project's mix config.
+Creating small firmware deltas requires tradeoffs. Internally, the `xdelta3`
+tool finds common data between firmware images. It's good, but the following
+work against it:
+
+1. Compression - a small change at the beginning propogates and removes common
+   byte sequences. Turn off compression or move frequently changing data to the
+   end of the image.
+2. Nondeterministic builds - Remove timestamps and debug information with local
+   paths. Anything that changes between builds increases delta size.
+3. File system packing - SquashFS packs filesystem data structures and small
+   files. Files that change size or disappear between firmwares can cause inode
+   tables and the like to change especially when packed
+4. xdelta3 source windows - A larger source window allows xdelta3 to scan more
+   data for matches. However, it also requires more memory on device. Source
+   windows over 8 MB can cause cache thrashing on devices and make updates take
+   a long time even though they are smaller.
+
+
+One way to start is to experiment with setting `mksquashfs_flags` to your
+project's mix config.
 
 ```elixir
 # Customize non-Elixir parts of the firmware. See
@@ -131,96 +142,6 @@ timestamps modifications from affecting the output bit representation.
 
 config :nerves, source_date_epoch: "1596027629"
 ```
-
-### Testing firmware patches locally
-
-Create a new project using `mix nerves.new <project name>` and apply the steps
-listed in the `Preparing your project` section. Then, choose a target, in this
-example, I will be using a Raspberry Pi Zero W `rpi0` and building an app
-called `test_patch`.
-
-```sh
-export MIX_TARGET=rpi0
-mix deps.get
-```
-
-Create your initial firmware and burn it to an SD card
-
-```sh
-mix firmware.burn
-```
-
-Connect the SD card and power on the device by connecting a micro USB cable to
-the host USB port on the Raspberry Pi. You can ssh into the device at
-`nerves.local` and you should get an IEX prompt.
-
-```sh
-ssh nerves.local
-
-Interactive Elixir (1.10.4) - press Ctrl+C to exit (type h() ENTER for help)
-Toolshed imported. Run h(Toolshed) for more info.
-RingLogger is collecting log messages from Elixir and Linux. To see the
-messages, either attach the current IEx session to the logger:
-
-  RingLogger.attach
-
-or print the next messages in the log:
-
-  RingLogger.next
-
-iex(1)> TestPatch.hello
-:world
-```
-
-Make some changes to the function. Open `lib/<app_name>.ex` and modify the
-`hello/0` function.
-
-```elixir
-def hello do
-  :patched
-end
-```
-
-Now lets generate a patch firmware.
-
-`mix firmware.patch`
-
-You should see output similar to the following:
-
-```text
-Finished generating patch firmware
-
-Source
-test_patch/_build/rpi0_dev/nerves/images/test_patch.fw
-uuid: 6cf7f75f-eb93-5a91-e28c-fd414602b6e7"
-
-size: 22079567 bytes
-
-Target
-nerves-project/tests/test_patch/_build/rpi0_dev/nerves/images/patch/target.fw
-uuid: 69752f24-291f-5f00-4ad3-ca359017009f"
-
-size: 22077072 bytes
-
-Patch
-test_patch/_build/rpi0_dev/nerves/images/patch.fw
-size: 4425660 bytes
-```
-
-Lets update the device using the patch file.
-
-```sh
-mix upload --firmware /path/to/test_patch/_build/rpi0_dev/nerves/images/patch.fw
-```
-
-The size difference between the `Target` output firmware size `22077072` and the
-patched firmware size `4425660` has a pretty significant size reduction. For
-such a small change, we might expect more. A lot of this size come from the
-files that are also included in the firmware that are not currently being patched
-such as the Linux kernel and other files that do not change frequently.
-We anticipate that all other files will offer similar support, but we started
-with the first most impactful file, the SquashFS root filesystem, so we can begin
-testing this workflow using devices.
 
 ## Nerves package environment variables
 

--- a/lib/mix/tasks/firmware.patch.ex
+++ b/lib/mix/tasks/firmware.patch.ex
@@ -33,6 +33,11 @@ defmodule Mix.Tasks.Firmware.Patch do
 
   @impl Mix.Task
   def run(args) do
+    Shell.warn("""
+    Please use https://hex.pm/packages/fwup_delta for generating patches now. It is
+    better maintained and has significant improvments over mix firmware.patch.
+    """)
+
     work_dir = Path.join(Nerves.Env.images_path(), "patch")
     _ = File.rm_rf!(work_dir)
     File.mkdir_p!(work_dir)


### PR DESCRIPTION
This shows a warning if trying to use `mix firmware.patch`. The docs
also have been updated to talk more generically about patches and leave
generation details to `fwup_delta`. Currently `fwup_delta` is so much
better than `mix firmware.patch` that anyone using it should switch.
