### PR TITLE
Add `:extra_rootfs_overlays` config for tools to inject overlays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@
 
 # Changelog
 
+## (unreleased)
+
+* New features
+  * Added `:extra_rootfs_overlays` option to `config :nerves, :firmware`. Tools
+    that need to inject rootfs overlays programmatically (e.g. package
+    distribution libraries) can now append paths without overwriting the
+    user's own `:rootfs_overlay` setting. The two lists are concatenated
+    before being passed to `rel2fw.sh`.
+
 ## v1.14.1 - 2026-04-22
 
 This release makes `mix nerves.system.shell` work again. We still recommend

--- a/lib/mix/tasks/firmware.ex
+++ b/lib/mix/tasks/firmware.ex
@@ -23,6 +23,17 @@ defmodule Mix.Tasks.Firmware do
     * `--verbose` - produce detailed output about release assembly
     * `--output` - (Optional) The path to the .fw file used to write the patch
       firmware. Defaults to `Nerves.Env.firmware_path/1`
+
+  ## Configuration
+
+  Set under `config :nerves, :firmware` in your project's config:
+
+    * `:extra_rootfs_overlays` - (Optional) Additional rootfs overlay paths
+      appended to `:rootfs_overlay`. Intended for tools that inject overlays
+      programmatically (e.g. package distribution libraries) and need to
+      coexist with the user's own `:rootfs_overlay` setting rather than
+      replace it.
+
   ## Environment variables
 
     * `NERVES_SYSTEM`    - may be set to a local directory to specify the Nerves
@@ -119,7 +130,10 @@ defmodule Mix.Tasks.Firmware do
 
     write_erlinit_config(build_rootfs_overlay)
 
-    project_rootfs_overlay = config_arg(:rootfs_overlay, firmware_config)
+    project_rootfs_overlay =
+      config_arg(:rootfs_overlay, firmware_config) ++
+        config_arg(:extra_rootfs_overlays, firmware_config)
+
     prevent_overlay_overwrites!(project_rootfs_overlay)
 
     rootfs_overlays =
@@ -309,6 +323,13 @@ defmodule Mix.Tasks.Firmware do
 
       overlay ->
         [Path.expand(overlay)]
+    end
+  end
+
+  defp config_arg(:extra_rootfs_overlays, firmware_config) do
+    case firmware_config[:extra_rootfs_overlays] do
+      nil -> []
+      overlays when is_list(overlays) -> overlays
     end
   end
 


### PR DESCRIPTION
## Summary

- Adds `:extra_rootfs_overlays` to `config :nerves, :firmware` — a list of overlay paths concatenated with `:rootfs_overlay` before being passed to `rel2fw.sh -a`.
- Lets tools that distribute pre-built rootfs overlays append paths programmatically without overwriting the user's own `:rootfs_overlay` setting.
- Documented in the firmware task's moduledoc; `CHANGELOG.md` entry under `(unreleased)`.

## Motivation

While prototyping a curated Hex repository for distributing Buildroot-built target packages as Hex artefacts (NBPR), I needed a Mix task running before `mix firmware` to inject extracted package overlays into the rootfs. The existing `:rootfs_overlay` is the user's own; clobbering it from a tool isn't acceptable, and reading-then-rewriting it programmatically is racy across multiple tools that might want to do the same thing.

An additive key avoids both problems and is generally useful for any tool that wants to layer onto the firmware build (CI helpers that bake in build IDs, vendor SDK injection, etc.) — not just NBPR.

## Implementation

Two small changes in `lib/mix/tasks/firmware.ex`:

1. `build_firmware/3` now reads both `:rootfs_overlay` and `:extra_rootfs_overlays` and concatenates them before the existing `prevent_overlay_overwrites!` and `-a` arg assembly.
2. New `config_arg(:extra_rootfs_overlays, _)` clause that returns `[]` when unset and the user-provided list otherwise (no `Path.expand`, matching the list-case behaviour of `:rootfs_overlay`).

## Test plan

- [x] Existing `mix test` suite passes (142 tests, 0 failures), `mix format --check-formatted` clean
- [x] End-to-end against a real Nerves project: a Mix task sets `:extra_rootfs_overlays`, `mix firmware` honours it, the fetched overlay's contents land in the built `.fw` rootfs
- [ ] Maintainer review for naming + doc placement