### PR TITLE
Update release.ex

### DIFF
--- a/lib/nerves/release.ex
+++ b/lib/nerves/release.ex
@@ -58,10 +58,10 @@ defmodule Nerves.Release do
   end
 
   @doc false
-  @spec erts() :: String.t() | true | nil
+  @spec erts() :: String.t() | true
   def erts() do
     if Nerves.Env.loaded?() do
-      System.get_env("ERTS_DIR")
+      System.fetch_env!("ERTS_DIR")
     else
       true
     end


### PR DESCRIPTION
I'm not sure if there is a good reason for "ERTS_DIR" to be unset, while `Nerves.Env.loaded?` is true. But potentially returning `nil` from that function is a problem because mix cannot deal with that:

```elixir
** (FunctionClauseError) no function clause matching in Mix.Release.erts_data/1

    The following arguments were given to Mix.Release.erts_data/1:

        # 1
        nil

    Attempted function clauses (showing 4 out of 4):

        defp erts_data(erts_data) when is_function(erts_data)
        defp erts_data(false)
        defp erts_data(true)
        defp erts_data(erts_source) when is_binary(erts_source)

    (mix 1.20.2) lib/mix/release.ex:267: Mix.Release.erts_data/1
    (mix 1.20.2) lib/mix/release.ex:112: Mix.Release.from_config!/3
```