### PR TITLE
Use Bearer auth for GitHub API

### DIFF
--- a/guides/advanced/customizing-systems.md
+++ b/guides/advanced/customizing-systems.md
@@ -347,8 +347,8 @@ retrieve it in the `artifacts_sites` list of the `nerves_package` config.
 There are currently five different artifact site helpers:
 
 - `{:github_releases, "organization/repo"}`
-- `{:github_api, "organization/repo", username: "", token: "", tag: ""}`
-- `{:gitea_releases, "site/organization/repo}`
+- `{:github_api, "organization/repo", token: "", tag: ""}`
+- `{:gitea_releases, "site/organization/repo"}`
 - `{:gitea_api, "organization/repo", base_url: "https://gitea.com/", token: "", tag: ""}`
 - `{:prefix, "url", opts \\ []}`
 

--- a/guides/advanced/systems.md
+++ b/guides/advanced/systems.md
@@ -228,7 +228,7 @@ The following keys are supported:
 
     ```elixir
     {:github_releases, "organization/project"}
-    {:github_api, "organization/project", username: System.get_env("GITHUB_USER"), token: System.get_env("GITHUB_TOKEN"), tag: @version}
+    {:github_api, "organization/project", token: System.get_env("GITHUB_TOKEN"), tag: @version}
     {:prefix, "http://myserver.com/artifacts"}
     {:prefix, "file:///my_artifacts/"}
     {:prefix, "/users/my_user/artifacts/"}
@@ -241,10 +241,10 @@ The following keys are supported:
 
     For an artifact site that uses GitHub Releases in a private repo, [create a
     personal access token](https://help.github.com/en/articles/creating-a-personal-access-token-for-the-command-line)
-    and use `:github_api` with `username`, `token`, and `tag` options:
+    and use `:github_api` with `token` and `tag` options:
 
     ```elixir
-    {:github_api, "owner/repo", username: "skroob", token: "1234567", tag: "v0.1.0"}
+    {:github_api, "owner/repo", token: "1234567", tag: "v0.1.0"}
     ```
 
     Artifact sites can pass options as a third parameter for adding headers

--- a/lib/nerves/artifact.ex
+++ b/lib/nerves/artifact.ex
@@ -237,10 +237,10 @@ defmodule Nerves.Artifact do
   Artifact sites can pass options as a third parameter for adding headers
   or query string parameters. For example, if you are trying to resolve
   artifacts hosted in a private Github repo, use `:github_api` and
-  pass a user, tag, and personal access token into the sites helper:
+  pass a tag and personal access token into the sites helper:
 
   ```elixir
-  {:github_api, "owner/repo", username: "skroob", token: "1234567", tag: "v0.1.0"}
+  {:github_api, "owner/repo", token: "1234567", tag: "v0.1.0"}
   ```
 
   Or pass query parameters for the URL:
@@ -419,7 +419,7 @@ defmodule Nerves.Artifact do
 
       Supported artifact sites:
       {:github_releases, "owner/repo"}
-      {:github_api, "owner/repo", username: "skroob", token: "1234567", tag: "v0.1.0"}
+      {:github_api, "owner/repo", token: "1234567", tag: "v0.1.0"}
       {:gitea_releases, "host/owner/repo"},
       {:gitea_api, "owner/repo", base_url: "https://gitea.com", token: "123456", tag: "v0.1.0"}
       {:prefix, "http://myserver.com/artifacts"}

--- a/lib/nerves/artifact/resolvers/github_api.ex
+++ b/lib/nerves/artifact/resolvers/github_api.ex
@@ -22,8 +22,7 @@ defmodule Nerves.Artifact.Resolvers.GithubAPI do
             repo: nil,
             tag: "",
             token: "",
-            url: nil,
-            username: ""
+            url: nil
 
   @impl Nerves.Artifact.Resolver
   def get({org_proj, opts}, dest_path) do
@@ -40,13 +39,8 @@ defmodule Nerves.Artifact.Resolvers.GithubAPI do
       if opts.public? do
         []
       else
-        # make safe values here in case nil was supplied as an option
-        # The request will fail and error will be reported later on
-        user = opts.username || ""
         token = opts.token || ""
-
-        credentials = Base.encode64(user <> ":" <> token)
-        [{"Authorization", "Basic " <> credentials}]
+        [{"Authorization", "Bearer " <> token}]
       end
 
     %{

--- a/test/nerves/artifact/resolvers_github_api_test.exs
+++ b/test/nerves/artifact/resolvers_github_api_test.exs
@@ -130,6 +130,22 @@ defmodule Nerves.Artifact.Resolvers.GithubAPITest do
     assert :ok = GithubAPI.get({context.repo, context.opts}, @good_download_path)
   end
 
+  test "username is ignored for backward compatibility", context do
+    opts = Keyword.put(context.opts, :username, "old_basic_auth_username")
+
+    HTTPClient
+    |> expect(:get, fn _url, opts ->
+      [{"Authorization", "Bearer " <> req_token}] = opts[:headers]
+      assert req_token == context.opts[:token]
+      {:ok, @no_artifacts_response}
+    end)
+
+    reject(&HTTPClient.download/3)
+
+    assert {:error, "No release artifacts"} =
+             GithubAPI.get({context.repo, opts}, @invalid_download_path)
+  end
+
   test "GITHUB_TOKEN takes precedence", context do
     env_token = "look-at-me!"
     gh_token = "dont-look-at-me!"
@@ -138,8 +154,7 @@ defmodule Nerves.Artifact.Resolvers.GithubAPITest do
 
     HTTPClient
     |> expect(:get, fn _url, opts ->
-      [{"Authorization", "Basic " <> encoded}] = opts[:headers]
-      [_, req_token] = String.split(Base.decode64!(encoded), ":")
+      [{"Authorization", "Bearer " <> req_token}] = opts[:headers]
       assert req_token == env_token
       {:ok, @no_artifacts_response}
     end)
@@ -162,12 +177,7 @@ defmodule Nerves.Artifact.Resolvers.GithubAPITest do
 
     HTTPClient
     |> expect(:get, fn _url, opts ->
-      # A bit hacky since you need to know the internals, but this
-      # breaks apart the Authorization header that was created with
-      # the token given to the request and confirms it is the one
-      # we wanted
-      [{"Authorization", "Basic " <> encoded}] = opts[:headers]
-      [_, req_token] = String.split(Base.decode64!(encoded), ":")
+      [{"Authorization", "Bearer " <> req_token}] = opts[:headers]
       assert req_token == env_token
       {:ok, ""}
     end)

--- a/test/nerves/artifact_test.exs
+++ b/test/nerves/artifact_test.exs
@@ -107,6 +107,26 @@ defmodule Nerves.ArtifactTest do
     assert String.ends_with?(opts[:artifact_name], checksum_short <> Artifact.ext(pkg))
   end
 
+  test "GitHub API artifact sites are expanded" do
+    repo = "nerves-project/system"
+
+    pkg = %{
+      app: "my_system",
+      version: "1.0.0",
+      path: "./",
+      config: [
+        artifact_sites: [{:github_api, repo, token: "ghp_fake123", tag: "v1.0.0"}]
+      ]
+    }
+
+    checksum_short = Nerves.Artifact.checksum(pkg, short: 7)
+
+    [{GithubAPI, {^repo, opts}}] = Artifact.expand_sites(pkg)
+    assert opts[:token] == "ghp_fake123"
+    assert opts[:tag] == "v1.0.0"
+    assert String.ends_with?(opts[:artifact_name], checksum_short <> Artifact.ext(pkg))
+  end
+
   test "Gitea artifact sites are expanded" do
     repo = "gitea.com/jmshrtn/nerves_artifact_test"
 


### PR DESCRIPTION
This is a transparent change to users. Bearer auth doesn't need the
username, so it's ignored if users provide it.
