### PR TITLE
Add `mix nerves.artifact.details --copy-fwup-conf <path>` helper 

### DIFF
--- a/guides/advanced/advanced-configuration.md
+++ b/guides/advanced/advanced-configuration.md
@@ -112,14 +112,40 @@ the boot partition, you will need to use your own `fwup.conf` file:
 
 #### Copy `fwup.conf` to Your `config/` Directory
 
+<!-- tabs-open -->
+
+### Mix task
+
+With `:nerves` >= 1.14.4, you can use a mix task to locate and copy the
+`fwup.conf` from the system:
+
+```sh
+mix nerves.artifact.details nerves_system_rpi0 --copy-fwup-conf config/
+```
+
+### Copy from Hex dependency
+
+> #### Note {: .warning}
+>
+> Some systems, such as the official Raspberry Pi systems, generate their
+> `fwup.conf` at build time and do not include it as a static file in the Hex
+> package. For these systems, use the Mix task or fetch from GitHub instead.
+
+For systems that include a static `fwup.conf` in their Hex package:
+
 ```bash
 # Locate the fwup.conf files available in your deps directory
 find deps -name fwup.conf
 # Copy the one that matches your target to the config directory.
-cp deps/nerves_system_rpi0/fwup.conf config/
-# Also copy cmdline.txt as you'll need it below.
-cp deps/nerves_system_rpi0/cmdline.txt config/
+cp deps/nerves_system_bbb/fwup.conf config/
 ```
+
+### Fetch from GitHub
+
+Find the `fwup.conf` (and `cmdline.txt` if needed) in the system's GitHub
+repository and download the file(s) directly into your `config/` directory.
+
+<!-- tabs-close -->
 
 #### Configure Your System to Use the Copied `fwup.conf`
 

--- a/lib/mix/tasks/nerves.artifact.details.ex
+++ b/lib/mix/tasks/nerves.artifact.details.ex
@@ -29,7 +29,7 @@ defmodule Mix.Tasks.Nerves.Artifact.Details do
   def run(argv) do
     debug_info("Nerves.Artifact.Details start")
 
-    {opts, argv} = OptionParser.parse!(argv, strict: [])
+    {opts, argv} = OptionParser.parse!(argv, strict: [copy_fwup_conf: :string])
 
     # We should have attempted precompile before this, but run it
     # here just in case. Noop if it has already been run.
@@ -50,6 +50,26 @@ defmodule Mix.Tasks.Nerves.Artifact.Details do
         {:error, _} -> Mix.raise("Could not find Nerves package #{package_name} in env")
       end
 
+    if cp_path = opts[:copy_fwup_conf] do
+      copy_fwup_conf(package, cp_path)
+    else
+      print_details(package)
+    end
+
+    debug_info("Nerves.Artifact.Details end")
+  end
+
+  defp copy_fwup_conf(package, cp_path) do
+    fwup_conf = Path.join([Artifact.dir(package), "images", "fwup.conf"])
+    File.exists?(fwup_conf) || Mix.raise("No fwup.conf exists for #{package.name}")
+
+    cp_path = Path.expand(cp_path)
+    cp_path = if File.dir?(cp_path), do: Path.join(cp_path, "fwup.conf"), else: cp_path
+    File.cp!(fwup_conf, cp_path)
+    Mix.shell().info("Copied #{fwup_conf} -> #{cp_path}")
+  end
+
+  defp print_details(package) do
     Mix.shell().info("""
     Version:            #{package.version}
     Checksum:           #{Artifact.checksum(package)}
@@ -63,7 +83,5 @@ defmodule Mix.Tasks.Nerves.Artifact.Details do
     Path:               #{Artifact.dir(package)}
     Build Path:         #{Artifact.build_path(package)}
     """)
-
-    debug_info("Nerves.Artifact.Details end")
   end
 end

--- a/lib/mix/tasks/nerves.artifact.details.ex
+++ b/lib/mix/tasks/nerves.artifact.details.ex
@@ -29,19 +29,26 @@ defmodule Mix.Tasks.Nerves.Artifact.Details do
   def run(argv) do
     debug_info("Nerves.Artifact.Details start")
 
+    {opts, argv} = OptionParser.parse!(argv, strict: [])
+
     # We should have attempted precompile before this, but run it
     # here just in case. Noop if it has already been run.
     Mix.Task.run("nerves.precompile", [])
 
-    package_name =
-      case OptionParser.parse(argv, switches: []) do
-        {_, [p | _], _} -> String.to_atom(p)
-        _ -> Mix.Project.config()[:app]
+    {package_name, package_path} =
+      case argv do
+        [p | _] ->
+          {String.to_atom(p), Path.join(Mix.Project.deps_path(), p)}
+
+        _ ->
+          {Mix.Project.config()[:app], File.cwd!()}
       end
 
-    package = Nerves.Env.package(package_name)
-
-    if is_nil(package), do: Mix.raise("Could not find Nerves package #{package_name} in env")
+    package =
+      case Nerves.Env.ensure_loaded(package_name, package_path) do
+        {:ok, package} -> package
+        {:error, _} -> Mix.raise("Could not find Nerves package #{package_name} in env")
+      end
 
     Mix.shell().info("""
     Version:            #{package.version}


### PR DESCRIPTION
The rpi systems now generate their own `fwup.conf` which is not available in the hex package. Instead, it should be fetched from the system's `images` directory.

This adds a flag to the details task to help in copying that `fwup.conf` which can be used when doing advanced configurations. It also includes a small adjustment to the `mix nerves.artifact.details` task so that `MIX_TARGET` does not need to be set in order to get some basic system details