### PR TITLE
Raise loudly when NERVES_SYSTEM or NERVES_TOOLCHAIN is set to a non-directory path

### DIFF
--- a/lib/nerves/artifact.ex
+++ b/lib/nerves/artifact.ex
@@ -196,11 +196,24 @@ defmodule Nerves.Artifact do
   """
   @spec dir(Nerves.Package.t()) :: String.t()
   def dir(pkg) do
-    if env_var?(pkg) do
-      System.get_env(env_var(pkg)) |> Path.expand()
-    else
-      base_dir()
-      |> Path.join(name(pkg))
+    var_name = env_var(pkg)
+    var_value = System.get_env(var_name)
+
+    cond do
+      var_value != nil and File.dir?(var_value) ->
+        Path.expand(var_value)
+
+      var_value != nil and var_value != "" ->
+        Mix.raise("""
+        #{var_name} is set to "#{var_value}" but that path is not a directory.
+
+        If this is a compressed artifact, extract it first or unset #{var_name}
+        to let Nerves resolve the artifact automatically.
+        """)
+
+      true ->
+        base_dir()
+        |> Path.join(name(pkg))
     end
   end
 

--- a/test/nerves/artifact_test.exs
+++ b/test/nerves/artifact_test.exs
@@ -76,6 +76,25 @@ defmodule Nerves.ArtifactTest do
     end)
   end
 
+  test "raises when NERVES_SYSTEM is set to a non-directory path" do
+    in_fixture("simple_app", fn ->
+      packages = ~w(system toolchain)
+      _ = load_env(packages)
+
+      tmp_file = Path.join(File.cwd!(), "tmp/system.tar.gz")
+      File.mkdir_p!(Path.dirname(tmp_file))
+      File.write!(tmp_file, "")
+
+      System.put_env("NERVES_SYSTEM", tmp_file)
+
+      on_exit(fn -> System.delete_env("NERVES_SYSTEM") end)
+
+      assert_raise Mix.Error, ~r/NERVES_SYSTEM.*is not a directory/, fn ->
+        Artifact.dir(Env.system())
+      end
+    end)
+  end
+
   test "checksum short length" do
     in_fixture("system", fn ->
       File.cwd!()


### PR DESCRIPTION
This resolves an issue I've run into multiple times where Nerves silently fails to pick up your intended NERVES_SYSTEM, leading to many hours debugging to figure out I simply hadn't extracted the compressed package 🤦 

Previously, if NERVES_SYSTEM (or any Nerves artifact env var) was set to a non-empty value that wasn't a directory — for example, a .tar.gz artifact path — Artifact.dir/1 silently fell back to the default computed artifact path. The build would complete successfully using the wrong system, with no indication the override was ignored.

The fix is in Artifact.dir/1, which is the single decision point for "use env override or computed default." It now distinguishes three states: set and a valid directory (use it), set but not a directory (raise), and unset/empty (fall back to default). The error message names the variable, shows the bad path, and hints at the tar.gz case. This affects all callers of Artifact.dir/1:

- Nerves.Env.system_path/0 — called from bootstrap/0 during mix firmware and related tasks
- Nerves.Env.toolchain_path/0 — called from bootstrap/0 for the same
- Mix.Tasks.Nerves.Artifact.Details — called when running mix nerves.artifact.details <package>