### PR TITLE
Simplify resolvers and switch to explicit 2-phase expansion

### DIFF
--- a/lib/nerves/artifact.ex
+++ b/lib/nerves/artifact.ex
@@ -15,6 +15,8 @@ defmodule Nerves.Artifact do
   alias Nerves.Artifact.Cache
   alias Nerves.Artifact.Resolvers
 
+  @resolver_modules [Resolvers.GithubAPI, Resolvers.GiteaAPI, Resolvers.URI]
+
   @checksum_short 7
 
   # credo:disable-for-next-line Credo.Check.Readability.Specs
@@ -255,9 +257,7 @@ defmodule Nerves.Artifact do
   {:prefix, "http://my-organization.com/", headers: [{"Authorization", "Basic " <> System.get_env("BASIC_AUTH")}}]}
   ```
   """
-  @spec expand_sites(Nerves.Package.t()) :: [
-          {Resolvers.URI | Resolvers.GithubAPI | Resolvers.GiteaAPI, {Path.t(), Keyword.t()}}
-        ]
+  @spec expand_sites(Nerves.Package.t()) :: [{module(), term()}]
   def expand_sites(pkg) do
     Keyword.get(pkg.config, :artifact_sites, [])
     |> Enum.map(&expand_site(&1, pkg))
@@ -354,65 +354,10 @@ defmodule Nerves.Artifact do
     |> Keyword.put_new(:path, File.cwd!())
   end
 
-  defp expand_site(_, _, _ \\ [])
+  defp expand_site(site, pkg) do
+    name = download_name(pkg) <> ext(pkg)
 
-  defp expand_site({:github_releases, org_proj}, pkg, opts) do
-    opts =
-      opts
-      |> Keyword.put(:artifact_name, download_name(pkg, opts) <> ext(pkg))
-      |> Keyword.put(:public?, true)
-      |> update_in([:tag], &(&1 || "v#{pkg.version}"))
-
-    {Resolvers.GithubAPI, {org_proj, opts}}
-  end
-
-  defp expand_site({:gitea_releases, repo_uri}, pkg, opts) when is_binary(repo_uri),
-    do: expand_site({:gitea_releases, URI.parse(repo_uri)}, pkg, opts)
-
-  defp expand_site({:gitea_releases, repo_uri}, pkg, opts)
-       when is_nil(repo_uri.scheme) and is_nil(repo_uri.host),
-       do: expand_site({:gitea_releases, URI.parse("https://#{repo_uri.path}")}, pkg, opts)
-
-  defp expand_site({:gitea_releases, repo_uri}, pkg, opts) do
-    repo_uri = URI.parse(repo_uri)
-    base_url = %{repo_uri | path: "/"} |> to_string()
-    org_proj = repo_uri.path |> String.trim_leading("/")
-
-    opts =
-      opts
-      |> Keyword.put(:base_url, base_url)
-      |> Keyword.put(:artifact_name, download_name(pkg, opts) <> ext(pkg))
-      |> Keyword.put(:public?, true)
-      |> update_in([:tag], &(&1 || "v#{pkg.version}"))
-
-    {Resolvers.GiteaAPI, {org_proj, opts}}
-  end
-
-  defp expand_site({:prefix, url}, pkg, opts) do
-    expand_site({:prefix, url, []}, pkg, opts)
-  end
-
-  defp expand_site({:prefix, path, resolver_opts}, pkg, opts) do
-    path = Path.join(path, download_name(pkg, opts) <> ext(pkg))
-    {Resolvers.URI, {path, resolver_opts}}
-  end
-
-  defp expand_site({:github_api, org_proj, resolver_opts}, pkg, opts) do
-    resolver_opts =
-      Keyword.put(resolver_opts, :artifact_name, download_name(pkg, opts) <> ext(pkg))
-
-    {Resolvers.GithubAPI, {org_proj, resolver_opts}}
-  end
-
-  defp expand_site({:gitea_api, org_proj, resolver_opts}, pkg, opts) do
-    resolver_opts =
-      Keyword.put(resolver_opts, :artifact_name, download_name(pkg, opts) <> ext(pkg))
-
-    {Resolvers.GiteaAPI, {org_proj, resolver_opts}}
-  end
-
-  defp expand_site(site, _pkg, _opts),
-    do:
+    Enum.find_value(@resolver_modules, fn mod -> mod.plan(site, pkg.version, name) end) ||
       Mix.raise("""
       Unsupported artifact site
       #{inspect(site)}
@@ -428,4 +373,5 @@ defmodule Nerves.Artifact do
       {:prefix, "file:///my_artifacts/"}
       {:prefix, "/users/my_user/artifacts/"}
       """)
+  end
 end

--- a/lib/nerves/artifact/resolver.ex
+++ b/lib/nerves/artifact/resolver.ex
@@ -7,7 +7,22 @@
 defmodule Nerves.Artifact.Resolver do
   @moduledoc false
 
-  @callback get(tuple(), Path.t()) :: :ok | {:error, term}
+  @doc """
+  Build a plan for downloading a package
+
+  This function should not make any HTTP requests.
+
+  Return `nil` if the implementing module can't handle the site spec.
+  """
+  @callback plan(tuple(), version :: String.t(), artifact_filename :: String.t()) ::
+              {module(), map()} | nil
+
+  @doc """
+  Download the package based on a previously returned plan
+
+  This function should download to the specified path.
+  """
+  @callback get(map(), Path.t()) :: :ok | {:error, term()}
 
   @spec get(list(), pkg :: Nerves.Package.t()) :: {:ok, path :: Path.t()} | {:error, term}
   def get([], _pkg) do
@@ -22,11 +37,11 @@ defmodule Nerves.Artifact.Resolver do
   defp do_get([], _pkg, nil), do: {:error, :no_result}
   defp do_get([], _pkg, reason), do: Mix.raise(reason)
 
-  defp do_get([{resolver, {id, resolver_opts}} | resolvers], pkg, raise_reason) do
+  defp do_get([{resolver, resolver_opts} | resolvers], pkg, raise_reason) do
     file = Nerves.Artifact.download_path(pkg)
     File.mkdir_p!(Nerves.Env.download_dir())
 
-    case resolver.get({id, resolver_opts}, file) do
+    case resolver.get(resolver_opts, file) do
       :ok ->
         validate_and_continue(file, resolvers, pkg)
 

--- a/lib/nerves/artifact/resolvers/gitea_api.ex
+++ b/lib/nerves/artifact/resolvers/gitea_api.ex
@@ -10,130 +10,130 @@ defmodule Nerves.Artifact.Resolvers.GiteaAPI do
   alias Nerves.Utils.HTTPClient
   alias Nerves.Utils.Shell
 
-  defstruct artifact_name: nil,
-            base_url: nil,
-            headers: [],
-            public?: false,
-            opts: [],
-            repo: nil,
-            tag: "",
-            token: "",
-            url: nil
+  defstruct [:org_repo_url, :api_url, :auth_token, :artifact_filename, :tag, :method]
 
   @impl Nerves.Artifact.Resolver
-  def get({repo, opts}, dest_path) do
-    opts =
-      %{struct(__MODULE__, opts) | opts: opts, repo: repo}
-      |> maybe_adjust_token()
-      |> add_http_opts()
-
-    fetch_artifact(dest_path, opts)
+  def plan({:gitea_releases, repo_uri}, version, artifact_filename) do
+    plan({:gitea_releases, repo_uri, []}, version, artifact_filename)
   end
 
-  defp add_http_opts(opts) do
-    headers =
-      if opts.public? do
-        []
-      else
-        # make safe values here in case nil was supplied as an option
-        # The request will fail and error will be reported later on
-        token = opts.token || ""
+  def plan({:gitea_api, org_repo, opts}, version, artifact_filename) do
+    base_url = Keyword.fetch!(opts, :base_url)
+    base_uri = base_url |> String.trim_trailing("/") |> uri_parse_with_default_scheme()
 
-        [{"Authorization", "token " <> token}]
-      end
-
-    %{
-      opts
-      | headers: headers,
-        url:
-          Path.join([
-            opts.base_url,
-            "api",
-            "v1",
-            "repos",
-            opts.repo,
-            "releases",
-            "tags",
-            opts.tag
-          ])
+    prepared = %__MODULE__{
+      org_repo_url: URI.append_path(base_uri, "/" <> org_repo),
+      api_url: URI.append_path(base_uri, "/api/v1/repos/" <> org_repo),
+      auth_token: get_auth_token(opts),
+      artifact_filename: artifact_filename,
+      tag: Keyword.get(opts, :tag, "v#{version}"),
+      method: :gitea_api
     }
+
+    {__MODULE__, prepared}
   end
 
-  defp maybe_adjust_token(opts) do
-    token = System.get_env("GITEA_TOKEN")
+  def plan({:gitea_releases, repo_uri, opts}, version, artifact_filename) do
+    prepared = %__MODULE__{
+      org_repo_url: uri_parse_with_default_scheme(repo_uri),
+      auth_token: get_auth_token(opts),
+      artifact_filename: artifact_filename,
+      tag: Keyword.get(opts, :tag, "v#{version}"),
+      method: :gitea_release
+    }
 
-    if token do
-      # Let the env var take precedence
-      %{opts | token: token}
-    else
-      opts
+    {__MODULE__, prepared}
+  end
+
+  def plan(_site, _version, _artifact_filename), do: nil
+
+  defp uri_parse_with_default_scheme(s) do
+    with %URI{scheme: nil} <- URI.parse(s) do
+      URI.parse("https://" <> s)
     end
   end
 
-  defp fetch_artifact(dest_path, opts) do
-    info = if System.get_env("NERVES_DEBUG") == "1", do: opts.url, else: opts.artifact_name
+  @impl Nerves.Artifact.Resolver
+  def get(%__MODULE__{} = opts, dest_path) do
+    auth_headers =
+      if opts.auth_token,
+        do: [{"Authorization", "token " <> opts.auth_token}],
+        else: []
+
+    info =
+      if System.get_env("NERVES_DEBUG") == "1",
+        do: "#{URI.to_string(opts.org_repo_url)} #{opts.tag}/#{opts.artifact_filename}",
+        else: opts.artifact_filename
 
     Shell.info(["  [Gitea] ", info])
 
-    with {:ok, assets_or_url} <- release_details(opts),
-         {:ok, asset_url} <- get_asset_url(assets_or_url, opts) do
-      http_opts = [headers: [{"Accept", "application/octet-stream"} | opts.headers]]
-
-      HTTPClient.download(asset_url, dest_path, http_opts)
-    end
-  end
-
-  defp release_details(opts) do
-    case HTTPClient.get_json(opts.url, headers: opts.headers) do
-      {:ok, _} = ok ->
-        ok
-
-      {:error, "Status 404 Not Found"} ->
-        invalid_token? = is_nil(opts.token) or opts.token == ""
-
-        msg =
-          if not opts.public? and invalid_token? do
-            """
-            Missing token
-
-                 For private releases, you must authenticate the request to fetch release assets.
-                 You can do this in a few ways:
-
-                   * export or set GITEA_TOKEN=<your-token>
-                   * set `token: <get-token-function>` for this Gitea repository in your Nerves system mix.exs
-            """
-          else
-            "No release"
-          end
-
-        {:error, msg}
+    case download(opts.method, opts, dest_path, auth_headers) do
+      :ok ->
+        :ok
 
       {:error, reason} ->
-        {:error, reason}
+        {:error,
+         """
+         Download failed: #{reason}
+
+         If this is a private repository, please check that you have a Gitea auth token.
+         Nerves checks the `GITEA_TOKEN` environment variable.
+         Alternatively, you can set `token:` in your Nerves system's `artifact_sites` specification.
+         `:gitea_releases` can work for private repositories when an auth token is provided.
+         If direct authenticated release downloads do not work for your Gitea setup, try
+         using `:gitea_api` instead.
+
+         This failure was specifically for downloading #{opts.artifact_filename}. Other
+         files could have been tried.
+
+         Check the release page for available artifacts:
+           "#{URI.to_string(opts.org_repo_url)}/releases/tag/#{opts.tag}"
+
+         Download method: #{opts.method}
+         """}
     end
   end
 
-  defp get_asset_url(url, _) when is_binary(url), do: {:ok, url}
+  defp download(:gitea_release, opts, dest_path, auth_headers) do
+    download_url =
+      URI.append_path(
+        opts.org_repo_url,
+        "/releases/download/#{opts.tag}/#{opts.artifact_filename}"
+      )
 
-  defp get_asset_url(%{"assets" => []}, _opts) do
-    {:error, "No release artifacts"}
+    HTTPClient.download(download_url, dest_path, headers: auth_headers)
   end
 
-  defp get_asset_url(%{"assets" => assets}, %{artifact_name: artifact_name}) do
-    ret =
-      Enum.find(assets, fn %{"name" => name} ->
-        String.equivalent?(artifact_name, name)
-      end)
+  defp download(:gitea_api, opts, dest_path, auth_headers) do
+    release_url = URI.append_path(opts.api_url, "/releases/tags/#{opts.tag}")
 
-    case ret do
-      nil ->
-        available = for %{"name" => name} <- assets, do: ["       * ", name, "\n"]
-        msg = ["No artifact with valid checksum\n\n     Found:\n", available]
+    with {:ok, release} <- HTTPClient.get_json(release_url, headers: auth_headers),
+         {:ok, download_url} <- find_asset_url(release, opts.artifact_filename) do
+      HTTPClient.download(download_url, dest_path, headers: auth_headers)
+    end
+  end
 
-        {:error, msg}
+  defp find_asset_url(%{"assets" => assets}, filename) do
+    case Enum.find(assets, fn a -> a["name"] == filename end) do
+      %{"browser_download_url" => url} -> {:ok, url}
+      nil -> {:error, "Asset '#{filename}' not found in release"}
+    end
+  end
 
-      %{"browser_download_url" => url} ->
-        {:ok, url}
+  defp find_asset_url(release, filename) do
+    {:error,
+     "Unexpected Gitea release response while looking for asset '#{filename}': " <>
+       "missing \"assets\" list in #{inspect(release)}"}
+  end
+
+  defp get_auth_token(opts) do
+    env_token = System.get_env("GITEA_TOKEN")
+    opts_token = opts[:token]
+
+    cond do
+      env_token != nil -> env_token
+      opts_token != nil -> opts_token
+      true -> nil
     end
   end
 end

--- a/lib/nerves/artifact/resolvers/github_api.ex
+++ b/lib/nerves/artifact/resolvers/github_api.ex
@@ -16,7 +16,8 @@ defmodule Nerves.Artifact.Resolvers.GithubAPI do
   @github_api_url "https://api.github.com"
 
   defstruct [
-    :github_url,
+    :api_url,
+    :web_url,
     :org_repo,
     :custom_auth_token,
     :artifact_filename,
@@ -27,10 +28,15 @@ defmodule Nerves.Artifact.Resolvers.GithubAPI do
 
   @impl Nerves.Artifact.Resolver
   def plan({:github_api, org_repo, opts}, version, artifact_filename) do
-    github_url = Keyword.get(opts, :github_url, @github_api_url) |> URI.parse()
+    {api_url, web_url} =
+      case Keyword.get(opts, :github_url) do
+        nil -> {URI.parse(@github_api_url), URI.parse(@github_url)}
+        custom -> {URI.parse(custom), nil}
+      end
 
     prepared = %__MODULE__{
-      github_url: github_url,
+      api_url: api_url,
+      web_url: web_url,
       org_repo: org_repo,
       custom_auth_token: opts[:token],
       artifact_filename: artifact_filename,
@@ -47,10 +53,15 @@ defmodule Nerves.Artifact.Resolvers.GithubAPI do
   end
 
   def plan({:github_releases, org_repo, opts}, version, artifact_filename) do
-    github_url = Keyword.get(opts, :github_url, @github_url) |> URI.parse()
+    {api_url, web_url} =
+      case Keyword.get(opts, :github_url) do
+        nil -> {URI.parse(@github_api_url), URI.parse(@github_url)}
+        custom -> {nil, URI.parse(custom)}
+      end
 
     prepared = %__MODULE__{
-      github_url: github_url,
+      api_url: api_url,
+      web_url: web_url,
       org_repo: org_repo,
       custom_auth_token: opts[:token],
       artifact_filename: artifact_filename,
@@ -87,6 +98,14 @@ defmodule Nerves.Artifact.Resolvers.GithubAPI do
       {:error, reason} ->
         elided_token = if auth_token, do: String.slice(auth_token, 0, 6) <> "...", else: "unset"
 
+        check_message =
+          if opts.web_url,
+            do: """
+            Check the release page for available artifacts:
+              #{URI.to_string(opts.web_url)}/#{opts.org_repo}/releases/tag/#{opts.tag}
+            """,
+            else: ""
+
         {:error,
          """
          Download failed: #{reason}
@@ -102,28 +121,40 @@ defmodule Nerves.Artifact.Resolvers.GithubAPI do
          This failure was specifically for downloading #{opts.artifact_filename}. Other
          files could have been tried.
 
-         Check the release page for available artifacts:
-           "#{opts.github_url}/#{opts.org_repo}/releases/tag/#{opts.tag}"
-
+         #{check_message}
          Download method: #{opts.method}
+         Web endpoint: #{safe_uri_to_string(opts.web_url)}
+         API endpoint: #{safe_uri_to_string(opts.api_url)}
+         Repository: #{opts.org_repo}
+         Release tag: #{opts.tag}
          GitHub auth token: #{elided_token}
          """}
     end
   end
 
+  defp safe_uri_to_string(nil), do: "nil"
+  defp safe_uri_to_string(uri), do: URI.to_string(uri)
+
   defp download(:github_release, opts, dest_path, auth_headers) do
     download_url =
       URI.append_path(
-        opts.github_url,
+        opts.web_url,
         "/#{opts.org_repo}/releases/download/#{opts.tag}/#{opts.artifact_filename}"
       )
 
-    HTTPClient.download(download_url, dest_path, headers: auth_headers)
+    result = HTTPClient.download(download_url, dest_path, headers: auth_headers)
+
+    if match?({:error, _}, result) and auth_headers != [] and opts.api_url != nil do
+      # Fall back to API if we have an auth token and know the API URL
+      download(:github_api, opts, dest_path, auth_headers)
+    else
+      result
+    end
   end
 
   defp download(:github_api, opts, dest_path, auth_headers) do
     release_url =
-      URI.append_path(opts.github_url, "/repos/#{opts.org_repo}/releases/tags/#{opts.tag}")
+      URI.append_path(opts.api_url, "/repos/#{opts.org_repo}/releases/tags/#{opts.tag}")
 
     with {:ok, release} <- HTTPClient.get_json(release_url, headers: auth_headers),
          {:ok, asset_api_url} <- find_asset_url(release, opts.artifact_filename) do

--- a/lib/nerves/artifact/resolvers/github_api.ex
+++ b/lib/nerves/artifact/resolvers/github_api.ex
@@ -12,134 +12,145 @@ defmodule Nerves.Artifact.Resolvers.GithubAPI do
   alias Nerves.Utils.HTTPClient
   alias Nerves.Utils.Shell
 
-  @base_url "https://api.github.com/"
+  @github_url "https://github.com"
+  @github_api_url "https://api.github.com"
 
-  defstruct artifact_name: nil,
-            base_url: @base_url,
-            headers: [],
-            public?: false,
-            opts: [],
-            repo: nil,
-            tag: "",
-            token: "",
-            url: nil
+  defstruct [
+    :github_url,
+    :org_repo,
+    :custom_auth_token,
+    :artifact_filename,
+    :tag,
+    :method,
+    :use_gh_cli?
+  ]
 
   @impl Nerves.Artifact.Resolver
-  def get({org_proj, opts}, dest_path) do
-    opts =
-      %{struct(__MODULE__, opts) | opts: opts, repo: org_proj}
-      |> maybe_adjust_token()
-      |> add_http_opts()
+  def plan({:github_api, org_repo, opts}, version, artifact_filename) do
+    github_url = Keyword.get(opts, :github_url, @github_api_url) |> URI.parse()
 
-    fetch_artifact(dest_path, opts)
-  end
-
-  defp add_http_opts(opts) do
-    headers =
-      if opts.public? do
-        []
-      else
-        token = opts.token || ""
-        [{"Authorization", "Bearer " <> token}]
-      end
-
-    %{
-      opts
-      | headers: headers,
-        url: Path.join([opts.base_url, "repos", opts.repo, "releases", "tags", opts.tag])
+    prepared = %__MODULE__{
+      github_url: github_url,
+      org_repo: org_repo,
+      custom_auth_token: opts[:token],
+      artifact_filename: artifact_filename,
+      tag: Keyword.get(opts, :tag, "v#{version}"),
+      method: :github_api,
+      use_gh_cli?: Keyword.get(opts, :use_gh_cli?, true)
     }
+
+    {__MODULE__, prepared}
   end
 
-  defp maybe_adjust_token(opts) do
-    token = System.get_env("GITHUB_TOKEN") || System.get_env("GH_TOKEN")
-
-    if token do
-      # Let the env var take precedence
-      %{opts | token: token}
-    else
-      opts
-    end
+  def plan({:github_releases, org_repo}, version, artifact_filename) do
+    plan({:github_releases, org_repo, []}, version, artifact_filename)
   end
 
-  defp fetch_artifact(dest_path, opts) do
-    info = if System.get_env("NERVES_DEBUG") == "1", do: opts.url, else: opts.artifact_name
+  def plan({:github_releases, org_repo, opts}, version, artifact_filename) do
+    github_url = Keyword.get(opts, :github_url, @github_url) |> URI.parse()
+
+    prepared = %__MODULE__{
+      github_url: github_url,
+      org_repo: org_repo,
+      custom_auth_token: opts[:token],
+      artifact_filename: artifact_filename,
+      tag: Keyword.get(opts, :tag, "v#{version}"),
+      method: :github_release,
+      use_gh_cli?: Keyword.get(opts, :use_gh_cli?, true)
+    }
+
+    {__MODULE__, prepared}
+  end
+
+  def plan(_site, _version, _artifact_filename), do: nil
+
+  @impl Nerves.Artifact.Resolver
+  def get(%__MODULE__{} = opts, dest_path) do
+    info =
+      if System.get_env("NERVES_DEBUG") == "1",
+        do: "#{opts.org_repo} #{opts.tag}/#{opts.artifact_filename}",
+        else: opts.artifact_filename
 
     Shell.info(["  [GitHub] ", info])
 
-    with {:ok, assets_or_url} <- release_details(opts),
-         {:ok, asset_url} <- get_asset_url(assets_or_url, opts) do
-      http_opts = [headers: [{"Accept", "application/octet-stream"} | opts.headers]]
+    auth_token = get_auth_token(opts)
 
-      HTTPClient.download(asset_url, dest_path, http_opts)
+    auth_headers =
+      if auth_token,
+        do: [{"Authorization", "Bearer " <> auth_token}],
+        else: []
+
+    case download(opts.method, opts, dest_path, auth_headers) do
+      :ok ->
+        :ok
+
+      {:error, reason} ->
+        elided_token = if auth_token, do: String.slice(auth_token, 0, 6) <> "...", else: "unset"
+
+        {:error,
+         """
+         Download failed: #{reason}
+
+         If this is a private repository or you're getting rate limited, please check
+         if you have a GitHub auth token. Nerves supports the `GITHUB_TOKEN` and `GH_TOKEN`
+         environment variables and can call the GitHub CLI to find it. Alternatively, you
+         can set a default strategy in your Nerves system's `artifact_sites` specification.
+         For private repositories, `:github_api` is the recommended strategy.
+         `:github_release` may work with authentication, but release downloads can still
+         fail depending on GitHub's access controls and behavior.
+
+         This failure was specifically for downloading #{opts.artifact_filename}. Other
+         files could have been tried.
+
+         Check the release page for available artifacts:
+           "#{opts.github_url}/#{opts.org_repo}/releases/tag/#{opts.tag}"
+
+         Download method: #{opts.method}
+         GitHub auth token: #{elided_token}
+         """}
     end
   end
 
-  defp release_details(opts) do
-    case HTTPClient.get_json(opts.url, headers: opts.headers) do
-      {:ok, _} = ok ->
-        ok
+  defp download(:github_release, opts, dest_path, auth_headers) do
+    download_url =
+      URI.append_path(
+        opts.github_url,
+        "/#{opts.org_repo}/releases/download/#{opts.tag}/#{opts.artifact_filename}"
+      )
 
-      {:error, "Status 403 rate limit exceeded"} when opts.public? ->
-        # Apparently this user has made too many public API requests from their IP
-        # so let's just fallback to the old way of fetching via a release download.
-        # If the release doesn't exist, we won't be able help provide hints about
-        # a checksum mismatch or bad name, but the tradeoff is worth it if the
-        # release actually does exist
-        {:ok,
-         "https://github.com/#{opts.repo}/releases/download/#{opts.tag}/#{opts.artifact_name}"}
+    HTTPClient.download(download_url, dest_path, headers: auth_headers)
+  end
 
-      {:error, "Status 404 Not Found"} ->
-        invalid_token? = is_nil(opts.token) or opts.token == ""
+  defp download(:github_api, opts, dest_path, auth_headers) do
+    release_url =
+      URI.append_path(opts.github_url, "/repos/#{opts.org_repo}/releases/tags/#{opts.tag}")
 
-        msg =
-          if not opts.public? and invalid_token? do
-            """
-            Missing token
-
-                 For private releases, you must authenticate the request to fetch release assets.
-                 You can do this in a few ways:
-
-                   * export or set GITHUB_TOKEN=<your-token>
-                   * set `token: <get-token-function>` for this GitHub repository in your Nerves system mix.exs
-            """
-          else
-            "No release"
-          end
-
-        {:error, msg}
-
-      result ->
-        result
+    with {:ok, release} <- HTTPClient.get_json(release_url, headers: auth_headers),
+         {:ok, asset_api_url} <- find_asset_url(release, opts.artifact_filename) do
+      download_headers = [{"Accept", "application/octet-stream"} | auth_headers]
+      HTTPClient.download(asset_api_url, dest_path, headers: download_headers)
     end
   end
 
-  defp get_asset_url(url, _opts) when is_binary(url), do: {:ok, url}
-
-  defp get_asset_url(%{"assets" => []}, _opts) do
-    {:error, "No release artifacts"}
-  end
-
-  defp get_asset_url(%{"assets" => assets}, %{artifact_name: artifact_name})
-       when is_list(assets) do
-    ret =
-      Enum.find(assets, fn %{"name" => name} ->
-        String.equivalent?(artifact_name, name)
-      end)
-
-    case ret do
-      nil ->
-        available = for %{"name" => name} <- assets, do: ["       * ", name, "\n"]
-        msg = ["No artifact with valid checksum\n\n     Found:\n", available]
-
-        {:error, msg}
-
-      %{"url" => url} ->
-        {:ok, url}
+  defp find_asset_url(%{"assets" => assets}, filename) do
+    case Enum.find(assets, fn a -> a["name"] == filename end) do
+      %{"url" => url} -> {:ok, url}
+      nil -> {:error, "Asset '#{filename}' not found in release"}
     end
   end
 
-  defp get_asset_url(response, _opts) do
-    truncated = inspect(response, limit: 10, printable_limit: 200)
-    {:error, "Unexpected API response when querying assets: #{truncated}"}
+  defp get_auth_token(opts) do
+    # Environment variables always override. gh is used last.
+    System.get_env("GITHUB_TOKEN") || System.get_env("GH_TOKEN") || opts.custom_auth_token ||
+      (opts.use_gh_cli? && gh_token())
+  end
+
+  defp gh_token() do
+    with gh when not is_nil(gh) <- System.find_executable("gh"),
+         {result, 0} <- System.cmd(gh, ["auth", "token"]) do
+      String.trim(result)
+    else
+      _err -> nil
+    end
   end
 end

--- a/lib/nerves/artifact/resolvers/uri.ex
+++ b/lib/nerves/artifact/resolvers/uri.ex
@@ -9,20 +9,35 @@ defmodule Nerves.Artifact.Resolvers.URI do
   """
   @behaviour Nerves.Artifact.Resolver
 
-  @doc """
-  Download the artifact from an http location
-  """
   @impl Nerves.Artifact.Resolver
-  def get({location, opts}, dest_path) do
-    Nerves.Utils.Shell.info("  => Trying #{location}")
+  def plan({:prefix, url}, version, artifact_filename) do
+    plan({:prefix, url, []}, version, artifact_filename)
+  end
 
-    {query_params, opts} = Keyword.pop(opts, :query_params, %{})
+  def plan({:prefix, url, opts}, _version, artifact_filename) do
+    base_uri = URI.parse(url) |> URI.append_path("/#{artifact_filename}")
 
     uri =
-      location
-      |> URI.parse()
-      |> Map.put(:query, URI.encode_query(query_params))
+      case Keyword.get(opts, :query_params) do
+        nil -> base_uri
+        "" -> base_uri
+        query_params -> URI.append_query(base_uri, URI.encode_query(query_params))
+      end
 
-    Nerves.Utils.HTTPClient.download(uri, dest_path, opts)
+    headers = Keyword.get(opts, :headers, [])
+
+    {__MODULE__, %{uri: uri, headers: headers}}
+  end
+
+  def plan(_site, _version, _artifact_filename), do: nil
+
+  defp uri_log_target(%URI{host: host}) when is_binary(host) and host != "", do: host
+  defp uri_log_target(%URI{} = uri), do: URI.to_string(uri)
+
+  @impl Nerves.Artifact.Resolver
+  def get(opts, dest_path) do
+    Nerves.Utils.Shell.info("  => Trying #{uri_log_target(opts.uri)}")
+
+    Nerves.Utils.HTTPClient.download(opts.uri, dest_path, headers: opts.headers)
   end
 end

--- a/test/nerves/artifact/plan_test.exs
+++ b/test/nerves/artifact/plan_test.exs
@@ -1,0 +1,200 @@
+# SPDX-FileCopyrightText: 2026 Frank Hunleth
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+defmodule Nerves.Artifact.PlanTest do
+  use ExUnit.Case
+
+  alias Nerves.Artifact
+  alias Nerves.Artifact.Resolvers.GiteaAPI
+  alias Nerves.Artifact.Resolvers.GithubAPI
+  alias Nerves.Artifact.Resolvers.URI, as: URIResolver
+
+  @version "1.0.0"
+
+  @pkg %{
+    app: "my_system",
+    version: @version,
+    type: :system,
+    path: "./",
+    config: []
+  }
+
+  @artifact_filename "my_system-portable-#{@version}-AABBCCDD.tar.gz"
+
+  setup do
+    System.delete_env("GITHUB_TOKEN")
+    System.delete_env("GH_TOKEN")
+    System.delete_env("GITEA_TOKEN")
+    :ok
+  end
+
+  describe "GithubAPI.plan/3" do
+    test "github_releases defaults to public with version tag" do
+      {GithubAPI, %GithubAPI{} = opts} =
+        GithubAPI.plan({:github_releases, "org/repo"}, @version, @artifact_filename)
+
+      assert opts.tag == "v1.0.0"
+      assert opts.org_repo == "org/repo"
+      assert opts.web_url == URI.parse("https://github.com")
+      assert opts.artifact_filename == @artifact_filename
+    end
+
+    test "github_releases with custom tag" do
+      {GithubAPI, %GithubAPI{} = opts} =
+        GithubAPI.plan(
+          {:github_releases, "org/repo", tag: "custom"},
+          @version,
+          @artifact_filename
+        )
+
+      assert opts.tag == "custom"
+    end
+
+    test "github_api sets auth token from explicit token" do
+      {GithubAPI, %GithubAPI{} = opts} =
+        GithubAPI.plan(
+          {:github_api, "org/repo", token: "ghp_secret"},
+          @version,
+          @artifact_filename
+        )
+
+      assert opts.custom_auth_token == "ghp_secret"
+    end
+
+    test "artifact name includes checksum" do
+      checksum_short = Artifact.checksum(@pkg, short: 7)
+      artifact_name = Artifact.download_name(@pkg) <> Artifact.ext(@pkg)
+
+      {GithubAPI, %GithubAPI{} = opts} =
+        GithubAPI.plan({:github_releases, "org/repo"}, @version, artifact_name)
+
+      assert String.contains?(opts.artifact_filename, checksum_short)
+    end
+
+    test "unsupported site returns nil" do
+      assert nil == GithubAPI.plan({:prefix, "https://example.com"}, @version, @artifact_filename)
+    end
+  end
+
+  describe "GiteaAPI.plan/3" do
+    test "gitea_releases parses full URL" do
+      {GiteaAPI, %GiteaAPI{} = opts} =
+        GiteaAPI.plan(
+          {:gitea_releases, "https://gitea.example.com/org/repo"},
+          @version,
+          @artifact_filename
+        )
+
+      assert opts.tag == "v1.0.0"
+      assert opts.org_repo_url == URI.parse("https://gitea.example.com/org/repo")
+    end
+
+    test "gitea_releases parses bare host/org/repo" do
+      {GiteaAPI, %GiteaAPI{} = opts} =
+        GiteaAPI.plan(
+          {:gitea_releases, "gitea.example.com/org/repo"},
+          @version,
+          @artifact_filename
+        )
+
+      assert opts.org_repo_url == URI.parse("https://gitea.example.com/org/repo")
+    end
+
+    test "gitea_api sets token auth" do
+      {GiteaAPI, %GiteaAPI{} = opts} =
+        GiteaAPI.plan(
+          {:gitea_api, "org/repo", base_url: "https://git.co/", token: "gitea_secret"},
+          @version,
+          @artifact_filename
+        )
+
+      assert opts.auth_token == "gitea_secret"
+    end
+
+    test "GITEA_TOKEN from env" do
+      System.put_env("GITEA_TOKEN", "env_gitea")
+
+      {GiteaAPI, %GiteaAPI{} = opts} =
+        GiteaAPI.plan(
+          {:gitea_releases, "gitea.example.com/org/repo"},
+          @version,
+          @artifact_filename
+        )
+
+      assert opts.auth_token == "env_gitea"
+    end
+
+    test "artifact name includes checksum" do
+      checksum_short = Artifact.checksum(@pkg, short: 7)
+      artifact_name = Artifact.download_name(@pkg) <> Artifact.ext(@pkg)
+
+      {GiteaAPI, %GiteaAPI{} = opts} =
+        GiteaAPI.plan(
+          {:gitea_releases, "gitea.example.com/org/repo"},
+          @version,
+          artifact_name
+        )
+
+      assert String.contains?(opts.artifact_filename, checksum_short)
+    end
+
+    test "unsupported site returns nil" do
+      assert nil ==
+               GiteaAPI.plan({:github_releases, "org/repo"}, @version, @artifact_filename)
+    end
+  end
+
+  describe "URIResolver.plan/3" do
+    test "prefix builds full path" do
+      {URIResolver, %{uri: uri, headers: []}} =
+        URIResolver.plan({:prefix, "https://dl.example.com"}, @version, @artifact_filename)
+
+      uri_string = URI.to_string(uri)
+      assert String.starts_with?(uri_string, "https://dl.example.com/")
+      assert String.contains?(uri_string, @artifact_filename)
+    end
+
+    test "prefix passes resolver opts through" do
+      {URIResolver, %{uri: uri}} =
+        URIResolver.plan(
+          {:prefix, "https://dl.example.com", query_params: %{"id" => "123"}},
+          @version,
+          @artifact_filename
+        )
+
+      assert URI.to_string(uri) =~ "id=123"
+    end
+
+    test "unsupported site returns nil" do
+      assert nil ==
+               URIResolver.plan({:github_releases, "org/repo"}, @version, @artifact_filename)
+    end
+  end
+
+  describe "Artifact.expand_sites/1 integration" do
+    test "github_releases goes through plan" do
+      pkg = %{@pkg | config: [artifact_sites: [{:github_releases, "org/repo"}]]}
+
+      [{GithubAPI, %GithubAPI{} = opts}] = Artifact.expand_sites(pkg)
+      assert opts.org_repo == "org/repo"
+      assert opts.tag == "v1.0.0"
+    end
+
+    test "gitea_releases goes through plan" do
+      pkg = %{@pkg | config: [artifact_sites: [{:gitea_releases, "gitea.co/org/repo"}]]}
+
+      [{GiteaAPI, %GiteaAPI{} = opts}] = Artifact.expand_sites(pkg)
+      assert opts.org_repo_url == URI.parse("https://gitea.co/org/repo")
+    end
+
+    test "prefix goes through plan" do
+      pkg = %{@pkg | config: [artifact_sites: [{:prefix, "https://dl.example.com"}]]}
+
+      [{URIResolver, opts}] = Artifact.expand_sites(pkg)
+
+      assert opts.uri ==
+               URI.parse("https://dl.example.com/my_system-portable-1.0.0-E3B0C44.tar.gz")
+    end
+  end
+end

--- a/test/nerves/artifact/resolvers_gitea_api_test.exs
+++ b/test/nerves/artifact/resolvers_gitea_api_test.exs
@@ -13,147 +13,208 @@ defmodule Nerves.Artifact.Resolvers.GiteaAPITest do
   @invalid_download_path "/should_not_work.tgz"
   @good_download_path "good_path.tar.gz"
 
-  @no_artifacts_response %{"assets" => []}
+  @org_repo "jmshrtn/nerves_artifact_test"
+  @artifact_filename "nerves_system_rpi-portable-1.0.0-1234567.tar.gz"
+  @version "1.0.0"
+  @release_tag "v1.0.0"
+  @base_url "https://gitea.com/"
+  @release_api_url "https://gitea.com/api/v1/repos/#{@org_repo}/releases/tags/#{@release_tag}"
+  @release_download_url "#{@base_url}#{@org_repo}/releases/download/#{@release_tag}/#{@artifact_filename}"
 
   setup do
     # Clean up any environment settings that affect tests. This should never
     # be specified by the user for any testing so there's no need to save and
     # restore the values.
     System.delete_env("GITEA_TOKEN")
-
-    %{
-      repo: "jmshrtn/nerves_artifact_test",
-      opts: [
-        base_url: "https://gitea.com",
-        artifact_name: "nerves_system_rpi-portable-1.0.0-1234567.tar.gz",
-        tag: "v1.0.0",
-        token: "1234"
-      ]
-    }
+    :ok
   end
 
-  test "public release not found", context do
-    HTTPClient |> expect(:get_json, fn _url, _opts -> {:error, "Status 404 Not Found"} end)
+  defp plan(opts \\ []) do
+    {site, opts} = Keyword.pop(opts, :site, :gitea_releases)
 
-    opts =
-      context.opts
-      |> Keyword.put(:public?, true)
-      |> Keyword.delete(:token)
+    case site do
+      :gitea_releases ->
+        uri = "#{@base_url}#{@org_repo}"
 
-    assert GiteaAPI.get({context.repo, opts}, @invalid_download_path) == {:error, "No release"}
+        {GiteaAPI, prepared} =
+          GiteaAPI.plan({:gitea_releases, uri, opts}, @version, @artifact_filename)
+
+        prepared
+
+      :gitea_api ->
+        opts = Keyword.put_new(opts, :base_url, @base_url)
+
+        {GiteaAPI, prepared} =
+          GiteaAPI.plan({:gitea_api, @org_repo, opts}, @version, @artifact_filename)
+
+        prepared
+    end
   end
 
-  test "private release not found", context do
-    HTTPClient |> expect(:get_json, fn _url, _opts -> {:error, "Status 404 Not Found"} end)
+  defp release_json(assets \\ nil) do
+    assets =
+      assets ||
+        [%{"name" => @artifact_filename, "browser_download_url" => @release_download_url}]
 
-    assert GiteaAPI.get({context.repo, context.opts}, @invalid_download_path) ==
-             {:error, "No release"}
+    %{"tag_name" => @release_tag, "assets" => assets}
   end
 
-  test "private release fails without token", context do
-    HTTPClient |> expect(:get_json, fn _url, _opts -> {:error, "Status 404 Not Found"} end)
-
-    opts = Keyword.delete(context.opts, :token)
-
-    assert {:error, msg} = GiteaAPI.get({context.repo, opts}, @invalid_download_path)
-
-    assert msg == """
-           Missing token
-
-                For private releases, you must authenticate the request to fetch release assets.
-                You can do this in a few ways:
-
-                  * export or set GITEA_TOKEN=<your-token>
-                  * set `token: <get-token-function>` for this Gitea repository in your Nerves system mix.exs
-           """
-  end
-
-  test "private release fails with nil token", context do
-    HTTPClient |> expect(:get_json, fn _url, _opts -> {:error, "Status 404 Not Found"} end)
-
-    opts = Keyword.put(context.opts, :token, nil)
-
-    assert {:error, msg} = GiteaAPI.get({context.repo, opts}, @invalid_download_path)
-
-    assert msg == """
-           Missing token
-
-                For private releases, you must authenticate the request to fetch release assets.
-                You can do this in a few ways:
-
-                  * export or set GITEA_TOKEN=<your-token>
-                  * set `token: <get-token-function>` for this Gitea repository in your Nerves system mix.exs
-           """
-  end
-
-  test "mismatched checksum", context do
-    details = %{"assets" => [%{"name" => "howdy.tar.xz"}]}
-    HTTPClient |> expect(:get_json, fn _url, _opts -> {:ok, details} end)
-    reject(&HTTPClient.download/3)
-
-    assert {:error, msg} = GiteaAPI.get({context.repo, context.opts}, @invalid_download_path)
-
-    assert msg == [
-             "No artifact with valid checksum\n\n     Found:\n",
-             [["       * ", "howdy.tar.xz", "\n"]]
-           ]
-  end
-
-  test "no artifacts in release", context do
-    HTTPClient |> expect(:get_json, fn _url, _opts -> {:ok, @no_artifacts_response} end)
-    reject(&HTTPClient.download/3)
-
-    assert {:error, "No release artifacts"} =
-             GiteaAPI.get({context.repo, context.opts}, @invalid_download_path)
-  end
-
-  test "valid artifact", context do
-    artifact_url = "http://example.com"
-
-    details = %{
-      "assets" => [
-        %{
-          "name" => context.opts[:artifact_name],
-          "browser_download_url" => artifact_url
-        }
-      ]
-    }
-
-    expected_details_url =
-      "https://gitea.com/api/v1/repos/#{context.repo}/releases/tags/#{context.opts[:tag]}"
+  test "public release not found" do
+    prepared = plan()
 
     HTTPClient
-    |> expect(:get_json, fn url, _opts ->
-      assert url == expected_details_url
-      {:ok, details}
+    |> expect(:download, fn _url, _path, _opts -> {:error, "Status 404 Not Found"} end)
+
+    assert {:error, msg} = GiteaAPI.get(prepared, @invalid_download_path)
+    assert msg =~ "Download failed"
+    assert msg =~ "#{@org_repo}/releases/tag/#{@release_tag}"
+  end
+
+  test "private release not found" do
+    prepared = plan(token: "1234")
+
+    HTTPClient
+    |> expect(:download, fn _url, _path, _opts -> {:error, "Status 404 Not Found"} end)
+
+    assert {:error, msg} = GiteaAPI.get(prepared, @invalid_download_path)
+    assert msg =~ "Download failed"
+    assert msg =~ "#{@org_repo}/releases/tag/#{@release_tag}"
+  end
+
+  test "private release fails without token" do
+    prepared = %GiteaAPI{
+      org_repo_url: URI.parse("#{@base_url}/#{@org_repo}"),
+      auth_token: nil,
+      artifact_filename: @artifact_filename,
+      tag: @release_tag,
+      method: :gitea_release
+    }
+
+    HTTPClient
+    |> expect(:download, fn _url, _path, _opts -> {:error, "Status 404 Not Found"} end)
+
+    assert {:error, msg} = GiteaAPI.get(prepared, @invalid_download_path)
+    assert msg =~ "Download failed"
+    assert msg =~ "GITEA_TOKEN"
+    assert msg =~ "#{@org_repo}/releases/tag/#{@release_tag}"
+  end
+
+  test "private release fails with nil token" do
+    prepared = %GiteaAPI{
+      org_repo_url: URI.parse("#{@base_url}/#{@org_repo}"),
+      auth_token: nil,
+      artifact_filename: @artifact_filename,
+      tag: @release_tag,
+      method: :gitea_release
+    }
+
+    HTTPClient
+    |> expect(:download, fn _url, _path, _opts -> {:error, "Status 404 Not Found"} end)
+
+    assert {:error, msg} = GiteaAPI.get(prepared, @invalid_download_path)
+    assert msg =~ "Download failed"
+    assert msg =~ "#{@org_repo}/releases/tag/#{@release_tag}"
+  end
+
+  test "mismatched checksum" do
+    prepared = plan(site: :gitea_api, token: "1234")
+
+    HTTPClient
+    |> expect(:get_json, fn _url, _opts ->
+      {:ok,
+       release_json([
+         %{
+           "name" => "wrong_filename.tar.gz",
+           "browser_download_url" => "https://example.com/wrong.tar.gz"
+         }
+       ])}
     end)
-    |> expect(:download, 1, fn url, path, _opts ->
-      assert url == artifact_url
+
+    assert {:error, msg} = GiteaAPI.get(prepared, @invalid_download_path)
+    assert msg =~ "Asset '#{@artifact_filename}' not found in release"
+  end
+
+  test "no artifacts in release" do
+    prepared = plan(site: :gitea_api, token: "1234")
+
+    HTTPClient
+    |> expect(:get_json, fn _url, _opts ->
+      {:ok, release_json([])}
+    end)
+
+    assert {:error, msg} = GiteaAPI.get(prepared, @invalid_download_path)
+    assert msg =~ "Asset '#{@artifact_filename}' not found in release"
+  end
+
+  test "valid artifact" do
+    prepared = plan(token: "1234")
+
+    expected_url =
+      URI.parse(
+        "#{@base_url}#{@org_repo}/releases/download/#{@release_tag}/#{@artifact_filename}"
+      )
+
+    HTTPClient
+    |> expect(:download, 1, fn url, path, opts ->
+      assert url == expected_url
       assert path == @good_download_path
+      assert [{"Authorization", "token 1234"}] = opts[:headers]
       :ok
     end)
 
-    assert :ok = GiteaAPI.get({context.repo, context.opts}, @good_download_path)
+    assert :ok = GiteaAPI.get(prepared, @good_download_path)
   end
 
-  test "GITEA_TOKEN takes precedence", context do
+  test "GITEA_TOKEN takes precedence" do
     env_token = "look-at-me!"
-    gitea_token = "dont-look-at-me!"
-    refute context.opts[:token] == env_token
-    refute context.opts[:token] == gitea_token
-
-    HTTPClient
-    |> expect(:get_json, fn _url, opts ->
-      [{"Authorization", "token " <> req_token}] = opts[:headers]
-      assert req_token == env_token
-      {:ok, @no_artifacts_response}
-    end)
 
     System.put_env("GITEA_TOKEN", env_token)
 
-    {:error, "No release artifacts"} =
-      GiteaAPI.get({context.repo, context.opts}, @invalid_download_path)
+    prepared = plan(token: "dont-look-at-me!")
 
-    System.delete_env("GITEA_TOKEN")
+    HTTPClient
+    |> expect(:download, 1, fn _url, _path, opts ->
+      assert [{"Authorization", "token " <> ^env_token}] = opts[:headers]
+      :ok
+    end)
+
+    assert :ok = GiteaAPI.get(prepared, @good_download_path)
+  end
+
+  test "gitea_release with token uses direct download" do
+    prepared = plan(token: "1234")
+
+    expected_url =
+      URI.parse(
+        "#{@base_url}#{@org_repo}/releases/download/#{@release_tag}/#{@artifact_filename}"
+      )
+
+    HTTPClient
+    |> stub(:get_json, fn _, _ -> flunk("get_json should not be called for :gitea_release") end)
+    |> expect(:download, fn url, _path, opts ->
+      assert url == expected_url
+      assert [{"Authorization", "token 1234"}] = opts[:headers]
+      :ok
+    end)
+
+    assert :ok = GiteaAPI.get(prepared, @good_download_path)
+  end
+
+  test "gitea_api uses API to find asset" do
+    prepared = plan(site: :gitea_api, token: "1234")
+
+    HTTPClient
+    |> expect(:get_json, fn url, opts ->
+      assert URI.to_string(url) == @release_api_url
+      assert [{"Authorization", "token 1234"}] = opts[:headers]
+      {:ok, release_json()}
+    end)
+    |> expect(:download, fn url, _path, opts ->
+      assert url == @release_download_url
+      assert [{"Authorization", "token 1234"}] = opts[:headers]
+      :ok
+    end)
+
+    assert :ok = GiteaAPI.get(prepared, @good_download_path)
   end
 end

--- a/test/nerves/artifact/resolvers_github_api_test.exs
+++ b/test/nerves/artifact/resolvers_github_api_test.exs
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 defmodule Nerves.Artifact.Resolvers.GithubAPITest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case
   use Mimic
 
   alias Nerves.Artifact.Resolvers.GithubAPI
@@ -13,7 +13,14 @@ defmodule Nerves.Artifact.Resolvers.GithubAPITest do
   @invalid_download_path "/should_not_work.tgz"
   @good_download_path "good_path.tar.gz"
 
-  @no_artifacts_response %{"assets" => []}
+  @org_repo "nerves-project/nerves_system_rpi4"
+  @artifact_filename "nerves_system_rpi-portable-1.0.0-1234567.tar.gz"
+  @version "1.0.0"
+  @release_tag "v1.0.0"
+
+  @release_api_url "https://api.github.com/repos/#{@org_repo}/releases/tags/#{@release_tag}"
+  @asset_api_url "https://api.github.com/repos/#{@org_repo}/releases/assets/12345"
+  @release_download_url "https://github.com/#{@org_repo}/releases/download/#{@release_tag}/#{@artifact_filename}"
 
   setup do
     # Clean up any environment settings that affect tests. These should never
@@ -22,210 +29,302 @@ defmodule Nerves.Artifact.Resolvers.GithubAPITest do
     System.delete_env("GITHUB_TOKEN")
     System.delete_env("GH_TOKEN")
 
-    %{
-      repo: "nerves-project/nerves_system_rpi4",
-      opts: [
-        artifact_name: "nerves_system_rpi-portable-1.0.0-1234567.tar.gz",
-        tag: "v1.0.0",
-        token: "1234"
-      ]
-    }
+    :ok
   end
 
-  test "public release not found", context do
-    HTTPClient |> expect(:get_json, fn _url, _opts -> {:error, "Status 404 Not Found"} end)
+  defp plan(opts \\ []) do
+    {site, opts} = Keyword.pop(opts, :method, :github_releases)
+    opts = Keyword.put_new(opts, :use_gh_cli?, false)
 
-    opts =
-      context.opts
-      |> Keyword.put(:public?, true)
-      |> Keyword.delete(:token)
+    {GithubAPI, prepared} =
+      GithubAPI.plan({site, @org_repo, opts}, @version, @artifact_filename)
 
-    assert GithubAPI.get({context.repo, opts}, @invalid_download_path) == {:error, "No release"}
+    prepared
   end
 
-  test "private release not found", context do
-    HTTPClient |> expect(:get_json, fn _url, _opts -> {:error, "Status 404 Not Found"} end)
-
-    assert GithubAPI.get({context.repo, context.opts}, @invalid_download_path) ==
-             {:error, "No release"}
+  defp release_json(assets \\ nil) do
+    assets = assets || [%{"name" => @artifact_filename, "url" => @asset_api_url}]
+    %{"tag_name" => @release_tag, "assets" => assets}
   end
 
-  test "private release fails without token", context do
-    HTTPClient |> expect(:get_json, fn _url, _opts -> {:error, "Status 404 Not Found"} end)
+  # --- No token: uses direct web URL ---
 
-    opts = Keyword.delete(context.opts, :token)
-
-    assert {:error, msg} = GithubAPI.get({context.repo, opts}, @invalid_download_path)
-
-    assert msg == """
-           Missing token
-
-                For private releases, you must authenticate the request to fetch release assets.
-                You can do this in a few ways:
-
-                  * export or set GITHUB_TOKEN=<your-token>
-                  * set `token: <get-token-function>` for this GitHub repository in your Nerves system mix.exs
-           """
-  end
-
-  test "private release fails with nil token", context do
-    HTTPClient |> expect(:get_json, fn _url, _opts -> {:error, "Status 404 Not Found"} end)
-
-    opts = Keyword.put(context.opts, :token, nil)
-
-    assert {:error, msg} = GithubAPI.get({context.repo, opts}, @invalid_download_path)
-
-    assert msg == """
-           Missing token
-
-                For private releases, you must authenticate the request to fetch release assets.
-                You can do this in a few ways:
-
-                  * export or set GITHUB_TOKEN=<your-token>
-                  * set `token: <get-token-function>` for this GitHub repository in your Nerves system mix.exs
-           """
-  end
-
-  test "mismatched checksum", context do
-    details = %{"assets" => [%{"name" => "howdy.tar.xz"}]}
-    HTTPClient |> expect(:get_json, fn _url, _opts -> {:ok, details} end)
-    reject(&HTTPClient.download/3)
-
-    assert {:error, msg} = GithubAPI.get({context.repo, context.opts}, @invalid_download_path)
-
-    assert msg == [
-             "No artifact with valid checksum\n\n     Found:\n",
-             [["       * ", "howdy.tar.xz", "\n"]]
-           ]
-  end
-
-  test "no artifacts in release", context do
-    HTTPClient |> expect(:get_json, fn _url, _opts -> {:ok, @no_artifacts_response} end)
-    reject(&HTTPClient.download/3)
-
-    assert {:error, "No release artifacts"} =
-             GithubAPI.get({context.repo, context.opts}, @invalid_download_path)
-  end
-
-  test "valid artifact", context do
-    artifact_url = "http://example.com"
-
-    details = %{
-      "assets" => [%{"name" => context.opts[:artifact_name], "url" => artifact_url}]
-    }
-
-    expected_details_url =
-      "https://api.github.com/repos/#{context.repo}/releases/tags/#{context.opts[:tag]}"
+  test "public release not found" do
+    prepared = plan()
 
     HTTPClient
-    |> expect(:get_json, fn url, _opts ->
-      assert url == expected_details_url
-      {:ok, details}
+    |> expect(:download, fn _url, _path, _opts -> {:error, "Status 404 Not Found"} end)
+
+    assert {:error, msg} = GithubAPI.get(prepared, @invalid_download_path)
+    assert msg =~ "Download failed"
+    assert msg =~ "#{@org_repo}/releases/tag/#{@release_tag}"
+  end
+
+  test "private release fails without token" do
+    prepared = %GithubAPI{
+      github_url: URI.parse("https://github.com"),
+      org_repo: @org_repo,
+      custom_auth_token: nil,
+      artifact_filename: @artifact_filename,
+      tag: @release_tag,
+      method: :github_release
+    }
+
+    HTTPClient
+    |> expect(:download, fn _url, _path, _opts -> {:error, "Status 404 Not Found"} end)
+
+    assert {:error, msg} = GithubAPI.get(prepared, @invalid_download_path)
+    assert msg =~ "Download failed"
+    assert msg =~ "#{@org_repo}/releases/tag/#{@release_tag}"
+  end
+
+  test "private release fails with nil token" do
+    prepared = %GithubAPI{
+      github_url: URI.parse("https://github.com"),
+      org_repo: @org_repo,
+      custom_auth_token: nil,
+      artifact_filename: @artifact_filename,
+      tag: @release_tag,
+      method: :github_release
+    }
+
+    HTTPClient
+    |> expect(:download, fn _url, _path, _opts -> {:error, "Status 404 Not Found"} end)
+
+    assert {:error, msg} = GithubAPI.get(prepared, @invalid_download_path)
+    assert msg =~ "Download failed"
+    assert msg =~ "#{@org_repo}/releases/tag/#{@release_tag}"
+  end
+
+  # --- With token: uses GitHub API ---
+
+  test "release API returns 404" do
+    prepared = plan(method: :github_api, token: "1234")
+
+    HTTPClient
+    |> expect(:get_json, fn url, opts ->
+      assert URI.to_string(url) == @release_api_url
+      assert {"Authorization", "Bearer 1234"} in opts[:headers]
+      {:error, "Status 404 Not Found"}
     end)
-    |> expect(:download, 1, fn url, path, _opts ->
-      assert url == artifact_url
+
+    assert {:error, msg} = GithubAPI.get(prepared, @invalid_download_path)
+    assert msg =~ "Download failed"
+    assert msg =~ "#{@org_repo}/releases/tag/#{@release_tag}"
+  end
+
+  test "asset not found in release" do
+    prepared = plan(method: :github_api, token: "1234")
+
+    HTTPClient
+    |> expect(:get_json, fn _url, _opts ->
+      {:ok, release_json([%{"name" => "wrong_filename.tar.gz", "url" => @asset_api_url}])}
+    end)
+
+    assert {:error, msg} = GithubAPI.get(prepared, @invalid_download_path)
+    assert msg =~ "Asset '#{@artifact_filename}' not found in release"
+  end
+
+  test "no artifacts in release" do
+    prepared = plan(method: :github_api, token: "1234")
+
+    HTTPClient
+    |> expect(:get_json, fn _url, _opts ->
+      {:ok, release_json([])}
+    end)
+
+    assert {:error, msg} = GithubAPI.get(prepared, @invalid_download_path)
+    assert msg =~ "Asset '#{@artifact_filename}' not found in release"
+  end
+
+  test "asset download fails" do
+    prepared = plan(method: :github_api, token: "1234")
+
+    HTTPClient
+    |> expect(:get_json, fn _url, _opts -> {:ok, release_json()} end)
+    |> expect(:download, fn _url, _path, _opts -> {:error, "Status 500 Internal Server Error"} end)
+
+    assert {:error, msg} = GithubAPI.get(prepared, @invalid_download_path)
+    assert msg =~ "Download failed"
+  end
+
+  test "valid artifact via API" do
+    prepared = plan(method: :github_api, token: "1234")
+
+    HTTPClient
+    |> expect(:get_json, fn url, opts ->
+      assert URI.to_string(url) == @release_api_url
+      assert {"Authorization", "Bearer 1234"} in opts[:headers]
+      {:ok, release_json()}
+    end)
+    |> expect(:download, fn url, path, opts ->
+      assert url == @asset_api_url
       assert path == @good_download_path
+      assert {"Accept", "application/octet-stream"} in opts[:headers]
+      assert {"Authorization", "Bearer 1234"} in opts[:headers]
       :ok
     end)
 
-    assert :ok = GithubAPI.get({context.repo, context.opts}, @good_download_path)
+    assert :ok = GithubAPI.get(prepared, @good_download_path)
   end
 
-  test "username is ignored for backward compatibility", context do
-    opts = Keyword.put(context.opts, :username, "old_basic_auth_username")
+  test "username is ignored for backward compatibility" do
+    prepared = plan(method: :github_api, token: "1234", username: "old_basic_auth_username")
 
     HTTPClient
     |> expect(:get_json, fn _url, opts ->
-      [{"Authorization", "Bearer " <> req_token}] = opts[:headers]
-      assert req_token == context.opts[:token]
-      {:ok, @no_artifacts_response}
+      assert {"Authorization", "Bearer 1234"} in opts[:headers]
+      {:ok, release_json()}
+    end)
+    |> expect(:download, fn _url, _path, opts ->
+      assert {"Authorization", "Bearer 1234"} in opts[:headers]
+      :ok
     end)
 
-    reject(&HTTPClient.download/3)
-
-    assert {:error, "No release artifacts"} =
-             GithubAPI.get({context.repo, opts}, @invalid_download_path)
+    assert :ok = GithubAPI.get(prepared, @good_download_path)
   end
 
-  test "GITHUB_TOKEN takes precedence", context do
+  test "GITHUB_TOKEN takes precedence" do
     env_token = "look-at-me!"
     gh_token = "dont-look-at-me!"
-    refute context.opts[:token] == env_token
-    refute context.opts[:token] == gh_token
-
-    HTTPClient
-    |> expect(:get_json, fn _url, opts ->
-      [{"Authorization", "Bearer " <> req_token}] = opts[:headers]
-      assert req_token == env_token
-      {:ok, @no_artifacts_response}
-    end)
-
-    reject(&HTTPClient.download/3)
 
     System.put_env("GITHUB_TOKEN", env_token)
     System.put_env("GH_TOKEN", gh_token)
 
-    {:error, "No release artifacts"} =
-      GithubAPI.get({context.repo, context.opts}, @invalid_download_path)
-
-    System.delete_env("GITHUB_TOKEN")
-    System.delete_env("GH_TOKEN")
-  end
-
-  test "supports GH_TOKEN shorthand", context do
-    env_token = "look-at-me!"
-    refute context.opts[:token] == env_token
+    prepared = plan(method: :github_api, token: "explicit_token")
 
     HTTPClient
     |> expect(:get_json, fn _url, opts ->
-      [{"Authorization", "Bearer " <> req_token}] = opts[:headers]
-      assert req_token == env_token
-      {:ok, @no_artifacts_response}
+      assert {"Authorization", "Bearer " <> ^env_token} =
+               List.keyfind(opts[:headers], "Authorization", 0)
+
+      {:ok, release_json()}
     end)
+    |> expect(:download, fn _url, _path, opts ->
+      assert {"Authorization", "Bearer " <> ^env_token} =
+               List.keyfind(opts[:headers], "Authorization", 0)
 
-    reject(&HTTPClient.download/3)
-
-    System.put_env("GH_TOKEN", env_token)
-
-    {:error, "No release artifacts"} =
-      GithubAPI.get({context.repo, context.opts}, @invalid_download_path)
-
-    System.delete_env("GH_TOKEN")
-  end
-
-  test "public release uses public download when API rate limit reached", context do
-    expected_details_url =
-      "https://api.github.com/repos/#{context.repo}/releases/tags/#{context.opts[:tag]}"
-
-    opts =
-      context.opts
-      |> Keyword.put(:public?, true)
-      |> Keyword.delete(:token)
-
-    expected_public_download_url =
-      "https://github.com/#{context.repo}/releases/download/#{opts[:tag]}/#{opts[:artifact_name]}"
-
-    HTTPClient
-    |> expect(:get_json, fn url, _opts ->
-      assert url == expected_details_url
-      {:error, "Status 403 rate limit exceeded"}
-    end)
-    |> expect(:download, 1, fn url, path, _opts ->
-      assert url == expected_public_download_url
-      assert path == @good_download_path
       :ok
     end)
 
-    assert :ok = GithubAPI.get({context.repo, opts}, @good_download_path)
+    assert :ok = GithubAPI.get(prepared, @good_download_path)
   end
 
-  test "private release fails when API rate limit reached", context do
+  test "supports GH_TOKEN shorthand" do
+    env_token = "look-at-me!"
+
+    System.put_env("GH_TOKEN", env_token)
+
+    prepared = plan(method: :github_api)
+
     HTTPClient
-    |> expect(:get_json, fn _url, _opts -> {:error, "Status 403 rate limit exceeded"} end)
+    |> expect(:get_json, fn _url, opts ->
+      assert {"Authorization", "Bearer " <> ^env_token} =
+               List.keyfind(opts[:headers], "Authorization", 0)
 
-    reject(&HTTPClient.download/3)
+      {:ok, release_json()}
+    end)
+    |> expect(:download, fn _url, _path, opts ->
+      assert {"Authorization", "Bearer " <> ^env_token} =
+               List.keyfind(opts[:headers], "Authorization", 0)
 
-    assert {:error, "Status 403 rate limit exceeded"} =
-             GithubAPI.get({context.repo, context.opts}, @invalid_download_path)
+      :ok
+    end)
+
+    assert :ok = GithubAPI.get(prepared, @good_download_path)
+  end
+
+  # --- Other tests ---
+
+  test "custom tag without token uses web URL" do
+    prepared = plan(tag: "custom-tag")
+
+    expected_url =
+      URI.parse(
+        "https://github.com/#{@org_repo}/releases/download/custom-tag/#{@artifact_filename}"
+      )
+
+    HTTPClient
+    |> expect(:download, 1, fn url, _path, _opts ->
+      assert url == expected_url
+      :ok
+    end)
+
+    assert :ok = GithubAPI.get(prepared, @good_download_path)
+  end
+
+  test "custom tag with token uses API" do
+    prepared = plan(method: :github_api, tag: "custom-tag", token: "1234")
+
+    custom_release_url =
+      "https://api.github.com/repos/#{@org_repo}/releases/tags/custom-tag"
+
+    HTTPClient
+    |> expect(:get_json, fn url, _opts ->
+      assert URI.to_string(url) == custom_release_url
+      {:ok, release_json()}
+    end)
+    |> expect(:download, fn url, _path, _opts ->
+      assert url == @asset_api_url
+      :ok
+    end)
+
+    assert :ok = GithubAPI.get(prepared, @good_download_path)
+  end
+
+  test "github_api site is supported for backward compatibility" do
+    {GithubAPI, prepared} =
+      GithubAPI.plan({:github_api, @org_repo, [token: "1234"]}, @version, @artifact_filename)
+
+    HTTPClient
+    |> expect(:get_json, fn url, _opts ->
+      assert URI.to_string(url) == @release_api_url
+      {:ok, release_json()}
+    end)
+    |> expect(:download, fn url, _path, opts ->
+      assert url == @asset_api_url
+      assert {"Authorization", "Bearer 1234"} in opts[:headers]
+      :ok
+    end)
+
+    assert :ok = GithubAPI.get(prepared, @good_download_path)
+  end
+
+  test "unsupported site returns nil" do
+    assert nil == GithubAPI.plan({:prefix, "https://example.com"}, @version, @artifact_filename)
+  end
+
+  test "github_release with token uses direct download" do
+    prepared = plan(token: "1234")
+
+    expected_url = URI.parse(@release_download_url)
+
+    HTTPClient
+    |> stub(:get_json, fn _, _ -> flunk("get_json should not be called for :github_release") end)
+    |> expect(:download, fn url, _path, opts ->
+      assert url == expected_url
+      assert {"Authorization", "Bearer 1234"} in opts[:headers]
+      :ok
+    end)
+
+    assert :ok = GithubAPI.get(prepared, @good_download_path)
+  end
+
+  test "github_api without token uses API" do
+    prepared = plan(method: :github_api)
+
+    HTTPClient
+    |> expect(:get_json, fn url, opts ->
+      assert URI.to_string(url) == @release_api_url
+      assert opts[:headers] == []
+      {:ok, release_json()}
+    end)
+    |> expect(:download, fn url, _path, opts ->
+      assert url == @asset_api_url
+      assert opts[:headers] == [{"Accept", "application/octet-stream"}]
+      :ok
+    end)
+
+    assert :ok = GithubAPI.get(prepared, @good_download_path)
   end
 end

--- a/test/nerves/artifact/resolvers_github_api_test.exs
+++ b/test/nerves/artifact/resolvers_github_api_test.exs
@@ -62,7 +62,7 @@ defmodule Nerves.Artifact.Resolvers.GithubAPITest do
 
   test "private release fails without token" do
     prepared = %GithubAPI{
-      github_url: URI.parse("https://github.com"),
+      web_url: URI.parse("https://github.com"),
       org_repo: @org_repo,
       custom_auth_token: nil,
       artifact_filename: @artifact_filename,
@@ -80,7 +80,7 @@ defmodule Nerves.Artifact.Resolvers.GithubAPITest do
 
   test "private release fails with nil token" do
     prepared = %GithubAPI{
-      github_url: URI.parse("https://github.com"),
+      web_url: URI.parse("https://github.com"),
       org_repo: @org_repo,
       custom_auth_token: nil,
       artifact_filename: @artifact_filename,
@@ -322,6 +322,32 @@ defmodule Nerves.Artifact.Resolvers.GithubAPITest do
     |> expect(:download, fn url, _path, opts ->
       assert url == @asset_api_url
       assert opts[:headers] == [{"Accept", "application/octet-stream"}]
+      :ok
+    end)
+
+    assert :ok = GithubAPI.get(prepared, @good_download_path)
+  end
+
+  test "github_release falls back to API on failure when token is set" do
+    prepared = plan(token: "1234")
+
+    expected_direct_url = URI.parse(@release_download_url)
+
+    HTTPClient
+    |> expect(:download, fn url, _path, _opts ->
+      assert url == expected_direct_url
+      {:error, "Status 404 Not Found"}
+    end)
+    |> expect(:get_json, fn url, opts ->
+      assert URI.to_string(url) == @release_api_url
+      assert {"Authorization", "Bearer 1234"} in opts[:headers]
+      {:ok, release_json()}
+    end)
+    |> expect(:download, fn url, path, opts ->
+      assert url == @asset_api_url
+      assert path == @good_download_path
+      assert {"Accept", "application/octet-stream"} in opts[:headers]
+      assert {"Authorization", "Bearer 1234"} in opts[:headers]
       :ok
     end)
 

--- a/test/nerves/artifact_test.exs
+++ b/test/nerves/artifact_test.exs
@@ -103,8 +103,8 @@ defmodule Nerves.ArtifactTest do
 
     checksum_short = Nerves.Artifact.checksum(pkg, short: 7)
 
-    [{GithubAPI, {^repo, opts}}] = Artifact.expand_sites(pkg)
-    assert String.ends_with?(opts[:artifact_name], checksum_short <> Artifact.ext(pkg))
+    [{GithubAPI, %GithubAPI{} = opts}] = Artifact.expand_sites(pkg)
+    assert String.ends_with?(opts.artifact_filename, checksum_short <> Artifact.ext(pkg))
   end
 
   test "GitHub API artifact sites are expanded" do
@@ -121,10 +121,10 @@ defmodule Nerves.ArtifactTest do
 
     checksum_short = Nerves.Artifact.checksum(pkg, short: 7)
 
-    [{GithubAPI, {^repo, opts}}] = Artifact.expand_sites(pkg)
-    assert opts[:token] == "ghp_fake123"
-    assert opts[:tag] == "v1.0.0"
-    assert String.ends_with?(opts[:artifact_name], checksum_short <> Artifact.ext(pkg))
+    [{GithubAPI, %GithubAPI{} = opts}] = Artifact.expand_sites(pkg)
+    assert opts.custom_auth_token == "ghp_fake123"
+    assert opts.tag == "v1.0.0"
+    assert String.ends_with?(opts.artifact_filename, checksum_short <> Artifact.ext(pkg))
   end
 
   test "Gitea artifact sites are expanded" do
@@ -139,8 +139,8 @@ defmodule Nerves.ArtifactTest do
 
     checksum_short = Nerves.Artifact.checksum(pkg, short: 7)
 
-    assert [{GiteaAPI, {"jmshrtn/nerves_artifact_test", opts}}] = Artifact.expand_sites(pkg)
-    assert String.ends_with?(opts[:artifact_name], checksum_short <> Artifact.ext(pkg))
+    assert [{GiteaAPI, %GiteaAPI{} = opts}] = Artifact.expand_sites(pkg)
+    assert String.ends_with?(opts.artifact_filename, checksum_short <> Artifact.ext(pkg))
   end
 
   test "precompile will raise if packages are stale and not fetched" do


### PR DESCRIPTION
Resolvers used to be expanded and then run to make their downloads. This
moves a little more work to the expansion phase (aka the planning phase)
to lock everything down. The expansion previously resulted in a lot of
temporary values moving around only to be changed or ignored later.
Everything is explicit now. If you are debugging and need to see the
full list of URLs that will be tried, that's easy to get by just dumping
the plan list.

While doing this I saw that the GitHub download methods, `git_api` and
`git_release` evolved to be almost identical. The main difference was
whether to send the auth token, and even that was made moot since
sending the auth token was needed to get past API rate limiting. On top
of that, the API didn't need to be called. Perhaps early on it needed
this, but not any more.

The unit tests needed many updates. In order to make this easier to
review, I tried to keep the test names. There's a future step makes the
unit tests better organized and deletes redundant tests.
